### PR TITLE
Add support for token authentication with the provided DATA_URL

### DIFF
--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -57,7 +57,7 @@ SOFTWARE.
 
 String WAGFAM_DATA_URL = ""; // URL to Pull WagFam Calendar Data from
 boolean WAGFAM_ENABLED = true;  // Enable/Disable WagFam Calendar Functions
-String WAGFAM_API_KEY = ""; // UNUSED - saved for future use
+String WAGFAM_API_KEY = ""; // Authorization token to use to authenticate to access the DATA_URL, only used if provided
 
 
 String TIMEDBKEY = ""; // Your API Key from https://timezonedb.com/register

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -44,18 +44,17 @@ void WagFamBdayClient::updateBdays() {
 
   HTTPClient https;
 
-  // TODO: implement Security on the URL
-//   if (myApiKey == "") {
-//     Serial.println("Please provide an API key for the News.");
-//     return;
-//   }
-
   Serial.println("Getting Birthdays Data");
   Serial.println(myJsonSourceUrl);
 
   if (!https.begin(*client, myJsonSourceUrl)) {
     Serial.println("[HTTPS] Unable to connect");
     return;
+  }
+
+  // Add Authorization token if one is provided
+  if (myApiKey != "") {
+    https.addHeader("Authorization", "token " + myApiKey);
   }
 
   int httpCode = https.GET();


### PR DESCRIPTION
This is targeted to work with raw.githubusercontent.com for accessing private repository data, with a generated Personal Access Token.  That Personal Access token is entered in as the "API_KEY" for the WagFam settings.

Previously I had thought that these keys were only valid for up to 12 months.  However, that is only true for "Fine Grained" tokens (which are a new thing), but classic personal access tokens can be generated with no expiration date.  Woot!  I still think we should likely implement the key rolling feature, just in case we need it down the road after the units ship to customers.

Thanks to this post: https://github.com/orgs/community/discussions/24744 for spelling out how to make this happen!