### PR TITLE
Changes to allow config to be passed down by server.

### DIFF
--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -58,6 +58,7 @@ SOFTWARE.
 String WAGFAM_DATA_URL = ""; // URL to Pull WagFam Calendar Data from
 boolean WAGFAM_ENABLED = true;  // Enable/Disable WagFam Calendar Functions
 String WAGFAM_API_KEY = ""; // Authorization token to use to authenticate to access the DATA_URL, only used if provided
+boolean WAGFAM_EVENT_TODAY = false; // Whether or not an event is happening today
 
 
 String TIMEDBKEY = ""; // Your API Key from https://timezonedb.com/register

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -30,20 +30,19 @@ SOFTWARE.
 
 class WagFamBdayClient: public JsonListener {
 
-  private:
-    String myJsonSourceUrl = "";
-    String myApiKey = "";
-
-    String currentKey = "";
-    int messageCounter = 0;
-
-    // Support up to 10 messages queued up for display
-    String messages[10];
-
   public:
+    typedef struct {
+      boolean dataSourceUrlValid;
+      String dataSourceUrl;
+      boolean apiKeyValid;
+      String apiKey;
+      boolean eventTodayValid;
+      boolean eventToday;
+    } configValues;
+
     WagFamBdayClient(String ApiKey, String JsonDataSourceUrl);
     void updateBdayClient(String ApiKey, String JsonDataSourceUrl);
-    void updateBdays();
+    WagFamBdayClient::configValues updateData();
     void updateDataSource(String JsonDataSourceUrl);
 
     String getMessage(int index);
@@ -59,5 +58,18 @@ class WagFamBdayClient: public JsonListener {
     virtual void endDocument();
     virtual void startArray();
     virtual void startObject();
+
+  private:
+    String myJsonSourceUrl = "";
+    String myApiKey = "";
+
+    String currentKey = "";
+    int messageCounter = 0;
+
+    // Support up to 10 messages queued up for display
+    String messages[10];
+
+    bool inConfig = false;
+    configValues currentConfig = {};
 
 };


### PR DESCRIPTION
This is particularly useful for enabling special display modes on different days, but may also come in handy if/when we ever need to send out a new url/api key to all clocks.

This was tested as follows:

Setup a "test" data source at this URL: https://raw.githubusercontent.com/jrwagz/clock-test-data/main/data_source.json

Setup that "test" data source to have a configuration entry, to automatically redirect the client to the production data URL.

Here is what happens:

- clock fetches data from the test data source URL, which gives it a new data source URL
- this URL config change is persisted to flash.
- data displayed continues to be from test data source URL (since we haven't fetched from the new URL yet)
- the next time the clock fetches data, it will pull it from the production URL

The intent of this feature is not just for redirecting to new URLs or API Keys, but for also being able to send down special configuration options that will enable special display modes on the clock, other than just the simple messages that it scrolls periodically. 