### PR TITLE
Add CLAUDE.md and rewrite README for WagFam fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@README.md
+
+---
+
+## Architecture
+
+All source lives in [marquee/](marquee/):
+
+| File | Role |
+| --- | --- |
+| [marquee.ino](marquee/marquee.ino) | Main sketch: `setup()`, `loop()`, web server handlers, display rendering |
+| [Settings.h](marquee/Settings.h) | Hardware pin config + all `#include` directives; default values for first-run only |
+| [OpenWeatherMapClient.h/.cpp](marquee/OpenWeatherMapClient.h) | Fetches weather from OpenWeatherMap API using ArduinoJson |
+| [WagFamBdayClient.h/.cpp](marquee/WagFamBdayClient.h) | Fetches family calendar JSON over HTTPS; parses messages and remote config |
+| [timeNTP.h/.cpp](marquee/timeNTP.h) | NTP time sync; exposes `timeNTPsetup()`, `getNtpTime()`, and `set_timeZoneSec()` |
+| [timeStr.h/.cpp](marquee/timeStr.h) | Time formatting helpers (zero-pad, day/month names, etc.) |
+
+Local library copies (not managed by PlatformIO) are in [lib/](lib/):
+
+- `arduino-Max72xxPanel` — MAX7219 LED matrix driver
+- `json-streaming-parser` — streaming JSON parser used by `WagFamBdayClient`
+
+## Main Loop Logic
+
+- **Every frame**: Render current time via `centerPrint()`; handle web server and OTA requests
+- **Every second** (`processEverySecond`): Calls `getWeatherData()` — which fetches both weather and calendar data together — if `minutesBetweenDataRefresh` has elapsed
+- **Every minute** (`processEveryMinute`): Scroll the marquee message (weather data + next calendar message from `bdayClient`)
+
+## Configuration Storage
+
+Runtime config is persisted via LittleFS (aliased as `SPIFFS` in the sketch) at `/conf.txt` as `key=value` pairs. The functions `savePersistentConfig()` and `readPersistentConfig()` in [marquee.ino](marquee/marquee.ino) own all reads and writes to this file. [Settings.h](marquee/Settings.h) contains compile-time defaults only — changes there require a filesystem erase to take effect.
+
+`WAGFAM_EVENT_TODAY` is not user-configurable via the web form — it is set exclusively by the server's `config.eventToday` field in the calendar JSON response and persisted across reboots via `/conf.txt`.
+
+## Key Constraints
+
+- Flash memory is tight on ESP8266 — avoid large string literals on the stack; use the `F()` macro or `PROGMEM` / `FPSTR()` for string constants (see existing `CHANGE_FORM*` and `WEB_ACTIONS*` constants in [marquee.ino](marquee/marquee.ino))
+- The LED display font is 5px wide + 1px spacer; `scrollMessageWait()` computes scroll distance from message length
+- `WagFamBdayClient` uses BearSSL with `setInsecure()` (no cert validation) — intentional for embedded use
+- ArduinoJson v7 is used (`^7.4` in `platformio.ini`) — do not generate v6-style `DynamicJsonDocument` / `StaticJsonDocument` code; use `JsonDocument` instead

--- a/README.md
+++ b/README.md
@@ -1,131 +1,135 @@
-# Marquee Scroller (Clock, Weather, News, and More)
+# WagFam CalClock
 
-## NOTICE
-The latest version of Marquee Scroller 3.01 works with **ESP8266 Core 3.0.2** -- if you are upgrading from Marquee Scroller 2.X version this may require you to enter in all your API Keys and settings.  Always meake sure you have coppied all your API keys somewhere before updating.  The ESP8266 Core 3.0.2 uses the newer FS (file system) that may require a fresh start on the configuration.
-Make sure you update to the latest version of WifiManager library (link below).
-* Removed Bitcoin features in 3.0
+A personal fork of [Marquee Scroller](https://github.com/Tronixstuff/marquee-scroller) by David Payne, customized as a family calendar + weather clock for a Wemos D1 Mini (ESP8266) with a MAX7219 LED matrix display.
 
-## Features include:
-* Accurate Clock refresh off Internet Time Servers
-* Local Weather and conditions (refreshed every 10 - 30 minutes)
-* News Headlines from all the major sources
-* Configured through Web Interface
-* Display 3D print progress from your OctoPrint Server
-* Option to display Pi-hole status and graph (each pixel accross is 10 minutes)
-* Basic Authorization around Configuration web interface
-* Support for OTA (loading firmware over WiFi)
-* Update firmware through web interface
-* Configurable scroll speed
-* Configurable scrolling frequency
-* Configurable number of LED panels
-* Options of different types of Clock Displays (display seconds or temperature) -- only on 8 or more display panels
-* Video: https://youtu.be/DsThufRpoiQ
-* Build Video by Chris Riley: https://youtu.be/KqBiqJT9_lE
+## Features
 
-## Required Parts:
-* Wemos D1 Mini: https://amzn.to/3tMl81U
-* Dot Matrix Module: https://amzn.to/2HtnQlD
+- Clock display with NTP time sync (12h or 24h, with optional PM indicator)
+- Local weather from OpenWeatherMap (temperature, conditions, wind, humidity, pressure, high/low)
+- **WagFam Calendar** — scrolls upcoming family events/birthdays fetched from a private JSON endpoint; animated border on event days
+- Configured entirely through a web interface (no re-flashing required for settings changes)
+- OTA firmware updates via web interface (file upload or URL)
+- Configurable scroll speed, brightness, and refresh interval
 
-Note: Using the links provided here help to support these types of projects. Thank you for the support.
+## Hardware
 
-## Wiring for the Wemos D1 Mini to the Dot Matrix Display
-CLK -> D5 (SCK)
-CS  -> D6
-DIN -> D7 (MOSI)
-VCC -> 5V+
-GND -> GND-
+- **Wemos D1 Mini** (ESP8266): <https://amzn.to/3tMl81U>
+- **MAX7219 Dot Matrix Module 4-in-1**: <https://amzn.to/2HtnQlD>
 
-![Marquee Scroller Wiring](/images/marquee_scroller_pins.png)
+### Wiring
 
-## 3D Printed Case by David Payne:
-Original Single Panel version: https://www.thingiverse.com/thing:2867294
-Double Wide LED version: https://www.thingiverse.com/thing:2989552
+| Display | Wemos D1 Mini |
+|---------|---------------|
+| CLK     | D5 (SCK)      |
+| CS      | D6            |
+| DIN     | D7 (MOSI)     |
+| VCC     | 5V+           |
+| GND     | GND           |
 
-## Upgrading from version 2.5 or Higher
-In version 2.6 and higher, the binary files that can be uploaded to your marque scrolling clock via the web interface.  From the main menu in the web interface select "Firmware Update" and follow the prompts.
-* **marquee.ino.d1_mini_3.01.bin** - compiled for Wemos D1 Mini and standard 4x1 LED (default)
-* **marquee.ino.d1_mini_wide_3.01.bin** - compiled for Wemos D1 Mini and double wide 8x1 LED display
+## Building and Flashing
 
-## Compiling and Loading to Wemos D1
-It is recommended to use Arduino IDE.  You will need to configure Arduino IDE to work with the Wemos board and USB port and installed the required USB drivers etc.
-* USB CH340G drivers:  https://sparks.gogo.co.nz/ch340.html
-* Enter http://arduino.esp8266.com/stable/package_esp8266com_index.json into Additional Board Manager URLs field. You can add multiple URLs, separating them with commas.  This will add support for the Wemos D1 Mini to Arduino IDE.
-* Open Boards Manager from Tools > Board menu and install esp8266 Core platform version Latest **3.0.2**
-* Select Board:  "ESP8266 Boards (3.0.2)" --> "LOLIN(WEMOS) D1 R2 & mini"
-* Set Flash Size: 4MB (FS:1MB OTA:~1019KB) -- **this project requires FS for saving and reading configuration settings.**
-* Select the **Port** from the tools menu.
+### PlatformIO (recommended)
 
-## Loading Supporting Library Files in Arduino
-Use the Arduino guide for details on how to installing and manage libraries https://www.arduino.cc/en/Guide/Libraries
-**Packages** -- the following packages and libraries are used (download and install):
-* <WiFiManager.h> --> https://github.com/tzapu/WiFiManager
-* <TimeLib.h> --> https://github.com/PaulStoffregen/Time
-* <Adafruit_GFX.h> --> https://github.com/adafruit/Adafruit-GFX-Library
-* <ArduinoJson> -->  https://github.com/bblanchon/ArduinoJson v7.4.2+
-* <Max72xxPanel.h> --> https://github.com/markruys/arduino-Max72xxPanel (cached in our repo under /lib)
-* <JsonStreamingParser.h> --> https://github.com/squix78/json-streaming-parser (cached in our repo under /lib)
+Open the project folder in VS Code with the [PlatformIO](https://platformio.org/) (or [PIOArduino](https://marketplace.visualstudio.com/items?itemName=pioarduino.pioarduino-ide)) extension installed.
 
-Note ArduinoJson (version 5.13.1) is now included as a library file in version 2.7 and later.
+```bash
+pio run                          # Build
+pio run --target upload          # Flash to device
+pio device monitor               # Serial monitor (115200 baud)
+```
 
-## Building with PlatformIO.
-Use [**VScode**](https://code.visualstudio.com/docs) with [**PlatformIO**](https://platformio.org/) or better, its desendant fork [**PIOarduino**](https://marketplace.visualstudio.com/items?itemName=pioarduino.pioarduino-ide) extension.
+All library dependencies are declared in `platformio.ini` and downloaded automatically.
 
-Please refer to the provided links on how to install VScode on your OS.
+Flash size must be set to **4MB (FS:1MB OTA:~1019KB)** — the filesystem is required for storing configuration.
 
-Then, open this project with `Visual Studio Code`, via File --> Open Folder: select folder containing `platformio.ini` file.
+### Arduino IDE (alternative)
 
-The `platformio.ini` file contains the references to the required external libraries and version numbers.
+1. Install USB CH340G drivers: <https://sparks.gogo.co.nz/ch340.html>
+2. Add `http://arduino.esp8266.com/stable/package_esp8266com_index.json` to Additional Board Manager URLs
+3. Install esp8266 platform via Boards Manager
+4. Select Board: **LOLIN(WEMOS) D1 R2 & mini**
+5. Set Flash Size: **4MB (FS:1MB OTA:~1019KB)**
 
-To build, open the `pioarduino` or `platformio` extension (icon on left hand side bar), then under *PROJECT TASKS* -> *Default* -> *General* : select **Build** and then **Upload**
+Required libraries (install via Library Manager or download manually):
 
-## Initial Configuration
-Editing the **Settings.h** file is totally optional and not required.  All API Keys are now managed in the Web Interface. It is not required to edit the Settings.h file before loading and running the code.
-* Open Weather Map free API key: http://openweathermap.org/  -- this is used to get weather data and the latitude and longitude for the current time zone. Weather API key is required for correct time.
-* TimeZoneDB free registration for API key: https://timezonedb.com/register -- this is used for setting the time and getting the correct time zone as well as managing time changes due to Day Light Savings time by regions.  This key is set and managed only through the web interface and added in version 2.10 of Marquee Scroller. TimeZoneDB key is required for correct time display.
-* News API key (free): https://newsapi.org/ -- Optional if you want to get current news headlines.
-* Your OctoPrint API Key -- optional if you use the OctoPrint status.
-* Version 2.0 supports Chained 4x1 LED displays -- configure up to 16x1 in the Settings.h file.
+- [WiFiManager](https://github.com/tzapu/WiFiManager) ≥ 2.0.17
+- [Adafruit GFX Library](https://github.com/adafruit/Adafruit-GFX-Library) ≥ 1.12
+- [Time](https://github.com/PaulStoffregen/Time) ≥ 1.6
+- [ArduinoJson](https://github.com/bblanchon/ArduinoJson) ^7.4
 
-NOTE: The settings in the Settings.h are the default settings for the first loading. After loading you will manage changes to the settings via the Web Interface. If you want to change settings again in the settings.h, you will need to erase the file system on the Wemos or use the “Reset Settings” option in the Web Interface.
+The following libraries are cached locally in `/lib` (no separate install needed):
 
-## Web Interface
-The Marquee Scroller uses the **WiFiManager** so when it can't find the last network it was connected to
-it will become a **AP Hotspot** -- connect to it with your phone and you can then enter your WiFi connection information.
+- `Max72xxPanel` — MAX7219 LED matrix driver
+- `JsonStreamingParser` — streaming JSON parser used by WagFam Calendar client
 
-After connected to your WiFi network it will display the IP addressed assigned to it and that can be
-used to open a browser to the Web Interface.  You will be able to manage your API Keys through the web interface.
-The default user / password for the configuration page is: admin / password
+## Pre-built Binaries
 
-The Clock will display the time of the City selected for the weather.
+For OTA flashing without recompiling (built from v3.03 — current source is v3.07.0-wagfam):
 
-<p align="center">
-  <img src="/images/2018-04-19%2006.58.05.png" width="200"/>
-  <img src="/images/2018-04-19%2006.58.15.png" width="200"/>
-  <img src="/images/2018-04-19%2006.58.32.png" width="200"/>
-  <img src="/images/2018-04-19%2006.58.58.png" width="200"/>
-</p>
+- `marquee.ino.d1_mini_3.03.bin` — standard 4×1 LED display
+- `marquee.ino.d1_mini_wide_3.03.bin` — double-wide 8×1 LED display
 
-## Donation or Tip
-Please do not feel obligated, but donations and tips are warmly welcomed.  I have added the donation button at the request of a few people that wanted to contribute and show appreciation.  Thank you, and enjoy the application and project.
+Upload via the web interface at `http://<device-ip>/update`.
 
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=A82AT6FLN2MPY)
+## Initial Setup
 
-Or -- you can buy me something from my Amazon Wishlist: https://www.amazon.com/hz/wishlist/ls/GINC2PHRNEY3
+On first boot (or after "Forget WiFi"), the device creates a WiFi AP named `CLOCK-<chip-id>`. Connect to it with a phone or laptop to enter your WiFi credentials.
 
-## Contributors
-David Payne <br>
-Nathan Glaus <br>
-Daniel Eichhorn -- Author of the TimeClient class (in older versions) <br>
-yanvigdev <br>
-nashiko-s <br>
-magnum129 <br>
-rob040 <br>
+Once connected to WiFi, the device displays its IP address. Open `http://<ip>/` in a browser to access the web interface.
 
-Contributing to this software is warmly welcomed. You can do this basically by forking from master, committing modifications and then making a pulling requests against the latest DEV branch to be reviewed (follow the links above for operating guide). Detailed comments are encouraged. Adding change log and your contact into file header is encouraged. Thanks for your contribution.
+Default web UI credentials: **admin / password**
 
-When considering making a code contribution, please keep in mind the following goals for the project:
-* User should not be required to edit the Settings.h file to compile and run.  This means the feature should be simple enough to manage through the web interface.
-* Changes should always support the recommended hardware (links above).
+## Configuration
 
-![Marquee Scroller](/images/5d7f02ccbf01125cabbf246f97f2ead1_preview_featured.jpg)
-![Marquee Parts](/images/1ffa0c835554d280258c13be5513c4fe_preview_featured.jpg)
+All settings are managed through the web interface and persisted to the device filesystem. Editing `Settings.h` only affects defaults for a completely fresh start (filesystem erased).
+
+### API Keys
+
+| Key | Purpose | Required? |
+| --- | ------- | --------- |
+| OpenWeatherMap API key | Weather data + timezone offset for NTP | Yes |
+| WagFam Calendar URL | JSON endpoint for family events | Optional |
+| WagFam API Key | Auth token sent as `Authorization: token <key>` | Optional |
+
+Get a free OpenWeatherMap key at <https://openweathermap.org/>
+
+### WagFam Calendar
+
+The calendar client fetches a JSON array from the configured URL (HTTPS supported). The endpoint should return:
+
+```json
+[
+  {
+    "config": {
+      "eventToday": "1"
+    }
+  },
+  { "message": "Justin's Birthday - 3 days away" },
+  { "message": "Family Dinner - this Saturday" }
+]
+```
+
+- Up to 10 messages are supported; they cycle through the marquee scroll
+- The `config` block is optional; if present, `eventToday: 1` enables an animated dot border around the clock display for the day
+- The `config` block can also remotely update `dataSourceUrl` and `apiKey` on the device
+
+### Geo Location
+
+Enter a city ID, city name + country code (`Chicago,US`), or GPS coordinates (`lat,lon`) — whatever format OpenWeatherMap accepts.
+
+## Firmware Update from URL
+
+From the Configure page, a firmware URL (HTTP only — HTTPS is not supported) can be entered to trigger an OTA update directly from a hosted `.bin` file. The device will restart automatically on success.
+
+## Web Interface Routes
+
+| Route | Description |
+| ----- | ----------- |
+| `/` | Home — shows upcoming events and current weather |
+| `/configure` | Settings form |
+| `/saveconfig` | Saves configuration (GET with form params) |
+| `/pull` | Forces immediate data refresh |
+| `/update` | OTA firmware upload (file) |
+| `/updateFromUrl` | OTA firmware update from URL |
+| `/systemreset` | Resets settings to defaults |
+| `/forgetwifi` | Clears saved WiFi credentials |

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -95,7 +95,6 @@ boolean SHOW_CITY = true;
 boolean SHOW_CONDITION = false;
 boolean SHOW_HUMIDITY = false;
 boolean SHOW_WIND = false;
-boolean SHOW_WINDDIR = false;
 boolean SHOW_PRESSURE = false;
 boolean SHOW_HIGHLOW = false;
 
@@ -142,7 +141,7 @@ static const char CHANGE_FORM4[] PROGMEM = "<p><button class='w3-button w3-block
                       "<script>function isNumberKey(e){var h=e.which?e.which:event.keyCode;return!(h>31&&(h<48||h>57))}</script>";
 
 static const char UPDATE_FORM[] PROGMEM = "<form class='w3-container' action='/updateFromUrl' method='get'><h2>Firmware Update Options:</h2>"
-                      "<p><label>Firmware Update URL (optional)</label><input class='w3-input w3-border w3-margin-bottom' type='url' name='firmwareUrl' placeholder='https://example.com/firmware.bin' maxlength='256' required></p>"
+                      "<p><label>Firmware Update URL (optional)</label><input class='w3-input w3-border w3-margin-bottom' type='url' name='firmwareUrl' placeholder='http://example.com/firmware.bin' maxlength='256' required></p>"
                       "<p><button class='w3-button w3-block w3-blue w3-section w3-padding' type='submit'>Update from URL</button></p>"
                       "<p><small>Note: You can also use the <a href='/update'>Firmware Update</a> page to upload a file directly.</small></p></form>";
 


### PR DESCRIPTION
README.md: replaced stale upstream Marquee Scroller README with
accurate, personal-fork-focused documentation. Removed references to
removed features (News API, OctoPrint, Pi-hole, TimeZoneDB). Added
WagFam Calendar API docs, OTA-from-URL feature, web interface route
table, and correct library versions (ArduinoJson ^7.4).

CLAUDE.md: new AI assistant guidance file. Includes README.md via
@README.md, followed by AI-specific sections: source file architecture
map, main loop timing, LittleFS config storage details, and coding
constraints (PROGMEM, ArduinoJson v7, BearSSL).

marquee.ino: remove dead SHOW_WINDDIR variable (never persisted or
shown in the web form); fix firmware update URL placeholder from
https:// to http:// to match the HTTP-only restriction enforced by
the update handler.
