### PR TITLE
Add CI pipeline with lint, build, and GitHub release workflow

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,16 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠️
+      labels:
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -1,0 +1,82 @@
+name: Lint, Test, and Build
+
+on:
+  push:
+    branches: ["master"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["master"]
+
+# Only allow a single running job for each PR/tag/branch
+# and cancel any running jobs if a new one is created on top of it
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+      artifact-metadata: write
+      actions: read
+      checks: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Lint
+        run: make lint
+
+      - name: Test
+        run: make test
+
+      - name: Build
+        run: make build
+
+      - name: Gather Artifacts
+        run: make artifacts
+
+      - name: Keep Artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: artifacts/
+
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-path: 'artifacts/*'
+
+      - name: Create release
+        if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+        id: create_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_URL=$(gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes)
+          echo "html_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Package release artifacts
+        if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+        run: zip -r "${{ github.event.repository.name }}-${{ github.ref_name }}-artifacts.zip" artifacts/
+
+      - name: Upload release artifacts
+        if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "${{ github.event.repository.name }}-${{ github.ref_name }}-artifacts.zip"
+
+      - name: Write release summary
+        if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+        run: |
+          echo "## Release" >> "$GITHUB_STEP_SUMMARY"
+          echo "[${{ github.ref_name }}](${{ steps.create_release.outputs.html_url }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 .vscode/
 .pio/
+.passwd
+artifacts/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,27 @@
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 120
+  # Number of characters for headings
+  heading_line_length: 100
+  # Number of characters for code blocks
+  code_block_line_length: 120
+  # Include code blocks
+  code_blocks: false
+  # Include tables
+  tables: false
+  # Include headings
+  headings: true
+  # Strict length checking
+  strict: false
+  # Stern length checking
+  stern: false
+
+MD033: false
+
+MD024: false
+
+# This requires the first line to be `#`. Which is a great requirement unless
+# we are writing fancy readmes with HTML. As long as GitHub renders it properly
+# we are good.
+MD041: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,18 +27,38 @@ Local library copies (not managed by PlatformIO) are in [lib/](lib/):
 ## Main Loop Logic
 
 - **Every frame**: Render current time via `centerPrint()`; handle web server and OTA requests
-- **Every second** (`processEverySecond`): Calls `getWeatherData()` — which fetches both weather and calendar data together — if `minutesBetweenDataRefresh` has elapsed
+- **Every second** (`processEverySecond`): Calls `getWeatherData()` — which fetches both weather and calendar data
+  together — if `minutesBetweenDataRefresh` has elapsed
 - **Every minute** (`processEveryMinute`): Scroll the marquee message (weather data + next calendar message from `bdayClient`)
 
 ## Configuration Storage
 
-Runtime config is persisted via LittleFS (aliased as `SPIFFS` in the sketch) at `/conf.txt` as `key=value` pairs. The functions `savePersistentConfig()` and `readPersistentConfig()` in [marquee.ino](marquee/marquee.ino) own all reads and writes to this file. [Settings.h](marquee/Settings.h) contains compile-time defaults only — changes there require a filesystem erase to take effect.
+Runtime config is persisted via LittleFS (aliased as `SPIFFS` in the sketch) at `/conf.txt` as `key=value` pairs.
+The functions `savePersistentConfig()` and `readPersistentConfig()` in [marquee.ino](marquee/marquee.ino)
+own all reads and writes to this file. [Settings.h](marquee/Settings.h) contains compile-time defaults only —
+changes there require a filesystem erase to take effect.
 
-`WAGFAM_EVENT_TODAY` is not user-configurable via the web form — it is set exclusively by the server's `config.eventToday` field in the calendar JSON response and persisted across reboots via `/conf.txt`.
+`WAGFAM_EVENT_TODAY` is not user-configurable via the web form — it is set exclusively by the server's
+`config.eventToday` field in the calendar JSON response and persisted across reboots via `/conf.txt`.
+
+## Markdown Style
+
+`make lint` enforces markdownlint on all `.md` files. Rules in effect (`.markdownlint.yaml`):
+
+- **MD013**: max **120 chars** per line for body text and list items; max **100 chars** for headings
+  - Table rows and fenced code block content are **exempt**
+  - When a line would exceed the limit, wrap at a natural word/clause boundary
+  - List item continuation lines must be indented **2 spaces** to stay in the same list item
+- MD033 (inline HTML), MD024 (duplicate headings), MD041 (first-line h1) are **disabled**
+
+Run `make lint-markdown` locally to check before committing any `.md` changes.
 
 ## Key Constraints
 
-- Flash memory is tight on ESP8266 — avoid large string literals on the stack; use the `F()` macro or `PROGMEM` / `FPSTR()` for string constants (see existing `CHANGE_FORM*` and `WEB_ACTIONS*` constants in [marquee.ino](marquee/marquee.ino))
+- Flash memory is tight on ESP8266 — avoid large string literals on the stack;
+  use the `F()` macro or `PROGMEM` / `FPSTR()` for string constants
+  (see existing `CHANGE_FORM*` and `WEB_ACTIONS*` constants in [marquee.ino](marquee/marquee.ino))
 - The LED display font is 5px wide + 1px spacer; `scrollMessageWait()` computes scroll distance from message length
 - `WagFamBdayClient` uses BearSSL with `setInsecure()` (no cert validation) — intentional for embedded use
-- ArduinoJson v7 is used (`^7.4` in `platformio.ini`) — do not generate v6-style `DynamicJsonDocument` / `StaticJsonDocument` code; use `JsonDocument` instead
+- ArduinoJson v7 is used (`^7.4` in `platformio.ini`) — do not generate v6-style
+  `DynamicJsonDocument` / `StaticJsonDocument` code; use `JsonDocument` instead

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # WagFam CalClock
 
-A personal fork of [Marquee Scroller](https://github.com/Tronixstuff/marquee-scroller) by David Payne, customized as a family calendar + weather clock for a Wemos D1 Mini (ESP8266) with a MAX7219 LED matrix display.
+A personal fork of [Marquee Scroller](https://github.com/Tronixstuff/marquee-scroller) by David Payne,
+customized as a family calendar + weather clock for a Wemos D1 Mini (ESP8266) with a MAX7219 LED matrix display.
 
 ## Features
 
 - Clock display with NTP time sync (12h or 24h, with optional PM indicator)
 - Local weather from OpenWeatherMap (temperature, conditions, wind, humidity, pressure, high/low)
-- **WagFam Calendar** — scrolls upcoming family events/birthdays fetched from a private JSON endpoint; animated border on event days
+- **WagFam Calendar** — scrolls upcoming family events/birthdays fetched from a private JSON endpoint;
+  animated border on event days
 - Configured entirely through a web interface (no re-flashing required for settings changes)
 - OTA firmware updates via web interface (file upload or URL)
 - Configurable scroll speed, brightness, and refresh interval
@@ -30,7 +32,8 @@ A personal fork of [Marquee Scroller](https://github.com/Tronixstuff/marquee-scr
 
 ### PlatformIO (recommended)
 
-Open the project folder in VS Code with the [PlatformIO](https://platformio.org/) (or [PIOArduino](https://marketplace.visualstudio.com/items?itemName=pioarduino.pioarduino-ide)) extension installed.
+Open the project folder in VS Code with the [PlatformIO](https://platformio.org/)
+(or [PIOArduino](https://marketplace.visualstudio.com/items?itemName=pioarduino.pioarduino-ide)) extension installed.
 
 ```bash
 pio run                          # Build
@@ -73,7 +76,8 @@ Upload via the web interface at `http://<device-ip>/update`.
 
 ## Initial Setup
 
-On first boot (or after "Forget WiFi"), the device creates a WiFi AP named `CLOCK-<chip-id>`. Connect to it with a phone or laptop to enter your WiFi credentials.
+On first boot (or after "Forget WiFi"), the device creates a WiFi AP named `CLOCK-<chip-id>`.
+Connect to it with a phone or laptop to enter your WiFi credentials.
 
 Once connected to WiFi, the device displays its IP address. Open `http://<ip>/` in a browser to access the web interface.
 
@@ -81,7 +85,8 @@ Default web UI credentials: **admin / password**
 
 ## Configuration
 
-All settings are managed through the web interface and persisted to the device filesystem. Editing `Settings.h` only affects defaults for a completely fresh start (filesystem erased).
+All settings are managed through the web interface and persisted to the device filesystem.
+Editing `Settings.h` only affects defaults for a completely fresh start (filesystem erased).
 
 ### API Keys
 
@@ -110,16 +115,19 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
 ```
 
 - Up to 10 messages are supported; they cycle through the marquee scroll
-- The `config` block is optional; if present, `eventToday: 1` enables an animated dot border around the clock display for the day
+- The `config` block is optional; if present, `eventToday: 1` enables an animated dot border around the clock display
+  for the day
 - The `config` block can also remotely update `dataSourceUrl` and `apiKey` on the device
 
 ### Geo Location
 
-Enter a city ID, city name + country code (`Chicago,US`), or GPS coordinates (`lat,lon`) — whatever format OpenWeatherMap accepts.
+Enter a city ID, city name + country code (`Chicago,US`), or GPS coordinates (`lat,lon`) —
+whatever format OpenWeatherMap accepts.
 
 ## Firmware Update from URL
 
-From the Configure page, a firmware URL (HTTP only — HTTPS is not supported) can be entered to trigger an OTA update directly from a hosted `.bin` file. The device will restart automatically on success.
+From the Configure page, a firmware URL (HTTP only — HTTPS is not supported) can be entered to trigger an OTA update
+directly from a hosted `.bin` file. The device will restart automatically on success.
 
 ## Web Interface Routes
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,64 @@
+IS_TTY:=$(shell tty -s && echo 1 || echo 0)
+ifeq ($(IS_TTY), 1)
+DOCKER_TTY_ARGS=-t
+else
+DOCKER_TTY_ARGS=
+endif
+
+MD_FILES:=$(shell find . -name "*.md" -not -path "./.venv/*" -not -path "./.pytest_cache/*" -not -path "./lib/*" -not -path "./.pio/*")
+
+MARKDOWNLINT_IMAGE:=davidanson/markdownlint-cli2:v0.22.0
+
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  help              - Show this help message"
+	@echo "  lint-markdown     - Run markdownlint on all Markdown files"
+	@echo "  lint-markdown-fix - Auto-fix markdownlint issues"
+	@echo "  lint              - Run lint-markdown"
+	@echo "  ready             - Full pipeline"
+
+.passwd:
+	echo "${USER}:x:$(shell id -u):$(shell id -g)::${HOME}:/bin/bash" > .passwd
+
+.PHONY: lint-markdown
+lint-markdown: .passwd
+	docker run \
+		--rm ${DOCKER_TTY_ARGS} \
+		-v ${PWD}:${PWD}:ro \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-u $(shell id -u):$(shell id -g) \
+		$(MARKDOWNLINT_IMAGE) \
+		--config .markdownlint.yaml ${MD_FILES}
+
+.PHONY: lint-markdown-fix
+lint-markdown-fix: .passwd
+	docker run \
+		--rm ${DOCKER_TTY_ARGS} \
+		-v ${PWD}:${PWD} \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-u $(shell id -u):$(shell id -g) \
+		$(MARKDOWNLINT_IMAGE) \
+		--fix --config .markdownlint.yaml ${MD_FILES}
+
+.PHONY: lint
+lint: lint-markdown
+
+.PHONY: test
+test:
+	@echo "No tests written yet!"
+
+.PHONY: build
+build:
+	@echo "No build implemented yet!"
+
+.PHONY: artifacts
+artifacts:
+	@echo "No artifacts implemented yet!"
+	mkdir -p artifacts/
+	touch artifacts/empty.txt
+
+.PHONY: ready
+ready: lint test build artifacts


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`lint-test-build.yaml`) that runs on pushes/PRs to `master` and on semver tags; runs lint, test, build, artifact upload, attestation, and automated GitHub release creation
- Adds `makefile` with targets for markdownlint (via Docker), test, build, and artifact gathering
- Adds `.markdownlint.yaml` enforcing 120-char line limit and disabling MD033/MD024/MD041
- Adds `.github/release.yaml` for changelog category configuration
- Reflowed long lines in `README.md` and `CLAUDE.md` to satisfy the new lint rules

## Test plan

- [x] Open a PR to `master` and confirm the workflow runs lint, test, and build steps
- [ ] Push a semver tag (e.g. `v3.08.0`) and confirm a GitHub release is created with generated notes and the artifacts zip attached
- [x] Confirm `make lint-markdown` passes locally