### PR TITLE
Add native unit tests for OWM, timeStr, and WagFam parser

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -36,6 +36,15 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Native Test Report
+        uses: dorny/test-reporter@v3
+        if: ${{ !cancelled() }} # run this step even if previous step failed
+        with:
+          name: Native Test Results
+          badge-title: Native Tests
+          path: 'artifacts/test-native-results.xml'
+          reporter: java-junit
+
       - name: Build
         run: make build
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ build/
 .vscode/
 .pio/
 .passwd
+.platformio/
 artifacts/
+**/__pycache__/

--- a/makefile
+++ b/makefile
@@ -8,6 +8,9 @@ endif
 MD_FILES:=$(shell find . -name "*.md" -not -path "./.venv/*" -not -path "./.pytest_cache/*" -not -path "./lib/*" -not -path "./.pio/*")
 
 MARKDOWNLINT_IMAGE:=davidanson/markdownlint-cli2:v0.22.0
+PIO_IMAGE:=ghcr.io/jrwagz/pio-image:v6.1.19
+LOCAL_PIO_CACHE:=./.platformio
+PIO_CACHE:=$(HOME)/.platformio
 
 .PHONY: help
 help:
@@ -16,10 +19,29 @@ help:
 	@echo "  lint-markdown     - Run markdownlint on all Markdown files"
 	@echo "  lint-markdown-fix - Auto-fix markdownlint issues"
 	@echo "  lint              - Run lint-markdown"
+	@echo "  test-native       - Run native C++ unit tests (no device required)"
 	@echo "  ready             - Full pipeline"
 
 .passwd:
 	echo "${USER}:x:$(shell id -u):$(shell id -g)::${HOME}:/bin/bash" > .passwd
+
+
+.PHONY: clean-pio
+clean-pio:
+	rm -rf .pio/
+	rm -rf .platformio/
+
+.PHONY: clean-passwd
+clean-passwd:
+	rm -rf .passwd
+
+.PHONY: clean-artifacts
+clean-artifacts:
+	rm -rf artifacts/
+
+
+.PHONY: clean
+clean: clean-pio clean-passwd clean-artifacts
 
 .PHONY: lint-markdown
 lint-markdown: .passwd
@@ -47,8 +69,20 @@ lint-markdown-fix: .passwd
 lint: lint-markdown
 
 .PHONY: test
-test:
-	@echo "No tests written yet!"
+test: test-native
+
+.PHONY: test-native
+test-native: .passwd
+	mkdir -p $(LOCAL_PIO_CACHE) artifacts
+	docker run \
+		--rm $(DOCKER_TTY_ARGS) \
+		-v ${PWD}:${PWD} \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-v $(LOCAL_PIO_CACHE):$(PIO_CACHE) \
+		-u $(shell id -u):$(shell id -g) \
+		$(PIO_IMAGE) \
+		pio test -e native_test --junit-output-path artifacts/test-native-results.xml
 
 .PHONY: build
 build:
@@ -61,4 +95,4 @@ artifacts:
 	touch artifacts/empty.txt
 
 .PHONY: ready
-ready: lint test build artifacts
+ready: clean lint test build artifacts

--- a/marquee/OpenWeatherMapClient.cpp
+++ b/marquee/OpenWeatherMapClient.cpp
@@ -37,6 +37,7 @@ OpenWeatherMapClient::OpenWeatherMapClient(const String &ApiKey, bool isMetric) 
 // UTF-8 to ANSI and viceversa)
 //
 int OpenWeatherMapClient::setGeoLocation(const String &location) {
+  if (location.length() == 0) return 1;
   int comma = location.indexOf(',');
   int comma2 = location.lastIndexOf(',');
   int decimal = location.indexOf('.');
@@ -70,7 +71,7 @@ int OpenWeatherMapClient::setGeoLocation(const String &location) {
     myGeoLocationType = LOC_CITYID;
     // USE http://api.openweathermap.org/data/2.5/weather?id={city-id}&appid={API-key}
   }
-  if ((len > 5) && (comma > 0) && (comma2 == 0) && (ch_cnt_digits >= len-3)) {
+  if ((len > 5) && (comma > 0) && (comma2 == comma) && (ch_cnt_digits >= len-3)) {
     myGeoLocationType = LOC_LATLON;
     myGeoLocation_lat = location.toFloat();
     myGeoLocation_lon = location.substring(comma+1).toFloat();

--- a/marquee/OpenWeatherMapClient.h
+++ b/marquee/OpenWeatherMapClient.h
@@ -11,19 +11,22 @@
 
 class OpenWeatherMapClient {
 
-private:
-  String myApiKey;
-
-  const char* servername = "api.openweathermap.org";  // remote server we will connect to
-
-  String myGeoLocation;
+public:
   enum locationtype_e {
     LOC_UNSET,
     LOC_UNKNOWN,
     LOC_CITYID,
     LOC_LATLON,
     LOC_NAME
-  } myGeoLocationType;
+  };
+
+private:
+  String myApiKey;
+
+  const char* servername = "api.openweathermap.org";  // remote server we will connect to
+
+  String myGeoLocation;
+  locationtype_e myGeoLocationType;
   int myGeoLocation_CityID;
   float myGeoLocation_lat;
   float myGeoLocation_lon;
@@ -85,6 +88,7 @@ public:
   inline String getWeatherDescription() {return weather.description;};
   inline String getIcon() {return weather.icon;};
   inline bool getWeatherDataValid() {return weather.isValid;};
+  inline locationtype_e getGeoLocationType() {return myGeoLocationType;};
   inline String getErrorMessage() {return errorMsg;};
   inline int getTimeZone() {return weather.timeZone/3600;}; // Local TimeZone delta with UTC in Hours
   inline int getTimeZoneSeconds() {return weather.timeZone;};

--- a/marquee/timeStr.cpp
+++ b/marquee/timeStr.cpp
@@ -6,7 +6,7 @@
  *
  */
 #include <Arduino.h>
-#include "timeLib.h"
+#include "TimeLib.h"
 #include "timeStr.h"
 
 String getDayName(int weekday) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ src_dir = marquee/
 include_dir = marquee/
 #lib_dir = marquee/libs
 default_envs = default
+test_dir = tests
 
 [env]
 platform = espressif8266
@@ -30,4 +31,18 @@ board = d1_mini
 # Wemos D1 (mini) is function compatible with Node MCU V0.9 and V2.0 and other ESP devkits, but not pin compatible!
 # Wemos D1 mini lite is NOT compatible! (has only 1MB flash)
 build_flags = #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
+
+[env:native_test]
+platform = native
+framework =
+test_framework = unity
+test_filter = native/*
+build_flags =
+  -std=gnu++17
+  -I tests/native/stubs
+  -I marquee
+  -I lib/json-streaming-parser
+build_src_filter = -<*>
+lib_deps =
+lib_ignore = json-streaming-parser
 

--- a/tests/native/stubs/Arduino.h
+++ b/tests/native/stubs/Arduino.h
@@ -1,0 +1,203 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+
+using boolean = bool;
+using byte = uint8_t;
+
+// Bring common std utilities into global scope (Arduino does this implicitly)
+using std::min;
+using std::max;
+
+#define PROGMEM
+#define PSTR(s) (s)
+
+class String {
+public:
+    std::string _s;
+
+    String() = default;
+    String(const String&) = default;
+    String& operator=(const String&) = default;
+    String(String&&) = default;
+    String& operator=(String&&) = default;
+
+    String(const char* s) : _s(s ? s : "") {}             // NOLINT
+    String(std::string s) : _s(std::move(s)) {}           // NOLINT
+    String(int n) : _s(std::to_string(n)) {}              // NOLINT
+    String(unsigned int n) : _s(std::to_string(n)) {}     // NOLINT
+    String(long n) : _s(std::to_string(n)) {}             // NOLINT
+    String(unsigned long n) : _s(std::to_string(n)) {}    // NOLINT
+    String(bool b) : _s(b ? "1" : "0") {}                 // NOLINT
+    String(char c) : _s(1, c) {}                          // NOLINT
+    String(float n, int dec = 2) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.*f", dec, (double)n);
+        _s = buf;
+    }
+    String(double n, int dec = 2) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%.*f", dec, n);
+        _s = buf;
+    }
+
+    String& operator=(const char* s) { _s = s ? s : ""; return *this; }
+    String& operator=(char c) { _s = std::string(1, c); return *this; }
+
+    bool operator==(const String& o) const { return _s == o._s; }
+    bool operator==(const char* s) const { return _s == (s ? s : ""); }
+    bool operator!=(const String& o) const { return _s != o._s; }
+    bool operator!=(const char* s) const { return _s != (s ? s : ""); }
+    bool operator<(const String& o) const { return _s < o._s; }
+
+    String operator+(const String& o) const { return String(_s + o._s); }
+    String operator+(const char* s) const { return String(_s + (s ? s : "")); }
+    String operator+(char c) const { return String(_s + c); }
+    String operator+(int n) const { return String(_s + std::to_string(n)); }
+    String& operator+=(const String& o) { _s += o._s; return *this; }
+    String& operator+=(const char* s) { if (s) _s += s; return *this; }
+    String& operator+=(char c) { _s += c; return *this; }
+
+    friend String operator+(const char* lhs, const String& rhs) {
+        return String(std::string(lhs ? lhs : "") + rhs._s);
+    }
+
+    char operator[](int i) const {
+        if (i < 0 || i >= (int)_s.size()) return 0;
+        return _s[i];
+    }
+    char& operator[](int i) { return _s[i]; }
+
+    // Implicit conversions for library compatibility
+    operator std::string() const { return _s; }
+    operator const char*() const { return _s.c_str(); }
+
+    unsigned int length() const { return (unsigned int)_s.size(); }
+    bool isEmpty() const { return _s.empty(); }
+    const char* c_str() const { return _s.c_str(); }
+    void reserve(unsigned int size) { _s.reserve(size); }
+
+    int indexOf(char c, int from = 0) const {
+        if (from < 0) from = 0;
+        size_t pos = _s.find(c, (size_t)from);
+        return (pos == std::string::npos) ? -1 : (int)pos;
+    }
+    int indexOf(const char* s, int from = 0) const {
+        if (from < 0) from = 0;
+        size_t pos = _s.find(s, (size_t)from);
+        return (pos == std::string::npos) ? -1 : (int)pos;
+    }
+    int indexOf(const String& s, int from = 0) const {
+        return indexOf(s._s.c_str(), from);
+    }
+
+    int lastIndexOf(char c) const {
+        size_t pos = _s.rfind(c);
+        return (pos == std::string::npos) ? -1 : (int)pos;
+    }
+    int lastIndexOf(const char* s) const {
+        size_t pos = _s.rfind(s);
+        return (pos == std::string::npos) ? -1 : (int)pos;
+    }
+    int lastIndexOf(const String& s) const {
+        return lastIndexOf(s._s.c_str());
+    }
+
+    String substring(int from, int to = -1) const {
+        if (from < 0) from = 0;
+        if (from > (int)_s.size()) return String("");
+        if (to == -1 || to > (int)_s.size()) return String(_s.substr(from));
+        if (to <= from) return String("");
+        return String(_s.substr(from, to - from));
+    }
+
+    void trim() {
+        size_t start = _s.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) { _s = ""; return; }
+        size_t end = _s.find_last_not_of(" \t\n\r");
+        _s = _s.substr(start, end - start + 1);
+    }
+
+    void toLowerCase() {
+        for (auto& c : _s) c = (char)tolower((unsigned char)c);
+    }
+    void toUpperCase() {
+        for (auto& c : _s) c = (char)toupper((unsigned char)c);
+    }
+
+    int toInt() const {
+        if (_s.empty()) return 0;
+        return (int)strtol(_s.c_str(), nullptr, 10);
+    }
+    float toFloat() const {
+        if (_s.empty()) return 0.0f;
+        return (float)strtof(_s.c_str(), nullptr);
+    }
+
+    bool startsWith(const char* prefix) const {
+        if (!prefix) return false;
+        return _s.rfind(prefix, 0) == 0;
+    }
+    bool startsWith(const String& s) const { return startsWith(s._s.c_str()); }
+
+    bool endsWith(const char* suffix) const {
+        if (!suffix) return false;
+        std::string s(suffix);
+        if (s.length() > _s.length()) return false;
+        return _s.compare(_s.length() - s.length(), s.length(), s) == 0;
+    }
+    bool endsWith(const String& s) const { return endsWith(s._s.c_str()); }
+
+    // replace all occurrences — operates on raw bytes, correct for multi-byte UTF-8 sequences
+    void replace(const char* from, const char* to) {
+        if (!from || !*from) return;
+        std::string f(from), t(to ? to : "");
+        size_t pos = 0;
+        while ((pos = _s.find(f, pos)) != std::string::npos) {
+            _s.replace(pos, f.length(), t);
+            pos += t.length();
+        }
+    }
+    void replace(const String& from, const String& to) {
+        replace(from._s.c_str(), to._s.c_str());
+    }
+
+    bool equals(const String& o) const { return _s == o._s; }
+    bool equals(const char* s) const { return _s == (s ? s : ""); }
+    bool equalsIgnoreCase(const String& o) const {
+        if (_s.size() != o._s.size()) return false;
+        for (size_t i = 0; i < _s.size(); i++)
+            if (tolower((unsigned char)_s[i]) != tolower((unsigned char)o._s[i])) return false;
+        return true;
+    }
+
+    int compareTo(const String& o) const { return _s.compare(o._s); }
+    bool concat(const String& s) { _s += s._s; return true; }
+    bool concat(const char* s) { if (s) _s += s; return true; }
+};
+
+// FPSTR/F must come after String definition
+#define F(s) (s)
+#define FPSTR(s) String(s)
+
+// Serial stub — writes to stdout
+struct _SerialClass {
+    template<typename T> void print(T v) { std::cout << v; }
+    void print(const String& s) { std::cout << s._s; }
+    template<typename T> void println(T v) { std::cout << v << "\n"; }
+    void println(const String& s) { std::cout << s._s << "\n"; }
+    void println() { std::cout << "\n"; }
+    void begin(int) {}
+    bool available() { return false; }
+};
+static _SerialClass Serial;
+
+inline void delay(unsigned long) {}
+inline unsigned long millis() { return 0; }
+inline unsigned long micros() { return 0; }

--- a/tests/native/stubs/ArduinoJson.h
+++ b/tests/native/stubs/ArduinoJson.h
@@ -1,0 +1,38 @@
+#pragma once
+// Minimal stub — allows OpenWeatherMapClient.cpp to compile without the real ArduinoJson
+// Only needs to satisfy the compiler; updateWeather() is never called in native tests
+
+struct JsonVariant {
+    template<typename T>
+    T as() const { return T{}; }
+
+    JsonVariant operator[](const char*) const { return {}; }
+    JsonVariant operator[](int) const { return {}; }
+
+    operator float()    const { return 0.0f; }
+    operator double()   const { return 0.0; }
+    operator int()      const { return 0; }
+    operator unsigned() const { return 0; }
+    operator bool()     const { return false; }
+    operator long()     const { return 0L; }
+
+    // uint32_t — same width as unsigned int on most platforms; avoid ambiguity
+    // by providing a named cast helper instead of implicit operator
+};
+
+struct JsonDocument {
+    JsonVariant operator[](const char*) const { return {}; }
+    JsonVariant operator[](int) const { return {}; }
+};
+
+struct DeserializationError {
+    bool _err = false;
+    explicit operator bool() const { return _err; }
+};
+
+template<typename TInput>
+inline DeserializationError deserializeJson(JsonDocument&, TInput&) { return {}; }
+template<typename TInput>
+inline DeserializationError deserializeJson(JsonDocument&, const TInput&) { return {}; }
+
+inline int measureJson(const JsonDocument&) { return 0; }

--- a/tests/native/stubs/ESP8266HTTPClient.h
+++ b/tests/native/stubs/ESP8266HTTPClient.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Arduino.h"
+#include "ESP8266WiFi.h"
+
+#define HTTP_CODE_OK               200
+#define HTTP_CODE_MOVED_PERMANENTLY 301
+
+class HTTPClient {
+public:
+    bool begin(WiFiClient&, const String&) { return false; }
+    void addHeader(const String&, const String&) {}
+    int GET() { return -1; }
+    int getSize() { return 0; }
+    WiFiClient* getStreamPtr() { return nullptr; }
+    bool connected() { return false; }
+    void end() {}
+    String errorToString(int) { return String(""); }
+};

--- a/tests/native/stubs/ESP8266WiFi.h
+++ b/tests/native/stubs/ESP8266WiFi.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "Arduino.h"
+
+class WiFiClient {
+public:
+    bool connect(const char*, int) { return false; }
+    bool connect(const String&, int) { return false; }
+    bool connected() { return false; }
+    void stop() {}
+    bool available() { return false; }
+    int read() { return -1; }
+    int readBytes(char*, int) { return 0; }
+    int readBytesUntil(char, char* buf, int len) {
+        if (len > 0) buf[0] = 0;
+        return 0;
+    }
+    bool find(const char*) { return false; }
+    void print(const String&) {}
+    void print(const char*) {}
+    void println(const String&) {}
+    void println(const char*) {}
+    void println() {}
+    void flush() {}
+};
+
+class WiFiClientSecure : public WiFiClient {};

--- a/tests/native/stubs/TimeLib.h
+++ b/tests/native/stubs/TimeLib.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <cstdint>
+
+// Minimal TimeLib stub for native compilation
+inline int numberOfHours(uint32_t epoch)   { return (int)((epoch % 86400UL) / 3600); }
+inline int numberOfMinutes(uint32_t epoch) { return (int)((epoch  % 3600UL) / 60); }
+inline int numberOfSeconds(uint32_t epoch) { return (int)(epoch  % 60UL); }

--- a/tests/native/stubs/WiFiClientSecureBearSSL.h
+++ b/tests/native/stubs/WiFiClientSecureBearSSL.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <memory>
+#include "ESP8266WiFi.h"
+
+namespace BearSSL {
+    class WiFiClientSecure : public WiFiClient {
+    public:
+        void setInsecure() {}
+        void setFingerprint(const char*) {}
+        void setCACert(const char*) {}
+    };
+}

--- a/tests/native/stubs/pgmspace.h
+++ b/tests/native/stubs/pgmspace.h
@@ -1,0 +1,2 @@
+#pragma once
+// Stub: PROGMEM and pgmspace functions are no-ops on native

--- a/tests/native/test_owm_geolocation/test_owm_geolocation.cpp
+++ b/tests/native/test_owm_geolocation/test_owm_geolocation.cpp
@@ -1,0 +1,120 @@
+#include <unity.h>
+#include <cmath>
+
+// Stubs — found via -I tests/native/stubs
+#include "Arduino.h"
+#include "ArduinoJson.h"
+#include "ESP8266WiFi.h"
+#include "TimeLib.h"
+
+// timeStr is included by OpenWeatherMapClient.cpp
+#include "timeStr.cpp"
+
+// EncodeUrlSpecialChars is declared extern in OpenWeatherMapClient.h but lives
+// in marquee.ino; provide a stub so the file compiles
+String EncodeUrlSpecialChars(const char* msg) {
+    return String(msg ? msg : "");
+}
+
+#include "OpenWeatherMapClient.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+// ── setGeoLocation ───────────────────────────────────────────────────────────
+
+void test_numeric_city_id_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("1234567"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_CITYID, c.getGeoLocationType());
+}
+
+void test_short_string_not_city_id_returns_nonzero() {
+    // len=3 fails the (len > 3) check for city ID
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_NOT_EQUAL(0, c.setGeoLocation("123"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_UNKNOWN, c.getGeoLocationType());
+}
+
+void test_city_name_only_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("London"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+void test_city_name_with_country_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("Chicago,US"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+void test_city_name_with_state_and_country_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("Seattle,WA,US"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+void test_empty_string_returns_error() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_NOT_EQUAL(0, c.setGeoLocation(""));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_UNSET, c.getGeoLocationType());
+}
+
+void test_latlon_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("47.606,-122.332"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_LATLON, c.getGeoLocationType());
+}
+
+void test_latlon_negative_lat_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("-33.87,151.21"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_LATLON, c.getGeoLocationType());
+}
+
+void test_latlon_both_negative_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("-34.603,-58.381"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_LATLON, c.getGeoLocationType());
+}
+
+void test_latlon_not_confused_with_city_two_commas() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("Seattle,WA,US"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+void test_city_with_spaces_in_name_returns_0() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("New York,US"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+void test_weather_data_initially_invalid() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_FALSE(c.getWeatherDataValid());
+}
+
+void test_geolocation_accepts_city_with_hyphen() {
+    OpenWeatherMapClient c("", false);
+    TEST_ASSERT_EQUAL(0, c.setGeoLocation("Aix-en-Provence,FR"));
+    TEST_ASSERT_EQUAL(OpenWeatherMapClient::LOC_NAME, c.getGeoLocationType());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_numeric_city_id_returns_0);
+    RUN_TEST(test_short_string_not_city_id_returns_nonzero);
+    RUN_TEST(test_city_name_only_returns_0);
+    RUN_TEST(test_city_name_with_country_returns_0);
+    RUN_TEST(test_city_name_with_state_and_country_returns_0);
+    RUN_TEST(test_empty_string_returns_error);
+    RUN_TEST(test_latlon_returns_0);
+    RUN_TEST(test_latlon_negative_lat_returns_0);
+    RUN_TEST(test_latlon_both_negative_returns_0);
+    RUN_TEST(test_latlon_not_confused_with_city_two_commas);
+    RUN_TEST(test_city_with_spaces_in_name_returns_0);
+    RUN_TEST(test_weather_data_initially_invalid);
+    RUN_TEST(test_geolocation_accepts_city_with_hyphen);
+    return UNITY_END();
+}

--- a/tests/native/test_timestr/test_timestr.cpp
+++ b/tests/native/test_timestr/test_timestr.cpp
@@ -1,0 +1,124 @@
+#include <unity.h>
+#include "Arduino.h"
+#include "TimeLib.h"
+#include "timeStr.h"
+#include "timeStr.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+void test_get_day_names() {
+    TEST_ASSERT_EQUAL_STRING("Sunday", getDayName(1).c_str());
+    TEST_ASSERT_EQUAL_STRING("Monday", getDayName(2).c_str());
+    TEST_ASSERT_EQUAL_STRING("Tuesday", getDayName(3).c_str());
+    TEST_ASSERT_EQUAL_STRING("Wednesday", getDayName(4).c_str());
+    TEST_ASSERT_EQUAL_STRING("Thursday", getDayName(5).c_str());
+    TEST_ASSERT_EQUAL_STRING("Friday", getDayName(6).c_str());
+    TEST_ASSERT_EQUAL_STRING("Saturday", getDayName(7).c_str());
+}
+
+void test_get_day_name_zero_returns_empty() {
+    TEST_ASSERT_EQUAL_STRING("", getDayName(0).c_str());
+}
+
+void test_get_day_name_eight_returns_empty() {
+    TEST_ASSERT_EQUAL_STRING("", getDayName(8).c_str());
+}
+
+void test_get_month_names() {
+    TEST_ASSERT_EQUAL_STRING("Jan", getMonthName(1).c_str());
+    TEST_ASSERT_EQUAL_STRING("Feb", getMonthName(2).c_str());
+    TEST_ASSERT_EQUAL_STRING("Mar", getMonthName(3).c_str());
+    TEST_ASSERT_EQUAL_STRING("Apr", getMonthName(4).c_str());
+    TEST_ASSERT_EQUAL_STRING("May", getMonthName(5).c_str());
+    TEST_ASSERT_EQUAL_STRING("June", getMonthName(6).c_str());
+    TEST_ASSERT_EQUAL_STRING("July", getMonthName(7).c_str());
+    TEST_ASSERT_EQUAL_STRING("Aug", getMonthName(8).c_str());
+    TEST_ASSERT_EQUAL_STRING("Sep", getMonthName(9).c_str());
+    TEST_ASSERT_EQUAL_STRING("Oct", getMonthName(10).c_str());
+    TEST_ASSERT_EQUAL_STRING("Nov", getMonthName(11).c_str());
+    TEST_ASSERT_EQUAL_STRING("Dec", getMonthName(12).c_str());
+}
+
+void test_get_month_name_zero_returns_empty() {
+    TEST_ASSERT_EQUAL_STRING("", getMonthName(0).c_str());
+}
+
+void test_get_month_name_thirteen_returns_empty() {
+    TEST_ASSERT_EQUAL_STRING("", getMonthName(13).c_str());
+}
+
+void test_get_am_pm_returns() {
+    TEST_ASSERT_EQUAL_STRING("PM", getAmPm(true).c_str());
+    TEST_ASSERT_EQUAL_STRING("AM", getAmPm(false).c_str());
+}
+
+void test_space_pad_single_digit() {
+    TEST_ASSERT_EQUAL_STRING(" 5", spacePad(5).c_str());
+}
+
+void test_space_pad_double_digit() {
+    TEST_ASSERT_EQUAL_STRING("10", spacePad(10).c_str());
+}
+
+void test_space_pad_zero() {
+    TEST_ASSERT_EQUAL_STRING(" 0", spacePad(0).c_str());
+}
+
+void test_zero_pad_single_digit() {
+    TEST_ASSERT_EQUAL_STRING("05", zeroPad(5u).c_str());
+}
+
+void test_zero_pad_double_digit() {
+    TEST_ASSERT_EQUAL_STRING("15", zeroPad(15u).c_str());
+}
+
+void test_zero_pad_zero() {
+    TEST_ASSERT_EQUAL_STRING("00", zeroPad(0u).c_str());
+}
+
+void test_zero_pad_with_length_3() {
+    TEST_ASSERT_EQUAL_STRING("007", zeroPad((uint32_t)7, (uint8_t)3).c_str());
+}
+
+void test_zero_pad_with_length_no_padding_needed() {
+    TEST_ASSERT_EQUAL_STRING("42", zeroPad((uint32_t)42, (uint8_t)2).c_str());
+}
+
+void test_get_24hr_colon_min_midnight() {
+    // epoch 0 = 00:00
+    TEST_ASSERT_EQUAL_STRING("00:00", get24HrColonMin(0).c_str());
+}
+
+void test_get_24hr_colon_min_noon() {
+    // 12 * 3600 = 43200
+    TEST_ASSERT_EQUAL_STRING("12:00", get24HrColonMin(43200).c_str());
+}
+
+void test_get_24hr_colon_min_with_minutes() {
+    // 9 hours + 5 minutes = 32700 seconds
+    TEST_ASSERT_EQUAL_STRING("09:05", get24HrColonMin(32700).c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_get_day_names);
+    RUN_TEST(test_get_day_name_zero_returns_empty);
+    RUN_TEST(test_get_day_name_eight_returns_empty);
+    RUN_TEST(test_get_month_names);
+    RUN_TEST(test_get_month_name_zero_returns_empty);
+    RUN_TEST(test_get_month_name_thirteen_returns_empty);
+    RUN_TEST(test_get_am_pm_returns);
+    RUN_TEST(test_space_pad_single_digit);
+    RUN_TEST(test_space_pad_double_digit);
+    RUN_TEST(test_space_pad_zero);
+    RUN_TEST(test_zero_pad_single_digit);
+    RUN_TEST(test_zero_pad_double_digit);
+    RUN_TEST(test_zero_pad_zero);
+    RUN_TEST(test_zero_pad_with_length_3);
+    RUN_TEST(test_zero_pad_with_length_no_padding_needed);
+    RUN_TEST(test_get_24hr_colon_min_midnight);
+    RUN_TEST(test_get_24hr_colon_min_noon);
+    RUN_TEST(test_get_24hr_colon_min_with_minutes);
+    return UNITY_END();
+}

--- a/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
+++ b/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
@@ -1,0 +1,174 @@
+#include <unity.h>
+
+// Stubs must be first — they're found via -I tests/native/stubs
+#include "Arduino.h"
+#include "ESP8266WiFi.h"
+#include "ESP8266HTTPClient.h"
+#include "WiFiClientSecureBearSSL.h"
+
+// Library source — found via -I lib/json-streaming-parser
+#include "JsonStreamingParser.cpp"
+#include "JsonListener.cpp"
+
+// Production source — found via -I marquee
+#include "WagFamBdayClient.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+static void feed_json(WagFamBdayClient& client, const char* json) {
+    JsonStreamingParser parser;
+    parser.setListener(&client);
+    parser.reset();
+    for (const char* p = json; *p; p++) {
+        parser.parse(*p);
+    }
+}
+
+// ── getNumMessages ──────────────────────────────────────────────────────────
+
+void test_empty_array_gives_zero_messages() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[]");
+    TEST_ASSERT_EQUAL(0, client.getNumMessages());
+}
+
+void test_single_message_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"message\": \"Happy Birthday!\"}]");
+    TEST_ASSERT_EQUAL(1, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("Happy Birthday!", client.getMessage(0).c_str());
+}
+
+void test_two_messages_parsed_in_order() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"message\":\"First\"},{\"message\":\"Second\"}]");
+    TEST_ASSERT_EQUAL(2, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("First", client.getMessage(0).c_str());
+    TEST_ASSERT_EQUAL_STRING("Second", client.getMessage(1).c_str());
+}
+
+void test_max_10_messages_enforced() {
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"message\":\"M1\"},{\"message\":\"M2\"},{\"message\":\"M3\"},"
+        "{\"message\":\"M4\"},{\"message\":\"M5\"},{\"message\":\"M6\"},"
+        "{\"message\":\"M7\"},{\"message\":\"M8\"},{\"message\":\"M9\"},"
+        "{\"message\":\"M10\"},{\"message\":\"M11 - ignored\"}]");
+    TEST_ASSERT_EQUAL(10, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("M1", client.getMessage(0).c_str());
+    TEST_ASSERT_EQUAL_STRING("M2", client.getMessage(1).c_str());
+    TEST_ASSERT_EQUAL_STRING("M3", client.getMessage(2).c_str());
+    TEST_ASSERT_EQUAL_STRING("M4", client.getMessage(3).c_str());
+    TEST_ASSERT_EQUAL_STRING("M5", client.getMessage(4).c_str());
+    TEST_ASSERT_EQUAL_STRING("M6", client.getMessage(5).c_str());
+    TEST_ASSERT_EQUAL_STRING("M7", client.getMessage(6).c_str());
+    TEST_ASSERT_EQUAL_STRING("M8", client.getMessage(7).c_str());
+    TEST_ASSERT_EQUAL_STRING("M9", client.getMessage(8).c_str());
+    TEST_ASSERT_EQUAL_STRING("M10", client.getMessage(9).c_str());
+}
+
+void test_config_block_does_not_count_as_message() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"eventToday\":\"1\"}},{\"message\":\"X\"}]");
+    TEST_ASSERT_EQUAL(1, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("X", client.getMessage(0).c_str());
+}
+
+void test_config_only_gives_zero_messages() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"dataSourceUrl\":\"http://new.example.com\",\"apiKey\":\"newkey\"}}]");
+    TEST_ASSERT_EQUAL(0, client.getNumMessages());
+}
+
+void test_second_parse_resets_message_counter() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"message\":\"First parse\"}]");
+    TEST_ASSERT_EQUAL(1, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("First parse", client.getMessage(0).c_str());
+    feed_json(client, "[{\"message\":\"A\"},{\"message\":\"B\"}]");
+    TEST_ASSERT_EQUAL(2, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("A", client.getMessage(0).c_str());
+    TEST_ASSERT_EQUAL_STRING("B", client.getMessage(1).c_str());
+}
+
+void test_whitespace_in_json_handled() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[\n  {\n    \"message\": \"Spaced Out\"\n  }\n]");
+    TEST_ASSERT_EQUAL(1, client.getNumMessages());
+    TEST_ASSERT_EQUAL_STRING("Spaced Out", client.getMessage(0).c_str());
+}
+
+// ── cleanText ───────────────────────────────────────────────────────────────
+
+void test_clean_text_ascii_passthrough() {
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("Hello World!", client.cleanText("Hello World!").c_str());
+}
+
+void test_clean_text_smart_left_double_quote() {
+    // U+201C LEFT DOUBLE QUOTATION MARK = \xe2\x80\x9c
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("\"Hello\"", client.cleanText("\xe2\x80\x9cHello\xe2\x80\x9d").c_str());
+}
+
+void test_clean_text_eacute_replaced() {
+    // U+00E9 é = \xc3\xa9
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("eleve", client.cleanText("\xc3\xa9l\xc3\xa8ve").c_str());
+}
+
+void test_clean_text_ellipsis_replaced() {
+    // U+2026 … = \xe2\x80\xa6
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("Wait...OK", client.cleanText("Wait\xe2\x80\xa6OK").c_str());
+}
+
+void test_clean_text_en_dash_replaced() {
+    // U+2013 – = \xe2\x80\x93
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("Jan - Feb", client.cleanText("Jan \xe2\x80\x93 Feb").c_str());
+}
+
+void test_clean_text_cedilla_replaced() {
+    // U+00E7 ç = \xc3\xa7
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("garcon", client.cleanText("gar\xc3\xa7on").c_str());
+}
+
+void test_clean_text_multiple_replacements() {
+    // Combination: é, … in one string
+    WagFamBdayClient client("", "");
+    String result = client.cleanText("\xc3\xa9l\xc3\xa8ve\xe2\x80\xa6wait");
+    TEST_ASSERT_EQUAL_STRING("eleve...wait", result.c_str());
+}
+
+void test_clean_text_smart_single_right_quote() {
+    // U+2019 RIGHT SINGLE QUOTATION MARK = \xe2\x80\x99
+    WagFamBdayClient client("", "");
+    TEST_ASSERT_EQUAL_STRING("it's", client.cleanText("it\xe2\x80\x99s").c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_empty_array_gives_zero_messages);
+    RUN_TEST(test_single_message_parsed);
+    RUN_TEST(test_two_messages_parsed_in_order);
+    RUN_TEST(test_max_10_messages_enforced);
+    RUN_TEST(test_config_block_does_not_count_as_message);
+    RUN_TEST(test_config_only_gives_zero_messages);
+    RUN_TEST(test_second_parse_resets_message_counter);
+    RUN_TEST(test_whitespace_in_json_handled);
+
+    RUN_TEST(test_clean_text_ascii_passthrough);
+    RUN_TEST(test_clean_text_smart_left_double_quote);
+    RUN_TEST(test_clean_text_eacute_replaced);
+    RUN_TEST(test_clean_text_ellipsis_replaced);
+    RUN_TEST(test_clean_text_en_dash_replaced);
+    RUN_TEST(test_clean_text_cedilla_replaced);
+    RUN_TEST(test_clean_text_multiple_replacements);
+    RUN_TEST(test_clean_text_smart_single_right_quote);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Adds three Unity-based native test suites (`test_owm_geolocation`, `test_timestr`, `test_wagfam_parser`) runnable without hardware
- Adds Arduino/ESP8266 stub headers under `tests/native/stubs/` to allow production source to compile natively
- Configures a `native_test` PlatformIO environment and `make test-native` target that runs tests in Docker

## Source fixes included

- `OpenWeatherMapClient`: fix lat/lon detection bug (`comma2 == 0` → `comma2 == comma`), add empty-string guard, expose `locationtype_e` publicly and add `getGeoLocationType()` accessor
- `timeStr.cpp`: fix `#include "timeLib.h"` → `#include "TimeLib.h"` (case-sensitive on Linux/Docker)

## Test plan

- [x] `make test-native` passes all tests in Docker
- [ ] `pio run` still builds the firmware successfully for `d1_mini`