### PR TITLE
Implement make build and artifacts; add bare .bin to releases

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -74,15 +74,25 @@ jobs:
 
       - name: Package release artifacts
         if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
-        run: zip -r "${{ github.event.repository.name }}-${{ github.ref_name }}-artifacts.zip" artifacts/
+        run: |
+          zip -r "${{ github.event.repository.name }}-${{ github.ref_name }}-artifacts.zip" artifacts/
+          cp artifacts/firmware.bin "${{ github.event.repository.name }}-${{ github.ref_name }}.bin"
 
-      - name: Upload release artifacts
+      - name: Upload release artifacts zip
         if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload "${{ github.ref_name }}" \
             "${{ github.event.repository.name }}-${{ github.ref_name }}-artifacts.zip"
+
+      - name: Upload release artifacts bin
+        if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "${{ github.event.repository.name }}-${{ github.ref_name }}.bin"
 
       - name: Write release summary
         if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )

--- a/makefile
+++ b/makefile
@@ -85,14 +85,22 @@ test-native: .passwd
 		pio test -e native_test --junit-output-path artifacts/test-native-results.xml
 
 .PHONY: build
-build:
-	@echo "No build implemented yet!"
+build: .passwd
+	mkdir -p $(LOCAL_PIO_CACHE)
+	docker run \
+		--rm $(DOCKER_TTY_ARGS) \
+		-v ${PWD}:${PWD} \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-v $(LOCAL_PIO_CACHE):$(PIO_CACHE) \
+		-u $(shell id -u):$(shell id -g) \
+		$(PIO_IMAGE) \
+		pio run -e default
 
 .PHONY: artifacts
 artifacts:
-	@echo "No artifacts implemented yet!"
 	mkdir -p artifacts/
-	touch artifacts/empty.txt
+	cp .pio/build/default/firmware.bin artifacts/firmware.bin
 
 .PHONY: ready
 ready: clean lint test build artifacts

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -48,8 +48,8 @@ SOFTWARE.
 #include <Max72xxPanel.h> // --> https://github.com/markruys/arduino-Max72xxPanel
 #include <pgmspace.h>
 #include "OpenWeatherMapClient.h"
-#include "TimeNTP.h"
-#include "TimeStr.h"
+#include "timeNTP.h"
+#include "timeStr.h"
 #include "WagFamBdayClient.h"
 
 //******************************


### PR DESCRIPTION
## Summary

- `make build` now compiles the ESP8266 firmware via `pio run -e default` inside the same
  Docker/PlatformIO container used for native tests
- `make artifacts` copies `.pio/build/default/firmware.bin` into `artifacts/` where CI
  archives and attests it
- On tagged releases, CI uploads a versioned bare `.bin` (`marquee-scroller-<tag>.bin`)
  alongside the existing `.zip`, so users can grab a ready-to-flash binary directly from
  the Releases page without unzipping

## Test plan

- [x] CI passes: lint → test → build → artifacts all green
- [x] `artifacts/firmware.bin` appears in the uploaded artifact on a CI run
- [ ] On a tagged release, both the `.zip` and the bare `.bin` appear as release assets