### PR TITLE
Add build provenance to VERSION via PlatformIO pre-build script

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -45,6 +45,15 @@ jobs:
           path: 'artifacts/test-native-results.xml'
           reporter: java-junit
 
+      - name: Scripts Test Report
+        uses: dorny/test-reporter@v3
+        if: ${{ !cancelled() }} # run this step even if previous step failed
+        with:
+          name: Scripts Test Results
+          badge-title: Scripts Tests
+          path: 'artifacts/test-scripts-results.xml'
+          reporter: java-junit
+
       - name: Build
         run: make build
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build/
 .platformio/
 artifacts/
 **/__pycache__/
+.coverage
+.ruff_cache/
+.pytest-image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,23 +47,23 @@ Local library copies (not managed by PlatformIO) are in [lib/](lib/):
 
 | Function | Line |
 | --- | --- |
-| Global variables (settings) | 60–98 |
-| PROGMEM HTML constants | 104–148 |
-| `setup()` | 173 |
-| `loop()` | 282 |
-| `processEverySecond()` | 308 |
-| `processEveryMinute()` | 325 |
-| `handleSaveConfig()` | 404 |
-| `handleConfigure()` | 449 |
-| `handleUpdateFromUrl()` | 575 |
-| `getWeatherData()` | 699 |
-| `sendHeader()` / `sendFooter()` | 804 / 834 |
-| `displayHomePage()` | 848 |
-| `savePersistentConfig()` | 984 |
-| `readPersistentConfig()` | 1023 |
-| `scrollMessageWait()` | 1111 |
-| `centerPrint()` | 1135 |
-| REST API handlers | 1174 |
+| Global variables (settings) | 65–103 |
+| PROGMEM HTML constants | 109–153 |
+| `setup()` | 178 |
+| `loop()` | 287 |
+| `processEverySecond()` | 313 |
+| `processEveryMinute()` | 330 |
+| `handleSaveConfig()` | 409 |
+| `handleConfigure()` | 454 |
+| `handleUpdateFromUrl()` | 580 |
+| `getWeatherData()` | 704 |
+| `sendHeader()` / `sendFooter()` | 809 / 839 |
+| `displayHomePage()` | 853 |
+| `savePersistentConfig()` | 989 |
+| `readPersistentConfig()` | 1028 |
+| `scrollMessageWait()` | 1116 |
+| `centerPrint()` | 1140 |
+| REST API handlers | 1177 |
 
 ## Configuration Storage
 
@@ -77,11 +77,11 @@ changes there require a filesystem erase to take effect.
 
 ### Adding a New Config Key
 
-1. Declare a global variable in `marquee.ino` (near line 60)
-2. Add `f.println("KEY=" + String(value))` in `savePersistentConfig()` (~line 877)
-3. Add an `if (line.indexOf("KEY=") >= 0)` block in `readPersistentConfig()` (~line 908)
-4. Add a form field in one of the `CHANGE_FORM*` PROGMEM constants (~line 113)
-5. Read from `server.arg("fieldName")` in `handleSaveConfig()` (~line 378)
+1. Declare a global variable in `marquee.ino` (near line 65)
+2. Add `f.println("KEY=" + String(value))` in `savePersistentConfig()` (~line 882)
+3. Add an `if (line.indexOf("KEY=") >= 0)` block in `readPersistentConfig()` (~line 913)
+4. Add a form field in one of the `CHANGE_FORM*` PROGMEM constants (~line 118)
+5. Read from `server.arg("fieldName")` in `handleSaveConfig()` (~line 383)
 
 ## Development Practices
 

--- a/Dockerfile.pytest
+++ b/Dockerfile.pytest
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+RUN pip install --no-cache-dir \
+    pytest~=8.3 \
+    pytest-cov~=6.0

--- a/makefile
+++ b/makefile
@@ -9,6 +9,8 @@ MD_FILES:=$(shell find . -name "*.md" -not -path "./.venv/*" -not -path "./.pyte
 
 MARKDOWNLINT_IMAGE:=davidanson/markdownlint-cli2:v0.22.0
 PIO_IMAGE:=ghcr.io/jrwagz/pio-image:v6.1.19
+PYTEST_IMAGE:=marquee-pytest:local
+RUFF_IMAGE:=ghcr.io/astral-sh/ruff:0.15.12
 LOCAL_PIO_CACHE:=./.platformio
 PIO_CACHE:=$(HOME)/.platformio
 
@@ -18,8 +20,11 @@ help:
 	@echo "  help              - Show this help message"
 	@echo "  lint-markdown     - Run markdownlint on all Markdown files"
 	@echo "  lint-markdown-fix - Auto-fix markdownlint issues"
-	@echo "  lint              - Run lint-markdown"
+	@echo "  lint-python       - Run ruff on scripts/ and tests/scripts/"
+	@echo "  lint              - Run lint-markdown + lint-python"
 	@echo "  test-native       - Run native C++ unit tests (no device required)"
+	@echo "  test-scripts      - Run Python tests for scripts/ with 100% coverage check"
+	@echo "  test              - Run test-native + test-scripts"
 	@echo "  ready             - Full pipeline"
 
 .passwd:
@@ -39,9 +44,13 @@ clean-passwd:
 clean-artifacts:
 	rm -rf artifacts/
 
+.PHONY: clean-pytest-image
+clean-pytest-image:
+	rm -f .pytest-image
+	docker rmi $(PYTEST_IMAGE) 2>/dev/null || true
 
 .PHONY: clean
-clean: clean-pio clean-passwd clean-artifacts
+clean: clean-pio clean-passwd clean-artifacts clean-pytest-image
 
 .PHONY: lint-markdown
 lint-markdown: .passwd
@@ -65,11 +74,40 @@ lint-markdown-fix: .passwd
 		$(MARKDOWNLINT_IMAGE) \
 		--fix --config .markdownlint.yaml ${MD_FILES}
 
+.PHONY: lint-python
+lint-python: .passwd
+	docker run \
+		--rm $(DOCKER_TTY_ARGS) \
+		-v ${PWD}:${PWD} \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-u $(shell id -u):$(shell id -g) \
+		$(RUFF_IMAGE) \
+		check scripts/ tests/scripts/
+
 .PHONY: lint
-lint: lint-markdown
+lint: lint-markdown lint-python
+
+.pytest-image: Dockerfile.pytest
+	docker build -t $(PYTEST_IMAGE) -f Dockerfile.pytest .
+	touch .pytest-image
+
+.PHONY: test-scripts
+test-scripts: .passwd .pytest-image
+	mkdir -p artifacts
+	docker run \
+		--rm $(DOCKER_TTY_ARGS) \
+		-v ${PWD}:${PWD} \
+		-w ${PWD} \
+		-v ${PWD}/.passwd:/etc/passwd:ro \
+		-u $(shell id -u):$(shell id -g) \
+		$(PYTEST_IMAGE) \
+		pytest tests/scripts/ \
+			--cov=scripts --cov-report=term-missing --cov-fail-under=100 \
+			--junit-xml=artifacts/test-scripts-results.xml
 
 .PHONY: test
-test: test-native
+test: test-native test-scripts
 
 .PHONY: test-native
 test-native: .passwd
@@ -89,6 +127,8 @@ build: .passwd
 	mkdir -p $(LOCAL_PIO_CACHE)
 	docker run \
 		--rm $(DOCKER_TTY_ARGS) \
+		-e CI \
+		-e USER \
 		-v ${PWD}:${PWD} \
 		-w ${PWD} \
 		-v ${PWD}/.passwd:/etc/passwd:ro \

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -27,7 +27,12 @@
 
 #include "Settings.h"
 
-#define VERSION "3.08.0-wagfam"
+#define BASE_VERSION "3.08.0-wagfam"
+#ifdef BUILD_SUFFIX
+#define VERSION BASE_VERSION BUILD_SUFFIX
+#else
+#define VERSION BASE_VERSION
+#endif
 
 #define HOSTNAME "CLOCK-"
 #define CONFIG "/conf.txt"

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,7 @@ lib_deps =
 board = d1_mini
 # Wemos D1 (mini) is function compatible with Node MCU V0.9 and V2.0 and other ESP devkits, but not pin compatible!
 # Wemos D1 mini lite is NOT compatible! (has only 1MB flash)
+extra_scripts = pre:scripts/build_version.py
 build_flags = #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
 
 [env:native_test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.pytest.ini_options]
+minversion = "8.3"
+# -v makes it easier to see what's happening on jenkins, strict-markers prevents typos
+addopts = "-vv --strict-markers"
+# Require an xfail test to actually fail.
+xfail_strict = 1
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/scripts/build_version.py
+++ b/scripts/build_version.py
@@ -1,0 +1,126 @@
+"""
+build_version.py — PlatformIO pre-build extra_script
+
+Injects a BUILD_SUFFIX C preprocessor define so the firmware's VERSION macro
+includes build provenance at compile time:
+
+  Local builds:  BASE_VERSION-<username>-<YYYYMMDD>-<hash>
+                 e.g. 3.08.0-wagfam-justin-20260426-a1b2c3d
+  CI builds:     BASE_VERSION-<hash>
+                 e.g. 3.08.0-wagfam-a1b2c3d
+
+BUILD_SUFFIX is consumed by marquee/marquee.ino via adjacent C string concatenation:
+
+    #define BASE_VERSION "3.08.0-wagfam"
+    #ifdef BUILD_SUFFIX
+    #define VERSION BASE_VERSION BUILD_SUFFIX
+    #else
+    #define VERSION BASE_VERSION   // fallback when script is not run (e.g. Arduino IDE)
+    #endif
+
+Environment variables read at build time:
+  CI              Set to any non-empty value for a CI-style suffix (hash only).
+                  GitHub Actions sets this automatically; the Makefile passes it
+                  into the Docker build container via '-e CI'.
+  USER / USERNAME Developer username for local-build suffixes.  Passed into the
+                  Docker build container via '-e USER' in the Makefile.
+
+Usage as a standalone script (for debugging or scripting):
+  python scripts/build_version.py          # print the computed suffix to stdout
+  python scripts/build_version.py --help   # show this help text
+
+PlatformIO invocation (automatic — do not call directly):
+  Declared as 'extra_scripts = pre:scripts/build_version.py' in platformio.ini.
+  PlatformIO's SConstruct runner injects Import() and the env object before
+  executing this script.
+"""
+
+import os
+import subprocess
+import sys
+from datetime import datetime
+from typing import Any
+
+__all__ = ["get_git_hash", "compute_suffix"]
+
+_HELP: str = __doc__ or ""
+
+
+def get_git_hash() -> str:
+    """Return the 7-char short git commit hash, or 'unknown' if git is unavailable."""
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return "unknown"
+
+
+def compute_suffix(
+    is_ci: bool,
+    user: str | None = None,
+    date: str | None = None,
+    git_hash: str | None = None,
+) -> str:
+    """Return the BUILD_SUFFIX string for the given build context.
+
+    Args:
+        is_ci:    True when building on CI; produces a hash-only suffix.
+        user:     Username for local builds.  Defaults to USER / USERNAME env var,
+                  then 'dev' if neither is set.
+        date:     Build date as YYYYMMDD.  Defaults to today.
+        git_hash: Short commit hash.  Defaults to the output of get_git_hash().
+
+    Returns:
+        A string beginning with '-', e.g. '-a1b2c3d' or '-justin-20260426-a1b2c3d'.
+    """
+    if git_hash is None:
+        git_hash = get_git_hash()
+    if is_ci:
+        return f"-{git_hash}"
+    if user is None:
+        user = os.environ.get("USER") or os.environ.get("USERNAME") or "dev"
+    if date is None:
+        date = datetime.now().strftime("%Y%m%d")
+    return f"-{user}-{date}-{git_hash}"
+
+
+def _pio_main(env: Any) -> None:
+    """Inject BUILD_SUFFIX into the PlatformIO / SCons build environment.
+
+    Called by the module-level bootstrap when running inside PlatformIO.
+    Not intended for direct use.
+    """
+    is_ci = bool(os.environ.get("CI"))
+    suffix = compute_suffix(is_ci=is_ci)
+    print(f"build_version: VERSION suffix = {suffix}")
+    env.Append(CPPDEFINES=[("BUILD_SUFFIX", f'\\"{suffix}\\"')])
+
+
+def _cli_main() -> None:
+    """Entry point when the script is run directly from the command line."""
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print(_HELP)
+        return
+    is_ci = bool(os.environ.get("CI"))
+    suffix = compute_suffix(is_ci=is_ci)
+    print(suffix)
+
+
+# ── PlatformIO entry point ────────────────────────────────────────────────────
+# Import() is a SCons built-in injected into the script's namespace at runtime.
+# It is not available in standard Python; the NameError is expected when this
+# module is imported outside a PlatformIO/SCons context (tests, CLI invocation).
+try:
+    Import("env")  # noqa: F821 — SCons built-in, not a standard Python name
+    _pio_main(env)  # noqa: F821 — env populated by Import() above
+except NameError:
+    pass
+
+if __name__ == "__main__":
+    _cli_main()

--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Make `scripts/build_version.py` importable as `build_version` without a package prefix.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))

--- a/tests/scripts/test_build_version.py
+++ b/tests/scripts/test_build_version.py
@@ -1,0 +1,197 @@
+"""
+Tests for scripts/build_version.py — 100% line and branch coverage.
+
+Strategy:
+  - Functions (get_git_hash, compute_suffix, _pio_main, _cli_main) are imported
+    and tested directly via the `build_version` module.
+  - Two exec-based tests cover the two module-level lines that are only reachable
+    in special runtime contexts:
+      * `_pio_main(env)` inside the try block — only reachable when Import() is
+        defined (PlatformIO/SCons context).  Tested by injecting a no-op Import
+        and a mock env into the exec namespace.
+      * `_cli_main()` inside `if __name__ == "__main__"` — only reachable when
+        the script is run directly.  Tested by exec-ing with __name__="__main__".
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import build_version
+
+ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "build_version.py"
+
+
+# ── get_git_hash ─────────────────────────────────────────────────────────────
+
+
+class TestGetGitHash:
+    def test_returns_hash_on_success(self):
+        with patch("subprocess.check_output", return_value=b"abc1234\n"):
+            assert build_version.get_git_hash() == "abc1234"
+
+    def test_returns_unknown_on_subprocess_failure(self):
+        with patch(
+            "subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            assert build_version.get_git_hash() == "unknown"
+
+
+# ── compute_suffix ────────────────────────────────────────────────────────────
+
+
+class TestComputeSuffix:
+    def test_ci_with_provided_hash(self):
+        assert build_version.compute_suffix(is_ci=True, git_hash="abc1234") == "-abc1234"
+
+    def test_ci_calls_get_git_hash_when_hash_omitted(self):
+        with patch.object(build_version, "get_git_hash", return_value="deadbee"):
+            assert build_version.compute_suffix(is_ci=True) == "-deadbee"
+
+    def test_local_all_args_provided(self):
+        result = build_version.compute_suffix(
+            is_ci=False, user="alice", date="20260101", git_hash="abc1234"
+        )
+        assert result == "-alice-20260101-abc1234"
+
+    def test_local_hash_calls_get_git_hash_when_omitted(self):
+        with patch.object(build_version, "get_git_hash", return_value="f00cafe"):
+            result = build_version.compute_suffix(is_ci=False, user="alice", date="20260101")
+        assert result == "-alice-20260101-f00cafe"
+
+    def test_local_user_from_USER_env(self, monkeypatch):
+        monkeypatch.setenv("USER", "bob")
+        monkeypatch.delenv("USERNAME", raising=False)
+        result = build_version.compute_suffix(is_ci=False, date="20260101", git_hash="abc")
+        assert result == "-bob-20260101-abc"
+
+    def test_local_user_from_USERNAME_env_when_USER_unset(self, monkeypatch):
+        monkeypatch.delenv("USER", raising=False)
+        monkeypatch.setenv("USERNAME", "carol")
+        result = build_version.compute_suffix(is_ci=False, date="20260101", git_hash="abc")
+        assert result == "-carol-20260101-abc"
+
+    def test_local_user_falls_back_to_dev(self, monkeypatch):
+        monkeypatch.delenv("USER", raising=False)
+        monkeypatch.delenv("USERNAME", raising=False)
+        result = build_version.compute_suffix(is_ci=False, date="20260101", git_hash="abc")
+        assert result == "-dev-20260101-abc"
+
+    def test_local_date_defaults_to_today(self):
+        with patch("build_version.datetime") as mock_dt:
+            mock_dt.now.return_value.strftime.return_value = "20990101"
+            result = build_version.compute_suffix(is_ci=False, user="alice", git_hash="abc")
+        assert result == "-alice-20990101-abc"
+
+
+# ── _pio_main ─────────────────────────────────────────────────────────────────
+
+
+class TestPioMain:
+    def _get_cppdefines(self, mock_env):
+        """Extract CPPDEFINES from the first env.Append call."""
+        mock_env.Append.assert_called_once()
+        return mock_env.Append.call_args.kwargs["CPPDEFINES"]
+
+    def test_ci_mode_injects_hash_only_suffix(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        mock_env = MagicMock()
+        with patch.object(build_version, "get_git_hash", return_value="abc1234"):
+            build_version._pio_main(mock_env)
+        [(key, val)] = self._get_cppdefines(mock_env)
+        assert key == "BUILD_SUFFIX"
+        assert val == '\\"-abc1234\\"'
+
+    def test_local_mode_injects_user_date_hash_suffix(self, monkeypatch):
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("USER", "tester")
+        mock_env = MagicMock()
+        with patch.object(build_version, "get_git_hash", return_value="abc1234"):
+            with patch("build_version.datetime") as mock_dt:
+                mock_dt.now.return_value.strftime.return_value = "20260101"
+                build_version._pio_main(mock_env)
+        [(key, val)] = self._get_cppdefines(mock_env)
+        assert key == "BUILD_SUFFIX"
+        assert "tester" in val
+        assert "20260101" in val
+        assert "abc1234" in val
+
+
+# ── _cli_main ─────────────────────────────────────────────────────────────────
+
+
+class TestCliMain:
+    def test_help_long_flag_prints_docstring(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["build_version.py", "--help"])
+        build_version._cli_main()
+        assert "BUILD_SUFFIX" in capsys.readouterr().out
+
+    def test_help_short_flag_prints_docstring(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["build_version.py", "-h"])
+        build_version._cli_main()
+        assert "BUILD_SUFFIX" in capsys.readouterr().out
+
+    def test_ci_mode_prints_hash_only_suffix(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["build_version.py"])
+        monkeypatch.setenv("CI", "true")
+        with patch.object(build_version, "get_git_hash", return_value="abc1234"):
+            build_version._cli_main()
+        output = capsys.readouterr().out.strip()
+        assert output == "-abc1234"
+
+    def test_local_mode_prints_user_date_hash_suffix(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["build_version.py"])
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("USER", "tester")
+        with patch.object(build_version, "get_git_hash", return_value="abc1234"):
+            with patch("build_version.datetime") as mock_dt:
+                mock_dt.now.return_value.strftime.return_value = "20260101"
+                build_version._cli_main()
+        output = capsys.readouterr().out.strip()
+        assert output == "-tester-20260101-abc1234"
+
+
+# ── Module-level bootstrap (exec-based) ──────────────────────────────────────
+
+
+class TestModuleBootstrap:
+    def _exec_script(self, globs: dict) -> None:
+        """Compile and exec build_version.py in the given globals namespace."""
+        source = SCRIPT_PATH.read_text()
+        exec(compile(source, str(SCRIPT_PATH), "exec"), globs)  # noqa: S102
+
+    def test_pio_entry_point_calls_pio_main(self, monkeypatch):
+        """The try block calls _pio_main(env) when Import() is defined (SCons context)."""
+        monkeypatch.setenv("CI", "true")
+        mock_env = MagicMock()
+        # Inject Import() as a no-op; env is pre-populated in the namespace.
+        self._exec_script(
+            {
+                "__builtins__": __builtins__,
+                "__name__": "pio_script",  # prevent __main__ block from running
+                "env": mock_env,
+                "Import": lambda _: None,
+            }
+        )
+        mock_env.Append.assert_called_once()
+        [(key, val)] = mock_env.Append.call_args.kwargs["CPPDEFINES"]
+        assert key == "BUILD_SUFFIX"
+        assert val.startswith('\\"') and val.endswith('\\"')
+
+    def test_main_block_calls_cli_main(self, monkeypatch, capsys):
+        """The if __name__ == '__main__' guard calls _cli_main() when run as a script."""
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr(sys, "argv", ["build_version.py"])
+        # No Import defined → NameError → except branch; __name__ == "__main__" → _cli_main().
+        self._exec_script(
+            {
+                "__builtins__": __builtins__,
+                "__name__": "__main__",
+            }
+        )
+        output = capsys.readouterr().out
+        suffix_lines = [ln for ln in output.splitlines() if ln.startswith("-")]
+        assert len(suffix_lines) == 1


### PR DESCRIPTION
Injects a BUILD_SUFFIX into the firmware VERSION macro at compile time so every binary is self-identifying: local builds embed username, date, and git hash (e.g. 3.08.0-wagfam-justin-20260426-a1b2c3d); CI builds embed hash only (e.g. 3.08.0-wagfam-a1b2c3d).

- scripts/build_version.py: new PlatformIO extra_script (pre:) that computes and injects BUILD_SUFFIX as a CPPDEFINE
- marquee.ino: replace hard-coded VERSION with BASE_VERSION + conditional BUILD_SUFFIX concatenation; falls back to BASE_VERSION in Arduino IDE
- platformio.ini: wire in extra_scripts = pre:scripts/build_version.py; pass CI and USER env vars from Makefile into the Docker build container
- makefile: add lint-python (ruff) and test-scripts (pytest + 100% coverage) targets; add Dockerfile.pytest and .pytest-image stamp file
- pyproject.toml: configure pytest and ruff for the scripts/ tree
- CI workflow: add Scripts Test Results reporter step