### PR TITLE
Speed up local build

### DIFF
--- a/makefile
+++ b/makefile
@@ -35,7 +35,6 @@ help:
 .PHONY: clean-pio
 clean-pio:
 	rm -rf .pio/
-	rm -rf .platformio/
 
 .PHONY: clean-passwd
 clean-passwd:


### PR DESCRIPTION
This speeds up `make ready` locally by not constantly deleting and re-downloading the platformio dependencies.