### PR TITLE
Auto-update wagfam-server firmware env vars on release

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -147,6 +147,24 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FIRMWARE_PUBLISH_PROFILE }}
           images: docker.io/jrwagz/simple-web-server:${{ env.FIRMWARE_VERSION }}
 
+      - name: Login to Azure for wagfam-server update
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_WAGFAM_SERVER_CREDENTIALS }}
+
+      - name: Notify wagfam-server of new firmware version
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: azure/cli@v2
+        with:
+          inlineScript: |
+            az webapp config appsettings set \
+              --name wagfam-server \
+              --resource-group wagfam-server-group \
+              --settings \
+                WAGFAM_FIRMWARE_VERSION="${{ env.FIRMWARE_VERSION }}" \
+                WAGFAM_FIRMWARE_URL="http://files-jrwagz.azurewebsites.net/marquee-scroller-${{ env.FIRMWARE_VERSION }}.bin"
+
       - name: Write release summary
         if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
         run: |

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -147,6 +147,23 @@ jobs:
           publish-profile: ${{ secrets.AZURE_FIRMWARE_PUBLISH_PROFILE }}
           images: docker.io/jrwagz/simple-web-server:${{ env.FIRMWARE_VERSION }}
 
+      - name: Back up wagfam-server before firmware env update
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        id: backup
+        env:
+          WAGFAM_API_KEY: ${{ secrets.WAGFAM_API_KEY }}
+        run: |
+          if curl -sf \
+               -H "Authorization: token ${WAGFAM_API_KEY}" \
+               "https://wagfam-server.azurewebsites.net/api/v1/backup" \
+               -o /tmp/backup.json; then
+            echo "has_backup=true" >> "$GITHUB_OUTPUT"
+            echo "Backup saved ($(wc -c < /tmp/backup.json) bytes)"
+          else
+            echo "has_backup=false" >> "$GITHUB_OUTPUT"
+            echo "No live server reachable — skipping backup"
+          fi
+
       - name: Login to Azure for wagfam-server update
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: azure/login@v2
@@ -164,6 +181,37 @@ jobs:
               --settings \
                 WAGFAM_FIRMWARE_VERSION="${{ env.FIRMWARE_VERSION }}" \
                 WAGFAM_FIRMWARE_URL="http://files-jrwagz.azurewebsites.net/marquee-scroller-${{ env.FIRMWARE_VERSION }}.bin"
+
+      - name: Wait for wagfam-server restart and restore backup
+        if: >-
+          github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') &&
+          steps.backup.outputs.has_backup == 'true'
+        env:
+          WAGFAM_API_KEY: ${{ secrets.WAGFAM_API_KEY }}
+        run: |
+          echo "Polling /health until server is back up (up to 5 min)..."
+          for i in $(seq 1 30); do
+            STATUS=$(curl -sf \
+                "https://wagfam-server.azurewebsites.net/health" \
+                | jq -r '.status' 2>/dev/null) || STATUS=""
+            if [ "$STATUS" = "ok" ]; then
+              echo "Server is up."
+              break
+            fi
+            echo "Attempt ${i}/30: got '${STATUS}', retrying in 10s..."
+            sleep 10
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: Server did not come back within 300s" >&2
+              exit 1
+            fi
+          done
+          echo "Restoring backup..."
+          curl -sf -X POST \
+            -H "Authorization: token ${WAGFAM_API_KEY}" \
+            -H "Content-Type: application/json" \
+            --data-binary @/tmp/backup.json \
+            "https://wagfam-server.azurewebsites.net/api/v1/backup"
+          echo "Restore complete."
 
       - name: Write release summary
         if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.08.4-wagfam"
+#define BASE_VERSION "3.08.5-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else


### PR DESCRIPTION
## Summary

- Adds two CI steps that run after every tagged firmware release: `azure/login@v2` (with a new `AZURE_WAGFAM_SERVER_CREDENTIALS` secret) then `azure/cli@v2` to call `az webapp config appsettings set` on the `wagfam-server` Azure App Service
- Sets `WAGFAM_FIRMWARE_VERSION` and `WAGFAM_FIRMWARE_URL` from the just-built `FIRMWARE_VERSION` env var, so clocks pick up the new version on their next calendar fetch and auto-update via OTA
- Bumps `BASE_VERSION` to `3.08.5-wagfam`

## One-time setup required before this works

Create a service principal scoped to the wagfam-server resource and add it as a GitHub Actions secret named `AZURE_WAGFAM_SERVER_CREDENTIALS`:

\`\`\`bash
az ad sp create-for-rbac \
  --name "marquee-scroller-ci" \
  --role contributor \
  --scopes /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/wagfam-server-group/providers/Microsoft.Web/sites/wagfam-server \
  --json-auth
\`\`\`

Also verify that `files-jrwagz` has **HTTPS Only disabled** — ESPhttpUpdate does not follow redirects, so `http://` firmware URLs must reach the server directly.

## Test plan

- [x] Add `AZURE_WAGFAM_SERVER_CREDENTIALS` secret to repo
- [x] Confirm `files-jrwagz` Azure app has HTTPS Only disabled
- [x] Push a semver tag (e.g. `v3.08.5-wagfam`) and verify both new steps go green in Actions
- [x] `curl -H "Authorization: token <key>" https://wagfam-server.azurewebsites.net/api/v1/calendar | jq '.[0].config'` shows the new `latestVersion` and `firmwareUrl`
- [x] Force a clock refresh via `POST /api/refresh` and confirm auto-OTA triggers