### PR TITLE
Fix auto-update: add firmware domain to SEC-03 allowlist (v3.08.7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,8 +359,8 @@ See `docs/CODE_REVIEW.md` for the full open-issues list. Top items by impact:
 - `isProtectedPath(path)` — prevents API writes/deletes to `/conf.txt` and `/ota_pending.txt`
 - `extractDomain(url)` — parses domain from URLs (handles scheme-less, userinfo, port, query)
 - `isTrustedFirmwareDomain(firmwareUrl, calendarUrl)` — validates OTA firmware URLs against
-  a compile-time domain allowlist (`WAGFAM_TRUSTED_FIRMWARE_DOMAINS` in `Settings.h`) plus the
-  calendar source domain
+  a compile-time domain allowlist (`WAGFAM_TRUSTED_FIRMWARE_DOMAINS` in `Settings.h`, set to
+  `"files-jrwagz.azurewebsites.net"` via `platformio.ini` build flags) plus the calendar source domain
 - `isInTrustedDomainList(domain, list)` — checks domain membership in comma-separated allowlist
 
 These are tested in `tests/native/test_security_helpers/`.

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.08.6-wagfam"
+#define BASE_VERSION "3.08.7-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,7 +31,9 @@ board = d1_mini
 # Wemos D1 (mini) is function compatible with Node MCU V0.9 and V2.0 and other ESP devkits, but not pin compatible!
 # Wemos D1 mini lite is NOT compatible! (has only 1MB flash)
 extra_scripts = pre:scripts/build_version.py
-build_flags = #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
+build_flags =
+  #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
+  '-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'
 
 [env:native_test]
 platform = native


### PR DESCRIPTION
## Problem

Auto-updates have been silently blocked on all deployed clocks. The SEC-03
domain trust check (`isTrustedFirmwareDomain`) requires the firmware URL's
domain to either appear in the compile-time `WAGFAM_TRUSTED_FIRMWARE_DOMAINS`
allowlist, or match the calendar URL's domain. Neither condition was met:

| | Domain |
|--|--|
| Calendar URL | `wagfam-server.azurewebsites.net` |
| Firmware URL | `files-jrwagz.azurewebsites.net` |
| `WAGFAM_TRUSTED_FIRMWARE_DOMAINS` (before this fix) | `""` (empty) |

On every refresh cycle after the 5-minute uptime guard passes, the device logs:
```
[SEC] Rejected firmware URL — domain not allowlisted and does not match calendar source
```
and skips the update. Confirmed live against a device running v3.08.1 that the
wagfam-server is advertising v3.08.6 — the update never fires.

## Fix

- **`platformio.ini`**: adds `'-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'`
  to `build_flags` so the production firmware host is trusted at compile time.
- **`marquee/marquee.ino`**: bumps `BASE_VERSION` to `3.08.7-wagfam`.
- **`CLAUDE.md`**: documents the configured allowlist value.

## Migration note

Devices running v3.08.6 or earlier cannot self-update to this fix (that is the
bug). One-time manual OTA required to bootstrap once v3.08.7 is released:

```bash
curl -u admin:<password> \
  "http://<device-ip>/updateFromUrl?firmwareUrl=http://files-jrwagz.azurewebsites.net/marquee-scroller-<v3.08.7-hash>.bin"
```

After that, all future auto-updates will work without intervention.

## Test plan

- [x] CI build passes (native tests, lint, firmware compile)
- [x] Verify tagged release sets `WAGFAM_FIRMWARE_VERSION=3.08.7-wagfam-<hash>` on wagfam-server
- [x] Flash v3.08.7 manually to a test device; confirm next calendar fetch triggers auto-update
  to a hypothetical v3.08.8 by checking serial for `[OTA] Server version:` log (not the
  `[SEC] Rejected` log)