### PR TITLE
Bump version to 3.09.0-wagfam

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.08.8-wagfam"
+#define BASE_VERSION "3.09.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else


### PR DESCRIPTION
Bumps minor version and resets patch to 0: `3.08.8-wagfam` → `3.09.0-wagfam`.