### PR TITLE
Send &utc_offset_sec= on calendar requests (wagfam-server PR #16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,18 +308,21 @@ Expected JSON format:
 Each calendar fetch includes device telemetry as query parameters:
 
 ```text
-GET /data_source.json?chip_id=5fc8ad&version=3.08.0-wagfam&uptime=1234567&heap=32496&rssi=-62&timezone=America/Chicago
+GET /data_source.json?chip_id=5fc8ad&version=3.08.0-wagfam&uptime=1234567&heap=32496&rssi=-62&utc_offset_sec=-21600
 ```
 
-The `timezone` param (IANA name, e.g. `America/Chicago`) is omitted when the setting is blank.
-The wagfam server uses it to compute the client's local "today" so event ordering is correct
-for the clock's location (see [wagfam-server PR #16](https://github.com/jrwagz/wagfam-server/pull/16)).
+The `utc_offset_sec` param is the UTC offset in seconds derived from the OWM weather response
+(e.g. `-21600` for UTC-6 / Central Standard Time). It is always included; when OWM has not yet
+returned data, it defaults to 0 (UTC). The wagfam server uses it to compute the client's local
+"today" so event ordering is correct for the clock's location
+(see [wagfam-server PR #16](https://github.com/jrwagz/wagfam-server/pull/16)).
 
 This lets a backend identify and monitor all deployed clocks without any additional
 connections. Static JSON hosts ignore the current set of params gracefully — this
 was empirically verified during PR #25 review with identical sha256 + HTTP 200 across
-all 5 current param names against `raw.githubusercontent.com` (see commit `bca26e6`
+the original 5 param names against `raw.githubusercontent.com` (see commit `bca26e6`
 and the [review thread](https://github.com/jrwagz/marquee-scroller/pull/25#discussion_r3144204226)).
+`utc_offset_sec` was added later and has not been re-verified against static hosts.
 
 **Caveat from that verification:** `raw.githubusercontent.com` *does* interpret
 `?token=…` as an auth attempt, returning HTTP 404 on a private repo when a bad

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,8 +308,12 @@ Expected JSON format:
 Each calendar fetch includes device telemetry as query parameters:
 
 ```text
-GET /data_source.json?chip_id=5fc8ad&version=3.08.0-wagfam&uptime=1234567&heap=32496&rssi=-62
+GET /data_source.json?chip_id=5fc8ad&version=3.08.0-wagfam&uptime=1234567&heap=32496&rssi=-62&timezone=America/Chicago
 ```
+
+The `timezone` param (IANA name, e.g. `America/Chicago`) is omitted when the setting is blank.
+The wagfam server uses it to compute the client's local "today" so event ordering is correct
+for the clock's location (see [wagfam-server PR #16](https://github.com/jrwagz/wagfam-server/pull/16)).
 
 This lets a backend identify and monitor all deployed clocks without any additional
 connections. Static JSON hosts ignore the current set of params gracefully — this

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
 ### Device Heartbeat
 
 Each calendar fetch includes device telemetry as URL query parameters (`chip_id`, `version`,
-`uptime`, `heap`, `rssi`, and `timezone` when configured). A backend can use these to identify
-and monitor all deployed clocks. Static JSON hosts ignore the query params.
+`uptime`, `heap`, `rssi`, and `utc_offset_sec`). The UTC offset in seconds is derived
+automatically from the OpenWeatherMap response — no extra configuration needed. A backend
+can use these to identify and monitor all deployed clocks. Static JSON hosts ignore the query
+params.
 
 ### Geo Location
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
 ### Device Heartbeat
 
 Each calendar fetch includes device telemetry as URL query parameters (`chip_id`, `version`,
-`uptime`, `heap`, `rssi`). A backend can use these to identify and monitor all deployed clocks.
-Static JSON hosts ignore the query params.
+`uptime`, `heap`, `rssi`, and `timezone` when configured). A backend can use these to identify
+and monitor all deployed clocks. Static JSON hosts ignore the query params.
 
 ### Geo Location
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,7 +308,7 @@ getWeatherData()
 │   └── Returns adjusted Unix time
 ├── setTime(t)                             → Updates TimeLib clock
 ├── bdayClient.updateData(devInfo)          → HTTPS GET to WAGFAM_DATA_URL
-│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi= (heartbeat)
+│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi=[&timezone=] (heartbeat)
 │   └── Streams JSON through parser
 │   └── Fills messages[0..9]
 │   └── Returns configValues (remote config)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -308,7 +308,7 @@ getWeatherData()
 │   └── Returns adjusted Unix time
 ├── setTime(t)                             → Updates TimeLib clock
 ├── bdayClient.updateData(devInfo)          → HTTPS GET to WAGFAM_DATA_URL
-│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi=[&timezone=] (heartbeat)
+│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi=&utc_offset_sec= (heartbeat)
 │   └── Streams JSON through parser
 │   └── Fills messages[0..9]
 │   └── Returns configValues (remote config)

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -60,7 +60,6 @@ SOFTWARE.
 
 String WAGFAM_DATA_URL = ""; // URL to Pull WagFam Calendar Data from
 String WAGFAM_API_KEY = ""; // Authorization token to use to authenticate to access the DATA_URL, only used if provided
-String WAGFAM_TIMEZONE = ""; // IANA timezone name sent as &timezone= on calendar requests (e.g. "America/Chicago")
 boolean WAGFAM_EVENT_TODAY = false; // Whether or not an event is happening today
 
 // SEC-03: Compile-time allowlist of domains that are *always* trusted as firmware

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -60,6 +60,7 @@ SOFTWARE.
 
 String WAGFAM_DATA_URL = ""; // URL to Pull WagFam Calendar Data from
 String WAGFAM_API_KEY = ""; // Authorization token to use to authenticate to access the DATA_URL, only used if provided
+String WAGFAM_TIMEZONE = ""; // IANA timezone name sent as &timezone= on calendar requests (e.g. "America/Chicago")
 boolean WAGFAM_EVENT_TODAY = false; // Whether or not an event is happening today
 
 // SEC-03: Compile-time allowlist of domains that are *always* trusted as firmware

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -63,10 +63,8 @@ WagFamBdayClient::configValues WagFamBdayClient::updateData(const DeviceInfo& de
   url += String(device.freeHeap);
   url += "&rssi=";
   url += String(device.rssi);
-  if (device.timezone.length() > 0) {
-    url += "&timezone=";
-    url += device.timezone;
-  }
+  url += "&utc_offset_sec=";
+  url += String(device.utcOffsetSec);
 
   Serial.println("Getting Birthdays Data");
   Serial.println(F("[calendar URL redacted]"));

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -50,7 +50,7 @@ WagFamBdayClient::configValues WagFamBdayClient::updateData(const DeviceInfo& de
 
   // Build URL with device telemetry query params for heartbeat/identification
   String url;
-  url.reserve(myJsonSourceUrl.length() + 120);
+  url.reserve(myJsonSourceUrl.length() + 180);
   url = myJsonSourceUrl;
   url += (url.indexOf('?') >= 0) ? '&' : '?';
   url += "chip_id=";
@@ -63,6 +63,10 @@ WagFamBdayClient::configValues WagFamBdayClient::updateData(const DeviceInfo& de
   url += String(device.freeHeap);
   url += "&rssi=";
   url += String(device.rssi);
+  if (device.timezone.length() > 0) {
+    url += "&timezone=";
+    url += device.timezone;
+  }
 
   Serial.println("Getting Birthdays Data");
   Serial.println(F("[calendar URL redacted]"));

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -34,6 +34,7 @@ struct DeviceInfo {
     uint32_t uptimeMs;
     uint32_t freeHeap;
     int32_t rssi;
+    String timezone; // IANA name (e.g. "America/Chicago"); omitted from URL when empty
 };
 
 class WagFamBdayClient: public JsonListener {

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -34,7 +34,7 @@ struct DeviceInfo {
     uint32_t uptimeMs;
     uint32_t freeHeap;
     int32_t rssi;
-    String timezone; // IANA name (e.g. "America/Chicago"); omitted from URL when empty
+    int32_t utcOffsetSec; // UTC offset in seconds from OWM (e.g. -21600 for UTC-6)
 };
 
 class WagFamBdayClient: public JsonListener {

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.09.0-wagfam"
+#define BASE_VERSION "3.09.1-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -150,6 +150,8 @@ static const char CHANGE_FORM1[] PROGMEM = "<form class='w3-container' action='/
                       "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamDataSource' value='%WAGFAMDATASOURCE%' maxlength='256'>"
                       "<label>WagFam Calendar API Key</label>"
                       "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamApiKey' value='%WAGFAMAPIKEY%' maxlength='128'>"
+                      "<label>Timezone (IANA, e.g. America/Chicago)</label>"
+                      "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamTimezone' value='%WAGFAMTIMEZONE%' maxlength='64'>"
                       "<hr>";
 
 static const char CHANGE_FORM2[] PROGMEM = "<label>OpenWeatherMap API Key (get from <a href='https://openweathermap.org/' target='_BLANK'>here</a>)</label>"
@@ -582,6 +584,7 @@ void handleSaveConfig(AsyncWebServerRequest *request) {
   if (newPw.length() > 0) webPassword = newPw;
   WAGFAM_DATA_URL = request->arg("wagFamDataSource");
   WAGFAM_API_KEY = request->arg("wagFamApiKey");
+  WAGFAM_TIMEZONE = request->arg("wagFamTimezone");
   bdayClient.updateBdayClient(WAGFAM_API_KEY,WAGFAM_DATA_URL);
   APIKEY = request->arg("openWeatherMapApiKey");
   geoLocation = request->arg("city1");
@@ -641,6 +644,7 @@ void handleConfigure(AsyncWebServerRequest *request) {
   form.replace("%WEBPASSWORD%", webPassword);
   form.replace("%WAGFAMDATASOURCE%", WAGFAM_DATA_URL);
   form.replace("%WAGFAMAPIKEY%", WAGFAM_API_KEY);
+  form.replace("%WAGFAMTIMEZONE%", WAGFAM_TIMEZONE);
   response->print(form);
 
 
@@ -931,6 +935,7 @@ void getWeatherData() //client function to send/receive GET request data.
   devInfo.uptimeMs = millis();
   devInfo.freeHeap = ESP.getFreeHeap();
   devInfo.rssi = WiFi.RSSI();
+  devInfo.timezone = WAGFAM_TIMEZONE;
   serverConfig = bdayClient.updateData(devInfo);
   bool needToSave = false;
   // SEC-12: Validate server-pushed dataSourceUrl must use HTTPS
@@ -1180,6 +1185,7 @@ void savePersistentConfig() {
     Serial.println("Saving settings now...");
     f.println("WAGFAM_DATA_URL=" + WAGFAM_DATA_URL);
     f.println("WAGFAM_API_KEY=" + WAGFAM_API_KEY);
+    f.println("WAGFAM_TIMEZONE=" + WAGFAM_TIMEZONE);
     f.println("WAGFAM_EVENT_TODAY=" + String(WAGFAM_EVENT_TODAY));
     f.println("APIKEY=" + APIKEY);
     f.println("CityID=" + geoLocation);
@@ -1233,6 +1239,9 @@ void readPersistentConfig() {
     } else if (key == "WAGFAM_API_KEY") {
       WAGFAM_API_KEY = value;
       Serial.println("WAGFAM_API_KEY: [set]");
+    } else if (key == "WAGFAM_TIMEZONE") {
+      WAGFAM_TIMEZONE = value;
+      Serial.println("WAGFAM_TIMEZONE: " + WAGFAM_TIMEZONE);
     } else if (key == "WAGFAM_EVENT_TODAY") {
       WAGFAM_EVENT_TODAY = value.toInt();
       Serial.println("WAGFAM_EVENT_TODAY: " + String(WAGFAM_EVENT_TODAY));
@@ -1472,6 +1481,7 @@ void handleApiConfigGet(AsyncWebServerRequest *request) {
   JsonDocument doc;
   doc["wagfam_data_url"] = WAGFAM_DATA_URL;
   doc["wagfam_api_key"] = WAGFAM_API_KEY;
+  doc["wagfam_timezone"] = WAGFAM_TIMEZONE;
   doc["wagfam_event_today"] = WAGFAM_EVENT_TODAY;
   doc["owm_api_key"] = APIKEY;
   doc["geo_location"] = geoLocation;
@@ -1508,6 +1518,7 @@ void handleApiConfigPost(AsyncWebServerRequest *request, JsonVariant &json) {
   // Partial update: only set fields that are present in the request body
   if (json["wagfam_data_url"].is<const char*>()) WAGFAM_DATA_URL = json["wagfam_data_url"].as<String>();
   if (json["wagfam_api_key"].is<const char*>()) WAGFAM_API_KEY = json["wagfam_api_key"].as<String>();
+  if (json["wagfam_timezone"].is<const char*>()) WAGFAM_TIMEZONE = json["wagfam_timezone"].as<String>();
   if (json["wagfam_event_today"].is<bool>()) WAGFAM_EVENT_TODAY = json["wagfam_event_today"].as<bool>();
   if (json["owm_api_key"].is<const char*>()) APIKEY = json["owm_api_key"].as<String>();
   if (json["geo_location"].is<const char*>()) geoLocation = json["geo_location"].as<String>();

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -150,8 +150,6 @@ static const char CHANGE_FORM1[] PROGMEM = "<form class='w3-container' action='/
                       "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamDataSource' value='%WAGFAMDATASOURCE%' maxlength='256'>"
                       "<label>WagFam Calendar API Key</label>"
                       "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamApiKey' value='%WAGFAMAPIKEY%' maxlength='128'>"
-                      "<label>Timezone (IANA, e.g. America/Chicago)</label>"
-                      "<input class='w3-input w3-border w3-margin-bottom' type='text' name='wagFamTimezone' value='%WAGFAMTIMEZONE%' maxlength='64'>"
                       "<hr>";
 
 static const char CHANGE_FORM2[] PROGMEM = "<label>OpenWeatherMap API Key (get from <a href='https://openweathermap.org/' target='_BLANK'>here</a>)</label>"
@@ -584,7 +582,6 @@ void handleSaveConfig(AsyncWebServerRequest *request) {
   if (newPw.length() > 0) webPassword = newPw;
   WAGFAM_DATA_URL = request->arg("wagFamDataSource");
   WAGFAM_API_KEY = request->arg("wagFamApiKey");
-  WAGFAM_TIMEZONE = request->arg("wagFamTimezone");
   bdayClient.updateBdayClient(WAGFAM_API_KEY,WAGFAM_DATA_URL);
   APIKEY = request->arg("openWeatherMapApiKey");
   geoLocation = request->arg("city1");
@@ -644,7 +641,6 @@ void handleConfigure(AsyncWebServerRequest *request) {
   form.replace("%WEBPASSWORD%", webPassword);
   form.replace("%WAGFAMDATASOURCE%", WAGFAM_DATA_URL);
   form.replace("%WAGFAMAPIKEY%", WAGFAM_API_KEY);
-  form.replace("%WAGFAMTIMEZONE%", WAGFAM_TIMEZONE);
   response->print(form);
 
 
@@ -935,7 +931,7 @@ void getWeatherData() //client function to send/receive GET request data.
   devInfo.uptimeMs = millis();
   devInfo.freeHeap = ESP.getFreeHeap();
   devInfo.rssi = WiFi.RSSI();
-  devInfo.timezone = WAGFAM_TIMEZONE;
+  devInfo.utcOffsetSec = weatherClient.getTimeZoneSeconds();
   serverConfig = bdayClient.updateData(devInfo);
   bool needToSave = false;
   // SEC-12: Validate server-pushed dataSourceUrl must use HTTPS
@@ -1185,7 +1181,6 @@ void savePersistentConfig() {
     Serial.println("Saving settings now...");
     f.println("WAGFAM_DATA_URL=" + WAGFAM_DATA_URL);
     f.println("WAGFAM_API_KEY=" + WAGFAM_API_KEY);
-    f.println("WAGFAM_TIMEZONE=" + WAGFAM_TIMEZONE);
     f.println("WAGFAM_EVENT_TODAY=" + String(WAGFAM_EVENT_TODAY));
     f.println("APIKEY=" + APIKEY);
     f.println("CityID=" + geoLocation);
@@ -1239,9 +1234,6 @@ void readPersistentConfig() {
     } else if (key == "WAGFAM_API_KEY") {
       WAGFAM_API_KEY = value;
       Serial.println("WAGFAM_API_KEY: [set]");
-    } else if (key == "WAGFAM_TIMEZONE") {
-      WAGFAM_TIMEZONE = value;
-      Serial.println("WAGFAM_TIMEZONE: " + WAGFAM_TIMEZONE);
     } else if (key == "WAGFAM_EVENT_TODAY") {
       WAGFAM_EVENT_TODAY = value.toInt();
       Serial.println("WAGFAM_EVENT_TODAY: " + String(WAGFAM_EVENT_TODAY));
@@ -1481,7 +1473,6 @@ void handleApiConfigGet(AsyncWebServerRequest *request) {
   JsonDocument doc;
   doc["wagfam_data_url"] = WAGFAM_DATA_URL;
   doc["wagfam_api_key"] = WAGFAM_API_KEY;
-  doc["wagfam_timezone"] = WAGFAM_TIMEZONE;
   doc["wagfam_event_today"] = WAGFAM_EVENT_TODAY;
   doc["owm_api_key"] = APIKEY;
   doc["geo_location"] = geoLocation;
@@ -1518,7 +1509,6 @@ void handleApiConfigPost(AsyncWebServerRequest *request, JsonVariant &json) {
   // Partial update: only set fields that are present in the request body
   if (json["wagfam_data_url"].is<const char*>()) WAGFAM_DATA_URL = json["wagfam_data_url"].as<String>();
   if (json["wagfam_api_key"].is<const char*>()) WAGFAM_API_KEY = json["wagfam_api_key"].as<String>();
-  if (json["wagfam_timezone"].is<const char*>()) WAGFAM_TIMEZONE = json["wagfam_timezone"].as<String>();
   if (json["wagfam_event_today"].is<bool>()) WAGFAM_EVENT_TODAY = json["wagfam_event_today"].as<bool>();
   if (json["owm_api_key"].is<const char*>()) APIKEY = json["owm_api_key"].as<String>();
   if (json["geo_location"].is<const char*>()) geoLocation = json["geo_location"].as<String>();


### PR DESCRIPTION
## Summary

- Sends `&utc_offset_sec=<N>` on every calendar fetch, where `<N>` is the UTC
  offset in seconds (e.g. `-21600` for UTC-6). This matches the updated server
  implementation in [wagfam-server PR #16](https://github.com/jrwagz/wagfam-server/pull/16).
- The value is derived automatically from the OpenWeatherMap response
  (`weatherClient.getTimeZoneSeconds()`), which is already fetched earlier in
  the same `getWeatherData()` call — **no new user-visible config parameter needed**.
- Replaces the earlier approach (IANA timezone string in a new `WAGFAM_TIMEZONE`
  setting) with the integer-seconds approach preferred by the server PR.
- Bumps version to `3.09.1-wagfam`.

## How it works

`getWeatherData()` already calls `weatherClient.updateWeather()` before building
`DeviceInfo`, so `getTimeZoneSeconds()` has the current OWM-provided offset (including
DST, since OWM reflects the actual current offset) by the time the calendar request
is made. On first boot or OWM failure the offset defaults to 0 (UTC), which matches
the server's fallback behavior when the param is absent.

## Files changed

| File | Change |
| --- | --- |
| `WagFamBdayClient.h` | `DeviceInfo.timezone` (String) → `utcOffsetSec` (int32_t) |
| `WagFamBdayClient.cpp` | Appends `&utc_offset_sec=<N>` unconditionally |
| `marquee.ino` | Sets `devInfo.utcOffsetSec = weatherClient.getTimeZoneSeconds()`; bumps version to 3.09.1-wagfam |
| `Settings.h` | Removes `WAGFAM_TIMEZONE` (no longer needed) |
| `CLAUDE.md` / `README.md` / `docs/ARCHITECTURE.md` | Updated heartbeat docs |

## Test plan

- [x] Build succeeds (`pio run`)
- [x] Native unit tests pass (`pio test -e native`)
- [x] Calendar request URL in serial log contains `&utc_offset_sec=-21600` (or
  correct local offset) after a successful OWM fetch
- [x] Server PR #16 (`wagfam-server`) accepts the integer param and returns
  correctly ordered events for the clock's local date