### PR TITLE
WebUI MVP: Status dashboard, Settings form, Actions page

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.09.1-wagfam"
+#define BASE_VERSION "3.09.2-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -1,0 +1,42 @@
+import type { StatusData, ConfigData } from "./types";
+
+const POST_HEADERS = {
+  "Content-Type": "application/json",
+  "X-Requested-With": "XMLHttpRequest",
+} as const;
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init);
+  if (!res.ok) {
+    const body = await res.text().catch(() => res.statusText);
+    throw new Error(`${res.status} ${res.statusText}: ${body}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+export const getStatus = (): Promise<StatusData> =>
+  apiFetch<StatusData>("/api/status");
+
+export const getConfig = (): Promise<ConfigData> =>
+  apiFetch<ConfigData>("/api/config");
+
+export const patchConfig = (
+  patch: Partial<ConfigData>,
+): Promise<{ status: string }> =>
+  apiFetch<{ status: string }>("/api/config", {
+    method: "POST",
+    headers: POST_HEADERS,
+    body: JSON.stringify(patch),
+  });
+
+export const postRefresh = (): Promise<{ status: string }> =>
+  apiFetch<{ status: string }>("/api/refresh", {
+    method: "POST",
+    headers: POST_HEADERS,
+  });
+
+export const postRestart = (): Promise<{ status: string }> =>
+  apiFetch<{ status: string }>("/api/restart", {
+    method: "POST",
+    headers: POST_HEADERS,
+  });

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -1,15 +1,38 @@
-// Empty SPA shell. Real pages land in subsequent PRs — this one just proves
-// the asset pipeline (LittleFS upload, gzip serving, Vite/Preact toolchain).
+import { signal } from "@preact/signals";
+import { StatusPage } from "./pages/StatusPage";
+import { SettingsPage } from "./pages/SettingsPage";
+import { ActionsPage } from "./pages/ActionsPage";
+
+type Tab = "status" | "settings" | "actions";
+
+const activeTab = signal<Tab>("status");
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "status", label: "Status" },
+  { id: "settings", label: "Settings" },
+  { id: "actions", label: "Actions" },
+];
+
 export function App() {
   return (
     <main class="container">
       <h1>WagFam CalClock</h1>
-      <p>SPA shell loaded. Pages coming soon.</p>
-      <p class="muted">
-        For now, the legacy UI lives at{" "}
-        <a href="/">/</a> and{" "}
-        <a href="/configure">/configure</a>.
-      </p>
+      <nav class="tab-bar">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            class={`tab${activeTab.value === t.id ? " active" : ""}`}
+            onClick={() => {
+              activeTab.value = t.id;
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+      {activeTab.value === "status" && <StatusPage />}
+      {activeTab.value === "settings" && <SettingsPage />}
+      {activeTab.value === "actions" && <ActionsPage />}
     </main>
   );
 }

--- a/webui/src/pages/ActionsPage.tsx
+++ b/webui/src/pages/ActionsPage.tsx
@@ -1,0 +1,114 @@
+import { signal } from "@preact/signals";
+import { postRefresh, postRestart } from "../api";
+
+type ActionState = "idle" | "loading" | "ok" | "error";
+
+const refreshState = signal<ActionState>("idle");
+const refreshMsg = signal("");
+const restartState = signal<ActionState>("idle");
+const restartCountdown = signal(0);
+
+async function doRefresh() {
+  refreshState.value = "loading";
+  refreshMsg.value = "";
+  try {
+    await postRefresh();
+    refreshState.value = "ok";
+    refreshMsg.value = "Refresh queued — data will update shortly.";
+    setTimeout(() => {
+      refreshState.value = "idle";
+      refreshMsg.value = "";
+    }, 4000);
+  } catch (e) {
+    refreshState.value = "error";
+    refreshMsg.value = String(e);
+    setTimeout(() => {
+      refreshState.value = "idle";
+    }, 5000);
+  }
+}
+
+async function doRestart() {
+  restartState.value = "loading";
+  try {
+    await postRestart();
+    restartState.value = "ok";
+    restartCountdown.value = 10;
+    const t = setInterval(() => {
+      restartCountdown.value -= 1;
+      if (restartCountdown.value <= 0) {
+        clearInterval(t);
+        restartState.value = "idle";
+      }
+    }, 1000);
+  } catch (e) {
+    restartState.value = "error";
+    setTimeout(() => {
+      restartState.value = "idle";
+    }, 5000);
+  }
+}
+
+export function ActionsPage() {
+  return (
+    <div>
+      <div class="action-card">
+        <div class="action-info">
+          <strong>Force Refresh</strong>
+          <p>Pull fresh weather and calendar data immediately.</p>
+        </div>
+        <div class="action-controls">
+          <button
+            class="btn"
+            disabled={refreshState.value === "loading"}
+            onClick={doRefresh}
+          >
+            {refreshState.value === "loading" ? (
+              <><span class="spinner" /> Refreshing…</>
+            ) : (
+              "Refresh Now"
+            )}
+          </button>
+          {refreshState.value === "ok" && (
+            <span class="save-ok">{refreshMsg.value}</span>
+          )}
+          {refreshState.value === "error" && (
+            <span class="error-msg">{refreshMsg.value}</span>
+          )}
+        </div>
+      </div>
+
+      <div class="action-card">
+        <div class="action-info">
+          <strong>Restart Device</strong>
+          <p>Reboot the clock. It will reconnect to WiFi automatically.</p>
+        </div>
+        <div class="action-controls">
+          {restartState.value === "idle" && (
+            <button class="btn btn-danger" onClick={doRestart}>
+              Restart
+            </button>
+          )}
+          {restartState.value === "loading" && (
+            <button class="btn btn-danger" disabled>
+              <span class="spinner" /> Sending…
+            </button>
+          )}
+          {restartState.value === "ok" && (
+            <span class="muted">
+              Restarting… reconnect in ~{restartCountdown.value} s
+            </span>
+          )}
+          {restartState.value === "error" && (
+            <span class="error-msg">Restart failed — check device connection.</span>
+          )}
+        </div>
+      </div>
+
+      <p class="muted" style={{ marginTop: "1.5rem", fontSize: "0.8rem" }}>
+        Legacy web interface:{" "}
+        <a href="/">Home</a> · <a href="/configure">Configure</a>
+      </p>
+    </div>
+  );
+}

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -1,0 +1,292 @@
+import { useEffect } from "preact/hooks";
+import { signal, computed } from "@preact/signals";
+import { getConfig, patchConfig } from "../api";
+import type { ConfigData } from "../types";
+
+type BoolKey = Extract<
+  keyof ConfigData,
+  | "is_24hour"
+  | "is_pm"
+  | "is_metric"
+  | "show_date"
+  | "show_city"
+  | "show_condition"
+  | "show_humidity"
+  | "show_wind"
+  | "show_pressure"
+  | "show_highlow"
+>;
+
+const DEFAULTS: ConfigData = {
+  wagfam_data_url: "",
+  wagfam_api_key: "",
+  wagfam_event_today: false,
+  owm_api_key: "",
+  geo_location: "",
+  is_24hour: false,
+  is_pm: true,
+  is_metric: false,
+  display_intensity: 4,
+  display_scroll_speed: 25,
+  minutes_between_data_refresh: 15,
+  minutes_between_scrolling: 1,
+  show_date: false,
+  show_city: true,
+  show_condition: false,
+  show_humidity: false,
+  show_wind: false,
+  show_pressure: false,
+  show_highlow: false,
+  ota_safe_url: "",
+  device_name: "",
+  web_password: "",
+};
+
+const config = signal<ConfigData | null>(null);
+const draft = signal<Partial<ConfigData>>({});
+const loadError = signal<string | null>(null);
+const saveStatus = signal<"idle" | "saving" | "ok" | "error">("idle");
+const saveError = signal<string | null>(null);
+
+const effective = computed<ConfigData>(() => ({
+  ...DEFAULTS,
+  ...config.value,
+  ...draft.value,
+}));
+
+const isDirty = computed(() => Object.keys(draft.value).length > 0);
+
+function setVal<K extends keyof ConfigData>(key: K, val: ConfigData[K]) {
+  if (config.value?.[key] === val) {
+    const d = { ...draft.value };
+    delete d[key];
+    draft.value = d;
+  } else {
+    draft.value = { ...draft.value, [key]: val };
+  }
+}
+
+function setBool(key: BoolKey, val: boolean) {
+  setVal(key, val);
+}
+
+async function save() {
+  saveStatus.value = "saving";
+  saveError.value = null;
+  try {
+    await patchConfig(draft.value);
+    config.value = { ...effective.value };
+    draft.value = {};
+    saveStatus.value = "ok";
+    setTimeout(() => {
+      saveStatus.value = "idle";
+    }, 3000);
+  } catch (e) {
+    saveError.value = String(e);
+    saveStatus.value = "error";
+  }
+}
+
+export function SettingsPage() {
+  useEffect(() => {
+    getConfig()
+      .then((data) => {
+        config.value = data;
+        draft.value = {};
+        loadError.value = null;
+      })
+      .catch((e: unknown) => {
+        loadError.value = String(e);
+      });
+  }, []);
+
+  const cfg = effective.value;
+  const saving = saveStatus.value === "saving";
+
+  if (!config.value && !loadError.value) {
+    return <p class="muted">Loading…</p>;
+  }
+  if (loadError.value) {
+    return <p class="error-msg">{loadError.value}</p>;
+  }
+
+  return (
+    <div>
+      <div class="form-section">
+        <h2>Display</h2>
+
+        <div class="form-row">
+          <label class="form-label" for="intensity">
+            Brightness
+          </label>
+          <div class="slider-group">
+            <input
+              id="intensity"
+              type="range"
+              min="0"
+              max="15"
+              value={cfg.display_intensity}
+              onInput={(e) =>
+                setVal(
+                  "display_intensity",
+                  +(e.target as HTMLInputElement).value,
+                )
+              }
+            />
+            <span class="slider-val">{cfg.display_intensity}</span>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <label class="form-label" for="speed">
+            Scroll speed
+          </label>
+          <div class="slider-group">
+            <input
+              id="speed"
+              type="range"
+              min="5"
+              max="100"
+              value={cfg.display_scroll_speed}
+              onInput={(e) =>
+                setVal(
+                  "display_scroll_speed",
+                  +(e.target as HTMLInputElement).value,
+                )
+              }
+            />
+            <span class="slider-val">{cfg.display_scroll_speed} ms</span>
+          </div>
+        </div>
+
+        <ToggleRow
+          id="24h"
+          label="24-hour clock"
+          checked={cfg.is_24hour}
+          onChange={(v) => setBool("is_24hour", v)}
+        />
+        <ToggleRow
+          id="metric"
+          label="Metric units (°C / km/h)"
+          checked={cfg.is_metric}
+          onChange={(v) => setBool("is_metric", v)}
+        />
+      </div>
+
+      <div class="form-section">
+        <h2>Refresh</h2>
+
+        <div class="form-row">
+          <label class="form-label" for="data-interval">
+            Data interval
+          </label>
+          <div class="num-group">
+            <input
+              id="data-interval"
+              type="number"
+              min="1"
+              max="60"
+              value={cfg.minutes_between_data_refresh}
+              onInput={(e) =>
+                setVal(
+                  "minutes_between_data_refresh",
+                  Math.max(1, +(e.target as HTMLInputElement).value),
+                )
+              }
+            />
+            <span class="form-note">min</span>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <label class="form-label" for="scroll-interval">
+            Scroll interval
+          </label>
+          <div class="num-group">
+            <input
+              id="scroll-interval"
+              type="number"
+              min="1"
+              max="10"
+              value={cfg.minutes_between_scrolling}
+              onInput={(e) =>
+                setVal(
+                  "minutes_between_scrolling",
+                  Math.max(1, +(e.target as HTMLInputElement).value),
+                )
+              }
+            />
+            <span class="form-note">min</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-section">
+        <h2>Weather items</h2>
+        {(
+          [
+            { key: "show_date", label: "Date" },
+            { key: "show_city", label: "City" },
+            { key: "show_condition", label: "Condition" },
+            { key: "show_humidity", label: "Humidity" },
+            { key: "show_wind", label: "Wind" },
+            { key: "show_pressure", label: "Pressure" },
+            { key: "show_highlow", label: "High / Low" },
+          ] as { key: BoolKey; label: string }[]
+        ).map(({ key, label }) => (
+          <ToggleRow
+            key={key}
+            id={key}
+            label={label}
+            checked={cfg[key]}
+            onChange={(v) => setBool(key, v)}
+          />
+        ))}
+      </div>
+
+      <div class="save-bar">
+        <button
+          class="btn"
+          disabled={!isDirty.value || saving}
+          onClick={save}
+        >
+          {saving ? <><span class="spinner" /> Saving…</> : "Save"}
+        </button>
+        {saveStatus.value === "ok" && (
+          <span class="save-ok">Saved!</span>
+        )}
+        {saveStatus.value === "error" && (
+          <span class="error-msg">{saveError.value}</span>
+        )}
+        {isDirty.value && saveStatus.value === "idle" && (
+          <span class="muted">{Object.keys(draft.value).length} change{Object.keys(draft.value).length !== 1 ? "s" : ""} unsaved</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ToggleRow({
+  id,
+  label,
+  checked,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label class="form-row toggle-row" for={id}>
+      <span class="form-label">{label}</span>
+      <input
+        id={id}
+        type="checkbox"
+        class="toggle"
+        checked={checked}
+        onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+      />
+    </label>
+  );
+}

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -1,0 +1,119 @@
+import { useEffect } from "preact/hooks";
+import { signal, computed } from "@preact/signals";
+import { getStatus } from "../api";
+import type { StatusData } from "../types";
+
+const status = signal<StatusData | null>(null);
+const loading = signal(false);
+const error = signal<string | null>(null);
+
+const uptimeStr = computed(() => {
+  if (!status.value) return "—";
+  const s = Math.floor(status.value.uptime_ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${h}h ${m}m ${sec}s`;
+});
+
+const heapColor = computed(() => {
+  const h = status.value?.free_heap ?? 0;
+  if (h >= 20000) return "var(--green)";
+  if (h >= 10000) return "var(--yellow)";
+  return "var(--red)";
+});
+
+export function StatusPage() {
+  useEffect(() => {
+    async function load() {
+      loading.value = true;
+      try {
+        status.value = await getStatus();
+        error.value = null;
+      } catch (e) {
+        error.value = String(e);
+      } finally {
+        loading.value = false;
+      }
+    }
+    load();
+    const id = setInterval(load, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const d = status.value;
+
+  return (
+    <div>
+      {loading.value && !d && <p class="muted">Loading…</p>}
+      {error.value && <p class="error-msg">{error.value}</p>}
+      {d && (
+        <div class="stat-grid">
+          <StatCard label="Device" value={d.device_name || d.chip_id} />
+          <StatCard label="Version" value={d.version} />
+          <StatCard label="Uptime" value={uptimeStr.value} />
+          <StatCard label="Reset reason" value={d.reset_reason} />
+
+          <div class="stat-card wide">
+            <div class="stat-label">Free heap</div>
+            <div class="stat-value" style={{ color: heapColor.value }}>
+              {(d.free_heap / 1024).toFixed(1)} KB
+              <span class="muted"> · {d.heap_fragmentation}% frag</span>
+            </div>
+            <div class="progress-bar">
+              <div
+                class="progress-fill"
+                style={{
+                  width: `${Math.min(100, (d.free_heap / 40000) * 100)}%`,
+                  background: heapColor.value,
+                }}
+              />
+            </div>
+          </div>
+
+          <div class="stat-card wide">
+            <div class="stat-label">WiFi — {d.wifi.ssid}</div>
+            <div class="stat-value">
+              {d.wifi.ip}
+              <span class="muted"> · {d.wifi.rssi} dBm</span>
+            </div>
+            <div class="progress-bar">
+              <div
+                class="progress-fill"
+                style={{ width: `${d.wifi.quality_pct}%` }}
+              />
+            </div>
+          </div>
+
+          {d.ota.pending_file_exists && (
+            <div class="stat-card wide">
+              <span class="badge badge-warn">OTA Pending</span>
+              <span class="muted"> Awaiting boot confirmation</span>
+            </div>
+          )}
+
+          <div class="stat-card wide sketch-row">
+            <span class="stat-label">Flash</span>
+            <span class="muted">
+              sketch {(d.sketch_size / 1024).toFixed(0)} KB ·
+              free {(d.free_sketch_space / 1024).toFixed(0)} KB ·
+              chip {(d.flash_size / 1024).toFixed(0)} KB
+            </span>
+          </div>
+        </div>
+      )}
+      <p class="muted refresh-hint">
+        {loading.value ? "Refreshing…" : "Auto-refreshes every 30 s"}
+      </p>
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div class="stat-card">
+      <div class="stat-label">{label}</div>
+      <div class="stat-value">{value}</div>
+    </div>
+  );
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -6,6 +6,10 @@
   --muted: GrayText;
   --accent: #2563eb;
   --border: color-mix(in srgb, CanvasText 15%, transparent);
+  --surface: color-mix(in srgb, CanvasText 4%, transparent);
+  --green: #16a34a;
+  --yellow: #ca8a04;
+  --red: #dc2626;
   --radius: 6px;
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
   line-height: 1.5;
@@ -34,3 +38,296 @@ a {
 }
 
 .muted { color: var(--muted); font-size: 0.9rem; }
+
+/* ── Tab bar ── */
+
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+  gap: 0;
+}
+
+.tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 0.45rem 1rem;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 0.95rem;
+  margin-bottom: -1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tab:hover { color: var(--fg); }
+
+.tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 500;
+}
+
+/* ── Status grid ── */
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.stat-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+}
+
+.stat-card.wide { grid-column: 1 / -1; }
+
+.sketch-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.2rem;
+}
+
+.stat-value {
+  font-size: 1.05rem;
+  font-weight: 500;
+}
+
+.refresh-hint {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+}
+
+/* ── Progress bar ── */
+
+.progress-bar {
+  height: 5px;
+  background: var(--border);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+/* ── Badge ── */
+
+.badge {
+  display: inline-block;
+  padding: 0.15em 0.55em;
+  border-radius: 1em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+}
+
+.badge-warn {
+  background: color-mix(in srgb, var(--yellow) 15%, transparent);
+  color: var(--yellow);
+}
+
+/* ── Settings form ── */
+
+.form-section { margin-bottom: 1.75rem; }
+
+.form-section h2 {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+  margin: 0 0 0.6rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.45rem 0;
+  gap: 1rem;
+}
+
+.toggle-row { cursor: pointer; }
+
+.form-label { flex: 1; font-size: 0.95rem; }
+
+.form-note { font-size: 0.8rem; color: var(--muted); }
+
+.slider-group,
+.num-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.slider-val {
+  font-size: 0.85rem;
+  color: var(--muted);
+  min-width: 3.5rem;
+  text-align: right;
+}
+
+input[type="range"] {
+  width: 130px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+input[type="number"] {
+  width: 4.5rem;
+  padding: 0.25rem 0.4rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+/* Toggle switch */
+input[type="checkbox"].toggle {
+  width: 2.4rem;
+  height: 1.3rem;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--border);
+  border-radius: 1rem;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+input[type="checkbox"].toggle:checked { background: var(--accent); }
+
+input[type="checkbox"].toggle::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: calc(1.3rem - 4px);
+  height: calc(1.3rem - 4px);
+  background: white;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+input[type="checkbox"].toggle:checked::after {
+  transform: translateX(1.1rem);
+}
+
+/* ── Save bar ── */
+
+.save-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 0 0.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.save-ok {
+  color: var(--green);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.error-msg {
+  color: var(--red);
+  font-size: 0.9rem;
+}
+
+/* ── Buttons ── */
+
+.btn {
+  padding: 0.45rem 1.2rem;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  background: var(--accent);
+  color: white;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.btn:hover:not(:disabled) { opacity: 0.85; }
+
+.btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.btn-danger { background: var(--red); }
+
+/* ── Action cards ── */
+
+.action-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.25rem;
+  margin-bottom: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--surface);
+}
+
+.action-info { flex: 1; }
+
+.action-info strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.action-info p {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.action-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+  min-width: 9rem;
+  text-align: right;
+}
+
+/* ── Spinner ── */
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.spinner {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  border: 2px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  vertical-align: -0.1em;
+}

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -1,0 +1,53 @@
+export interface WifiStatus {
+  ssid: string;
+  ip: string;
+  rssi: number;
+  quality_pct: number;
+}
+
+export interface OtaStatus {
+  confirm_at: number;
+  pending_url: string;
+  safe_url: string;
+  pending_file_exists: boolean;
+}
+
+export interface StatusData {
+  version: string;
+  uptime_ms: number;
+  free_heap: number;
+  heap_fragmentation: number;
+  chip_id: string;
+  device_name: string;
+  flash_size: number;
+  sketch_size: number;
+  free_sketch_space: number;
+  reset_reason: string;
+  wifi: WifiStatus;
+  ota: OtaStatus;
+}
+
+export interface ConfigData {
+  wagfam_data_url: string;
+  wagfam_api_key: string;
+  wagfam_event_today: boolean;
+  owm_api_key: string;
+  geo_location: string;
+  is_24hour: boolean;
+  is_pm: boolean;
+  is_metric: boolean;
+  display_intensity: number;
+  display_scroll_speed: number;
+  minutes_between_data_refresh: number;
+  minutes_between_scrolling: number;
+  show_date: boolean;
+  show_city: boolean;
+  show_condition: boolean;
+  show_humidity: boolean;
+  show_wind: boolean;
+  show_pressure: boolean;
+  show_highlow: boolean;
+  ota_safe_url: string;
+  device_name: string;
+  web_password: string;
+}


### PR DESCRIPTION
## Summary

- **Status dashboard** — pulls `GET /api/status` on mount and every 30 s; renders device
  name, firmware version, uptime, color-coded free-heap bar (green/yellow/red), WiFi SSID +
  signal-quality bar, and an OTA-pending badge when a rollback record exists
- **Settings page** — loads `GET /api/config`, renders sliders for brightness and scroll speed,
  toggles for 12 h/24 h and °F/°C, checkboxes for all seven weather display fields; dirty-tracks
  changes via a draft signal and posts *only* changed fields via `POST /api/config`
- **Actions page** — Force Refresh (`POST /api/refresh`) and Restart Device (`POST /api/restart`)
  with per-button loading spinners, success/error inline messages, and a 10 s countdown after
  restart so the user knows when to reconnect
- **Signal-driven tab nav** — three tabs swap pages via a single `signal<Tab>`, no router library;
  tab-mount/unmount drives polling lifecycle cleanly through `useEffect`
- **Typed API layer** (`api.ts` + `types.ts`) — all fetch calls are typed end-to-end against the
  exact JSON shapes the firmware returns; CSRF header on all POSTs

## Architecture notes

The draft-signal pattern in SettingsPage is the key demo: `config` holds the last server state,
`draft` holds only the keys the user has changed, `effective = computed(() => {...config, ...draft})`
is what the form renders, and `patchConfig(draft.value)` sends a minimal diff. Reverting a field
to its original value removes it from the draft automatically.

## Bundle

```
index.js   29.7 KB raw  /  10.9 KB gzip   (was 5.6 KB shell)
index.css   4.6 KB raw  /   1.6 KB gzip
Total gzip: 12.7 KB  (budget: 20–30 KB full app)
```

## Test plan

- [ ] `make webui-typecheck` passes (zero tsc errors)
- [ ] `make webui` passes; gzip sizes logged in build output
- [ ] Dev server (`cd webui && npm run dev` with `.env.local` pointing at device):
  - Status tab shows real device data and refreshes every 30 s
  - Settings tab loads current config; moving a slider enables Save; saving updates device and
    clears the dirty indicator
  - Actions tab: Force Refresh returns success banner; Restart triggers 10 s countdown
- [ ] Serial-flash bundle to device (`make webui && pio run --target uploadfs`); verify
  `/spa/` serves correctly with `Content-Encoding: gzip` from browser devtools