### PR TITLE
Restore GET /update upload form (fixes #60)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,20 @@ Lessons from code review — these are non-obvious enough to state explicitly:
 The only disabled rules in this repo are those with deliberate permanent policy reasons
 (MD033, MD024, MD041) — they were disabled intentionally, not to unblock a failure.
 
+**When dropping a third-party route registrar, audit every HTTP method it
+registered.** Libraries that "set up" an endpoint often register more than
+one method on it. The canonical example: ESP8266HTTPUpdateServer used to
+register BOTH `GET /update` (file-upload form) AND `POST /update` (upload
+handler). The async migration in commit `fdbc6fb` only reimplemented POST,
+so GET fell through to `onNotFound → redirectHome` and the firmware-upload
+page silently 302'd to `/` (issue #60, fixed in PR #61). Before deleting
+any `server.something()` line, grep the lib's source for every
+`on()`/`addHandler()`/`serveStatic()` call it makes and reimplement each.
+The static regression test
+[`tests/scripts/test_firmware_routes.py`](tests/scripts/test_firmware_routes.py)
+pins `/update`'s GET+POST pair so this specific regression can't recur — add
+similar pins for any other multi-method endpoint you migrate.
+
 **Don't duplicate logic when a shared helper exists or is obvious.**
 When writing a second code path that does the same core operation as an existing one,
 extract a shared function. The `doOtaFlash()` / `handleUpdateFromUrl()` /

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -180,6 +180,15 @@ static const char UPDATE_FORM[] PROGMEM = "<form class='w3-container' action='/u
                       "<p><button class='w3-button w3-block w3-blue w3-section w3-padding' type='submit'>Update from URL</button></p>"
                       "<p><small>Note: You can also use the <a href='/update'>Firmware Update</a> page to upload a file directly.</small></p></form>";
 
+// File-upload form rendered by GET /update. ESP8266HTTPUpdateServer used to register
+// both GET (form) and POST (upload) on /update; when we dropped that lib in the async
+// migration, only the POST half was reimplemented, so GET fell through to onNotFound
+// and redirected to "/". This form posts the firmware binary back to POST /update.
+static const char UPLOAD_FORM[] PROGMEM = "<form class='w3-container' method='POST' action='/update' enctype='multipart/form-data'><h2>Firmware Upload:</h2>"
+                      "<p><label>Firmware Binary (.bin)</label><input class='w3-input w3-border w3-margin-bottom' type='file' name='update' accept='.bin' required></p>"
+                      "<p><button class='w3-button w3-block w3-blue w3-section w3-padding' type='submit'>Upload &amp; Flash</button></p>"
+                      "<p><small>The device will reboot automatically when the upload completes.</small></p></form>";
+
 // OTA auto-update state
 String OTA_SAFE_URL = "";       // URL of last confirmed firmware; rollback target for next update
 uint32_t otaConfirmAt = 0;      // non-zero: millis() target after which the pending update is confirmed
@@ -341,6 +350,20 @@ void setup() {
     fsWritePost->setMaxContentLength(8192);
     server.addHandler(fsWritePost);
   }
+
+  // GET /update — render the file-upload form. This used to be served implicitly
+  // by ESP8266HTTPUpdateServer; the async migration only reimplemented POST.
+  server.on("/update", HTTP_GET, [](AsyncWebServerRequest *request) {
+    if (!requireWebAuth(request)) return;
+    AsyncResponseStream *response = request->beginResponseStream(F("text/html"));
+    response->addHeader(F("Cache-Control"), F("no-cache, no-store"));
+    response->addHeader(F("Pragma"), F("no-cache"));
+    response->addHeader(F("Expires"), F("-1"));
+    sendHeader(response);
+    response->print(FPSTR(UPLOAD_FORM));
+    sendFooter(response);
+    request->send(response);
+  });
 
   // SEC-01: Firmware upload — manual handler because ESP8266HTTPUpdateServer is
   // sync-only. Auth check is done manually (via requestHasValidBasicAuth) to

--- a/tests/scripts/test_firmware_routes.py
+++ b/tests/scripts/test_firmware_routes.py
@@ -1,0 +1,62 @@
+"""
+Static-analysis regression tests for marquee/marquee.ino route registrations.
+
+Why this exists:
+  When the web server was migrated from ESP8266WebServer to ESPAsyncWebServer
+  (commit fdbc6fb), ESP8266HTTPUpdateServer was dropped. That library used to
+  register BOTH GET (file-upload form) and POST (upload handler) on /update,
+  but the migration only reimplemented POST. GET /update silently fell through
+  to onNotFound → redirectHome, which the user perceived as the page being
+  "broken" — see issue #60. These tests pin the route table so a future
+  migration or refactor can't drop a method from a multi-method endpoint
+  without the test suite noticing.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+INO = Path(__file__).parent.parent.parent / "marquee" / "marquee.ino"
+
+
+@pytest.fixture(scope="module")
+def ino_source() -> str:
+    return INO.read_text(encoding="utf-8")
+
+
+def _registered_methods(source: str, route: str) -> set[str]:
+    """Return the set of HTTP method tokens registered for `route` via server.on(...)."""
+    pattern = re.compile(
+        r'server\.on\(\s*"' + re.escape(route) + r'"\s*,\s*(HTTP_\w+)',
+    )
+    return set(pattern.findall(source))
+
+
+def test_update_route_supports_both_get_and_post(ino_source: str) -> None:
+    """GET /update must serve the upload form; POST /update receives the binary.
+
+    Regression: dropping the GET handler makes /update redirect to home (issue #60).
+    """
+    methods = _registered_methods(ino_source, "/update")
+    assert "HTTP_GET" in methods, (
+        "GET /update handler missing — visiting /update in a browser will "
+        "redirect to home instead of showing the upload form. See issue #60."
+    )
+    assert "HTTP_POST" in methods, "POST /update handler missing"
+
+
+def test_update_form_posts_back_to_update(ino_source: str) -> None:
+    """The upload form must target /update with multipart/form-data, or the
+    upload chunk handler will never receive the body."""
+    assert "UPLOAD_FORM" in ino_source, "UPLOAD_FORM constant missing"
+    form_match = re.search(
+        r"UPLOAD_FORM\[\]\s*PROGMEM\s*=\s*((?:\"[^\"]*\"\s*)+);",
+        ino_source,
+    )
+    assert form_match, "could not locate UPLOAD_FORM string literal"
+    form_html = form_match.group(1)
+    assert "method='POST'" in form_html
+    assert "action='/update'" in form_html
+    assert "enctype='multipart/form-data'" in form_html
+    assert "type='file'" in form_html


### PR DESCRIPTION
## Summary
- Reimplement `GET /update` so the firmware-upload page renders instead of 302'ing to `/`.
- Pin `/update`'s GET+POST pair with a static-analysis regression test.
- Document the "audit every method when dropping a third-party route registrar" rule in CLAUDE.md.

Closes #60.

## Root cause
`ESP8266HTTPUpdateServer::setup()` registered **two** handlers on `/update`: a GET that
served the multipart upload form and a POST that received the binary. When the web stack
was migrated from `ESP8266WebServer` to `ESPAsyncWebServer` in commit `fdbc6fb`, the
update server library was dropped and only the POST half was reimplemented manually
(`marquee/marquee.ino:398`). With no GET handler registered, the request fell through to
`server.onNotFound(redirectHome)` (`marquee/marquee.ino:439`), which sends a 302 to `/`.
That matches the reported symptom exactly: visiting `/update` redirects to the home page.

The migration smoke test ("104 native test cases pass; firmware builds clean") couldn't
have caught this — the route was lost in a `.ino` file with no test coverage of route
registration, and end-to-end OTA testing had been deferred. The `--update`-via-URL form
embedded inside the home page kept the URL-flow working, which masked the missing
file-upload path until someone tried to use it manually.

## Fix
- Add `server.on("/update", HTTP_GET, ...)` that renders a small `UPLOAD_FORM` PROGMEM
  string (auth-gated via `requireWebAuth`, branded with `sendHeader`/`sendFooter`,
  posts back to `/update` as `multipart/form-data`).
- The existing POST handler is unchanged — it already validated auth, drove
  `Update.begin/write/end`, and deferred `ESP.restart()` to the main loop.

## Why this fixes the reported issue
With both methods registered, `AsyncWebServer` routes `GET /update` to the new handler
instead of falling through to `onNotFound`. The new handler returns 200 with an HTML
form (no redirect). The form's `action='/update'` + `method='POST'` +
`enctype='multipart/form-data'` matches what the existing POST upload handler expects,
so submitting it drives the same code path that was already proven to work for the URL
flow.

Verified locally:
- `pio run -e default` builds clean (Flash 53.5%, RAM 47.7%).
- `pio test -e native_test` — 121/121 pass.
- New `tests/scripts/test_firmware_routes.py` — 2/2 pass; verified it fails when the
  GET handler is removed.

## Insight on the underlying cause
The migration commit message explicitly flagged that "End-to-end hardware testing of the
captive portal, web UI, and OTA paths is still required before this lands." The OTA
file-upload path was the one piece that had no automated coverage *and* no manual
verification before merge. Two compounding gaps:

1. **Hidden behavior in dropped libraries.** When you delete a `<lib>.setup(server)`
   line, you lose every route the lib registered — not just the one obvious endpoint.
   ESP8266HTTPUpdateServer's source registers two handlers in a single `setup()` call,
   which is invisible at the call site.
2. **No route-table tests.** Native unit tests cover parsing/security helpers but not
   the route table. A static scan of `marquee.ino` for `server.on(...)` calls would
   have flagged the missing GET handler immediately.

To prevent recurrence:
- The new `tests/scripts/test_firmware_routes.py` runs in CI and pins `/update`'s
  GET+POST pair. Adding similar pins for any other multi-method endpoint is cheap
  insurance.
- CLAUDE.md now explicitly tells future contributors (human or LLM) to grep the
  source of any third-party registrar they're removing for every `on()` /
  `addHandler()` / `serveStatic()` call before deleting it.

## Test plan
- [x] `pio run -e default` succeeds
- [x] `pio test -e native_test` — 121 cases pass
- [x] `pytest tests/scripts/test_firmware_routes.py` — 2 pass; manually verified it
      catches the regression by simulating the missing GET handler
- [ ] Hardware: visit `http://<device>/update` in a browser, confirm the upload form
      renders, upload a `.bin`, confirm the device reboots into the new version