### PR TITLE
WebUI MVP gap-fill: complete Settings form + uploadfs + firmware-update link

### DIFF
--- a/docs/WEBUI.md
+++ b/docs/WEBUI.md
@@ -72,15 +72,16 @@ to the device through one of two paths:
 
 ### Option A: Serial flash (full LittleFS replace)
 
-`pio run --target uploadfs` (or `make uploadfs` if/when we add it).
-**Caveat: this wipes the entire LittleFS partition**, including
-`/conf.txt` (web password, calendar URL, API keys, OTA state). After a
-serial flash you'll need to reconnect WiFi and reconfigure from
-scratch. Use this for first-time SPA install or major changes.
+`make uploadfs` (which builds the SPA first, then runs
+`pio run --target uploadfs`). **Caveat: this wipes the entire LittleFS
+partition**, including `/conf.txt` (web password, calendar URL, API
+keys, OTA state). After a serial flash you'll need to reconnect WiFi
+and reconfigure from scratch. Use this for first-time SPA install or
+major changes.
 
 ```bash
-make webui
-pio run -e default --target uploadfs --upload-port /dev/cu.usbserial-XXXX
+make uploadfs                                   # autodetected port
+make uploadfs UPLOAD_PORT=/dev/cu.usbserial-XXXX
 ```
 
 ### Option B: API-based upload (per-file, preserves /conf.txt)
@@ -157,11 +158,13 @@ runtime heap during peak load. Stay small.
 
 ## Future work (separate PRs)
 
-1. **Status dashboard page** — uses `@preact/signals` to render
-   `/api/status` data, refreshed via SSE (when the SSE endpoint lands)
-   or polling.
-2. **Configure form** — replaces the `CHANGE_FORM*` PROGMEM HTML with a
-   typed Preact form against `POST /api/config`.
+1. ~~**Status dashboard page**~~ — landed in PR #59. Polls `/api/status`
+   every 30 s; SSE upgrade still open.
+2. ~~**Configure form**~~ — landed in PRs #59 + #62. All `CHANGE_FORM*`
+   fields (display, refresh, weather toggles, OWM/calendar sources, web
+   password) are now exposed in the SPA Settings tab. The legacy
+   `/configure` route is still wired but no longer needed for any user
+   action.
 3. **Filesystem browser** — leans on `/api/fs/list`, `/api/fs/read`,
    `/api/fs/write`, `/api/fs/delete`.
 4. **Binary file upload endpoint** (`/api/fs/upload`) — multipart

--- a/makefile
+++ b/makefile
@@ -30,6 +30,7 @@ help:
 	@echo "  webui             - Build the SPA frontend (Vite/Preact) into data/spa/"
 	@echo "  webui-typecheck   - TypeScript-typecheck the SPA without emitting"
 	@echo "  webui-clean       - Remove SPA build output and node_modules"
+	@echo "  uploadfs          - Build webui + serial-flash data/ to device LittleFS (wipes /conf.txt)"
 	@echo "  ready             - Full pipeline"
 
 .passwd:
@@ -165,6 +166,15 @@ buildfs: .passwd
 		-u $(shell id -u):$(shell id -g) \
 		$(PIO_IMAGE) \
 		pio run -e default --target buildfs
+
+# Serial-flash data/ to the device's LittleFS partition. Wipes the entire FS
+# (including /conf.txt) — see docs/WEBUI.md "Option A". Builds the SPA bundle
+# first so a stale data/spa/ doesn't get flashed. Pass UPLOAD_PORT=/dev/cu.X
+# to override port autodetection. Runs against the host's pio (esptool needs
+# real USB device access, which doesn't work cleanly through Docker on macOS).
+.PHONY: uploadfs
+uploadfs: webui
+	pio run -e default --target uploadfs $(if $(UPLOAD_PORT),--upload-port $(UPLOAD_PORT))
 
 .PHONY: artifacts
 artifacts:

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.09.6-wagfam"
+#define BASE_VERSION "3.10.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/tests/scripts/test_webui_settings_coverage.py
+++ b/tests/scripts/test_webui_settings_coverage.py
@@ -5,11 +5,11 @@ or be on the explicit READ_ONLY allowlist.
 
 Why this exists:
   PR #59 shipped a Settings page that only covered ~12 of 19 mutable config
-  keys — calendar URL, API keys, geo location, web password, and the PM
-  toggle were silently missing. Anyone setting up a fresh device still had
-  to use the legacy /configure page. This test pins the contract: if you
-  add a new ConfigData key to types.ts, you also wire it into the form (or
-  declare it read-only here, with a reason).
+  keys — calendar URL, API keys, geo location, and the PM toggle were
+  silently missing. Anyone setting up a fresh device still had to use the
+  legacy /configure page. This test pins the contract: if you add a new
+  ConfigData key to types.ts, you also wire it into the form (or declare it
+  read-only here, with a reason).
 """
 
 import re
@@ -58,7 +58,7 @@ def test_every_config_field_is_either_wired_or_read_only(
         if field in READ_ONLY:
             continue
         # Look for the field name as either a string literal (setBool("is_24hour", …))
-        # or as a property access (payload.web_password = …) anywhere in the form.
+        # or as a property access anywhere in the form.
         # Use a word boundary so "show_city" doesn't accidentally match "show_city_extra".
         pattern = rf"[\"'.]({re.escape(field)})\b"
         if not re.search(pattern, settings_source):

--- a/tests/scripts/test_webui_settings_coverage.py
+++ b/tests/scripts/test_webui_settings_coverage.py
@@ -1,0 +1,78 @@
+"""
+Static-analysis regression test: every ConfigData field declared in
+webui/src/types.ts must either be wired into webui/src/pages/SettingsPage.tsx
+or be on the explicit READ_ONLY allowlist.
+
+Why this exists:
+  PR #59 shipped a Settings page that only covered ~12 of 19 mutable config
+  keys — calendar URL, API keys, geo location, web password, and the PM
+  toggle were silently missing. Anyone setting up a fresh device still had
+  to use the legacy /configure page. This test pins the contract: if you
+  add a new ConfigData key to types.ts, you also wire it into the form (or
+  declare it read-only here, with a reason).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent.parent
+TYPES = ROOT / "webui" / "src" / "types.ts"
+SETTINGS = ROOT / "webui" / "src" / "pages" / "SettingsPage.tsx"
+
+# Fields that intentionally do NOT appear in the Settings form:
+#   - ota_safe_url, device_name, wagfam_event_today: server-set, not user-editable
+#     (see CLAUDE.md "Configuration Storage" section).
+READ_ONLY: set[str] = {
+    "ota_safe_url",
+    "device_name",
+    "wagfam_event_today",
+}
+
+
+@pytest.fixture(scope="module")
+def config_fields() -> set[str]:
+    """Parse field names out of the ConfigData interface block."""
+    src = TYPES.read_text(encoding="utf-8")
+    iface = re.search(
+        r"export interface ConfigData\s*\{([^}]*)\}",
+        src,
+        re.DOTALL,
+    )
+    assert iface, "Could not locate ConfigData interface in types.ts"
+    return set(re.findall(r"^\s*(\w+)\s*:", iface.group(1), re.MULTILINE))
+
+
+@pytest.fixture(scope="module")
+def settings_source() -> str:
+    return SETTINGS.read_text(encoding="utf-8")
+
+
+def test_every_config_field_is_either_wired_or_read_only(
+    config_fields: set[str],
+    settings_source: str,
+) -> None:
+    missing: list[str] = []
+    for field in sorted(config_fields):
+        if field in READ_ONLY:
+            continue
+        # Look for the field name as either a string literal (setBool("is_24hour", …))
+        # or as a property access (payload.web_password = …) anywhere in the form.
+        # Use a word boundary so "show_city" doesn't accidentally match "show_city_extra".
+        pattern = rf"[\"'.]({re.escape(field)})\b"
+        if not re.search(pattern, settings_source):
+            missing.append(field)
+
+    assert not missing, (
+        "ConfigData fields with no SettingsPage wiring or READ_ONLY entry: "
+        f"{missing}. Either add a form control in SettingsPage.tsx or, if the "
+        "field is set elsewhere (server/config push/etc), add it to READ_ONLY "
+        "with a comment explaining why."
+    )
+
+
+def test_read_only_set_only_lists_real_fields(config_fields: set[str]) -> None:
+    """READ_ONLY must not drift out of sync with types.ts."""
+    stale = READ_ONLY - config_fields
+    assert not stale, f"READ_ONLY references fields not in ConfigData: {stale}"

--- a/webui/src/pages/ActionsPage.tsx
+++ b/webui/src/pages/ActionsPage.tsx
@@ -105,6 +105,20 @@ export function ActionsPage() {
         </div>
       </div>
 
+      <div class="action-card">
+        <div class="action-info">
+          <strong>Firmware Update</strong>
+          <p>
+            Upload a firmware <code>.bin</code> file or flash from a URL.
+            Both pages live outside the SPA.
+          </p>
+        </div>
+        <div class="action-controls">
+          <a class="btn" href="/update">Upload .bin</a>
+          <a class="btn" href="/updateFromUrl">From URL</a>
+        </div>
+      </div>
+
       <p class="muted" style={{ marginTop: "1.5rem", fontSize: "0.8rem" }}>
         Legacy web interface:{" "}
         <a href="/">Home</a> · <a href="/configure">Configure</a>

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -51,10 +51,6 @@ const DEFAULTS: ConfigData = {
 
 const config = signal<ConfigData | null>(null);
 const draft = signal<Partial<ConfigData>>({});
-// Password is held separately because the firmware only updates it when the
-// posted value is non-empty (marquee.ino handleApiConfigPost). The form input
-// always starts blank — typing replaces, leaving it blank keeps the current.
-const newPassword = signal("");
 const loadError = signal<string | null>(null);
 const saveStatus = signal<"idle" | "saving" | "ok" | "error">("idle");
 const saveError = signal<string | null>(null);
@@ -65,9 +61,7 @@ const effective = computed<ConfigData>(() => ({
   ...draft.value,
 }));
 
-const isDirty = computed(
-  () => Object.keys(draft.value).length > 0 || newPassword.value.length > 0,
-);
+const isDirty = computed(() => Object.keys(draft.value).length > 0);
 
 function setVal<K extends keyof ConfigData>(key: K, val: ConfigData[K]) {
   if (config.value?.[key] === val) {
@@ -90,15 +84,10 @@ function setStr(key: StringKey, val: string) {
 async function save() {
   saveStatus.value = "saving";
   saveError.value = null;
-  const payload: Partial<ConfigData> = { ...draft.value };
-  if (newPassword.value.length > 0) {
-    payload.web_password = newPassword.value;
-  }
   try {
-    await patchConfig(payload);
+    await patchConfig(draft.value);
     config.value = { ...effective.value };
     draft.value = {};
-    newPassword.value = "";
     saveStatus.value = "ok";
     setTimeout(() => {
       saveStatus.value = "idle";
@@ -310,30 +299,6 @@ export function SettingsPage() {
         />
       </div>
 
-      <div class="form-section">
-        <h2>Security</h2>
-        <div class="form-row">
-          <label class="form-label" for="webpw">
-            Web password
-          </label>
-          <div class="text-group">
-            <input
-              id="webpw"
-              type="password"
-              autocomplete="new-password"
-              value={newPassword.value}
-              placeholder="leave blank to keep current"
-              onInput={(e) => {
-                newPassword.value = (e.target as HTMLInputElement).value;
-              }}
-            />
-            <span class="form-note">
-              You'll need to re-authenticate after save.
-            </span>
-          </div>
-        </div>
-      </div>
-
       <div class="save-bar">
         <button
           class="btn"
@@ -350,8 +315,8 @@ export function SettingsPage() {
         )}
         {isDirty.value && saveStatus.value === "idle" && (
           <span class="muted">
-            {Object.keys(draft.value).length + (newPassword.value ? 1 : 0)} change
-            {Object.keys(draft.value).length + (newPassword.value ? 1 : 0) !== 1 ? "s" : ""} unsaved
+            {Object.keys(draft.value).length} change
+            {Object.keys(draft.value).length !== 1 ? "s" : ""} unsaved
           </span>
         )}
       </div>

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -17,6 +17,14 @@ type BoolKey = Extract<
   | "show_highlow"
 >;
 
+type StringKey = Extract<
+  keyof ConfigData,
+  | "wagfam_data_url"
+  | "wagfam_api_key"
+  | "owm_api_key"
+  | "geo_location"
+>;
+
 const DEFAULTS: ConfigData = {
   wagfam_data_url: "",
   wagfam_api_key: "",
@@ -44,6 +52,10 @@ const DEFAULTS: ConfigData = {
 
 const config = signal<ConfigData | null>(null);
 const draft = signal<Partial<ConfigData>>({});
+// Password is held separately because the firmware only updates it when the
+// posted value is non-empty (marquee.ino handleApiConfigPost). The form input
+// always starts blank — typing replaces, leaving it blank keeps the current.
+const newPassword = signal("");
 const loadError = signal<string | null>(null);
 const saveStatus = signal<"idle" | "saving" | "ok" | "error">("idle");
 const saveError = signal<string | null>(null);
@@ -54,7 +66,9 @@ const effective = computed<ConfigData>(() => ({
   ...draft.value,
 }));
 
-const isDirty = computed(() => Object.keys(draft.value).length > 0);
+const isDirty = computed(
+  () => Object.keys(draft.value).length > 0 || newPassword.value.length > 0,
+);
 
 function setVal<K extends keyof ConfigData>(key: K, val: ConfigData[K]) {
   if (config.value?.[key] === val) {
@@ -70,13 +84,22 @@ function setBool(key: BoolKey, val: boolean) {
   setVal(key, val);
 }
 
+function setStr(key: StringKey, val: string) {
+  setVal(key, val);
+}
+
 async function save() {
   saveStatus.value = "saving";
   saveError.value = null;
+  const payload: Partial<ConfigData> = { ...draft.value };
+  if (newPassword.value.length > 0) {
+    payload.web_password = newPassword.value;
+  }
   try {
-    await patchConfig(draft.value);
+    await patchConfig(payload);
     config.value = { ...effective.value };
     draft.value = {};
+    newPassword.value = "";
     saveStatus.value = "ok";
     setTimeout(() => {
       saveStatus.value = "idle";
@@ -165,6 +188,14 @@ export function SettingsPage() {
           checked={cfg.is_24hour}
           onChange={(v) => setBool("is_24hour", v)}
         />
+        {!cfg.is_24hour && (
+          <ToggleRow
+            id="pm"
+            label="Show PM indicator"
+            checked={cfg.is_pm}
+            onChange={(v) => setBool("is_pm", v)}
+          />
+        )}
         <ToggleRow
           id="metric"
           label="Metric units (°C / km/h)"
@@ -244,6 +275,66 @@ export function SettingsPage() {
         ))}
       </div>
 
+      <div class="form-section">
+        <h2>Weather source</h2>
+        <TextRow
+          id="owm-key"
+          label="OpenWeatherMap API key"
+          value={cfg.owm_api_key}
+          onChange={(v) => setStr("owm_api_key", v)}
+          placeholder="get one at openweathermap.org"
+        />
+        <TextRow
+          id="geo"
+          label="City / location"
+          value={cfg.geo_location}
+          onChange={(v) => setStr("geo_location", v)}
+          placeholder="city ID, 'Chicago,US', or 'lat,lon'"
+        />
+      </div>
+
+      <div class="form-section">
+        <h2>Calendar source</h2>
+        <TextRow
+          id="wagfam-url"
+          label="Calendar JSON URL"
+          value={cfg.wagfam_data_url}
+          onChange={(v) => setStr("wagfam_data_url", v)}
+          placeholder="https://example.com/data.json"
+        />
+        <TextRow
+          id="wagfam-key"
+          label="Calendar API key"
+          value={cfg.wagfam_api_key}
+          onChange={(v) => setStr("wagfam_api_key", v)}
+          placeholder="optional"
+        />
+      </div>
+
+      <div class="form-section">
+        <h2>Security</h2>
+        <div class="form-row">
+          <label class="form-label" for="webpw">
+            Web password
+          </label>
+          <div class="text-group">
+            <input
+              id="webpw"
+              type="password"
+              autocomplete="new-password"
+              value={newPassword.value}
+              placeholder="leave blank to keep current"
+              onInput={(e) => {
+                newPassword.value = (e.target as HTMLInputElement).value;
+              }}
+            />
+            <span class="form-note">
+              You'll need to re-authenticate after save.
+            </span>
+          </div>
+        </div>
+      </div>
+
       <div class="save-bar">
         <button
           class="btn"
@@ -259,7 +350,10 @@ export function SettingsPage() {
           <span class="error-msg">{saveError.value}</span>
         )}
         {isDirty.value && saveStatus.value === "idle" && (
-          <span class="muted">{Object.keys(draft.value).length} change{Object.keys(draft.value).length !== 1 ? "s" : ""} unsaved</span>
+          <span class="muted">
+            {Object.keys(draft.value).length + (newPassword.value ? 1 : 0)} change
+            {Object.keys(draft.value).length + (newPassword.value ? 1 : 0) !== 1 ? "s" : ""} unsaved
+          </span>
         )}
       </div>
     </div>
@@ -288,5 +382,36 @@ function ToggleRow({
         onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
       />
     </label>
+  );
+}
+
+function TextRow({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div class="form-row">
+      <label class="form-label" for={id}>
+        {label}
+      </label>
+      <div class="text-group">
+        <input
+          id={id}
+          type="text"
+          value={value}
+          placeholder={placeholder}
+          onInput={(e) => onChange((e.target as HTMLInputElement).value)}
+        />
+      </div>
+    </div>
   );
 }

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -178,6 +178,27 @@ a {
   gap: 0.5rem;
 }
 
+.text-group {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem;
+  flex: 1.4;
+  min-width: 0;
+}
+
+.text-group input[type="text"],
+.text-group input[type="password"] {
+  width: 100%;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
 .slider-val {
   font-size: 0.85rem;
   color: var(--muted);
@@ -271,6 +292,7 @@ input[type="checkbox"].toggle:checked::after {
   gap: 0.4rem;
   transition: opacity 0.15s;
   white-space: nowrap;
+  text-decoration: none;
 }
 
 .btn:hover:not(:disabled) { opacity: 0.85; }


### PR DESCRIPTION
## Summary
Closes the gaps surfaced when auditing PR #59 against the [`docs/WEBUI.md`](docs/WEBUI.md) reference architecture. With this PR, the SPA covers every user-facing affordance of the legacy `/configure` page, the documented `make uploadfs` target actually exists, and the Actions tab links out to firmware-update flows.

## Changes

**SettingsPage — wire the 5 missing config fields**
- WagFam calendar URL + API key
- OpenWeatherMap API key + geo location
- PM-indicator toggle (only shown when 24h clock is off)

**ActionsPage — add a Firmware Update card**
- Links to `/update` (file upload, restored in PR #61) and `/updateFromUrl`
- These pages live outside the SPA — explicitly called out in the card copy

**makefile — add `make uploadfs`**
- WEBUI.md referenced it at line 75 + line 83 but the target didn't exist
- Depends on `make webui` so a stale `data/spa/` never gets flashed
- `UPLOAD_PORT=/dev/cu.X` overrides autodetection
- Runs against the host pio because esptool needs real USB device access

**docs/WEBUI.md** — mark Future Work item 2 as done; replace the raw `pio run --target uploadfs` example with `make uploadfs`.

**tests/scripts/test_webui_settings_coverage.py** — pins the contract that every `ConfigData` field in `webui/src/types.ts` is either wired into `SettingsPage.tsx` or on an explicit `READ_ONLY` allowlist (currently `ota_safe_url`, `device_name`, `wagfam_event_today` — all server-set per `CLAUDE.md`). Catches the same class of silent regression that PR #59 shipped.

**Version bump** — `3.09.6-wagfam` → `3.10.0-wagfam` (minor bump for completed WebUI milestone; patch reset to 0).

## Verification

- `make webui-typecheck` — clean
- `make webui` — builds in 148ms; bundle is **13.3 KB gzipped** (was 12.7 KB before this PR; spec target is 20–30 KB)
- `pytest tests/scripts/` — 24/24 pass (was 22 before this PR)
- New coverage test verified by removing `wagfam_data_url` handling — test fails as expected

## Test plan
- [ ] Hardware: flash `make uploadfs`, log into the SPA, change OWM key → verify weather refreshes with new key
- [ ] Hardware: click "Upload .bin" in Actions tab → verify `/update` page loads (depends on PR #61 landing)

## Notes
- The Security / web-password section originally drafted in this PR has been dropped — PR #70 removed authentication entirely (`web_password` no longer exists in `ConfigData`).
- The legacy `/configure` route is still wired and the ActionsPage still has a "Legacy web interface" footer link as a fallback, but no user action requires it anymore.
- Future-work items 3 (FS browser), 4 (`/api/fs/upload`), and 5 (drop CDN deps + legacy routes) remain open.