### PR TITLE
Make /api/fs/list recursive (fixes #68)

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.09.4-wagfam"
+#define BASE_VERSION "3.09.5-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -1819,18 +1819,29 @@ void handleApiFsDelete(AsyncWebServerRequest *request) {
   sendJsonOk(request, "deleted");
 }
 
+static void listFilesRecursive(const String &path, JsonArray &files) {
+  Dir dir = LittleFS.openDir(path);
+  while (dir.next()) {
+    String entryPath = path;
+    if (!entryPath.endsWith("/")) entryPath += "/";
+    entryPath += dir.fileName();
+    if (dir.isDirectory()) {
+      listFilesRecursive(entryPath, files);
+    } else {
+      JsonObject entry = files.add<JsonObject>();
+      entry["name"] = entryPath;
+      entry["size"] = dir.fileSize();
+    }
+  }
+}
+
 void handleApiFsList(AsyncWebServerRequest *request) {
   if (!requireApiAuth(request)) return;
 
   JsonDocument doc;
   JsonArray files = doc["files"].to<JsonArray>();
 
-  Dir dir = LittleFS.openDir("/");
-  while (dir.next()) {
-    JsonObject entry = files.add<JsonObject>();
-    entry["name"] = dir.fileName();
-    entry["size"] = dir.fileSize();
-  }
+  listFilesRecursive("/", files);
 
   sendJsonResponse(request, 200, doc);
 }


### PR DESCRIPTION
## Summary

- Extracts a \`listFilesRecursive(path, files)\` static helper that walks subdirectories depth-first
- \`handleApiFsList\` now calls it from \`/\` instead of doing a flat \`LittleFS.openDir("/")\`
- Previously, \`/spa/*\` assets (index.html, assets/, etc.) were silently omitted from the listing;
  now they appear with their full paths (e.g. \`/spa/index.html\`)

## Live device test — 2026-05-03

Firmware flashed via USB serial to Wemos D1 Mini (chip `24adfa`), firmware version
`3.09.5-wagfam-justinwagner-20260503-64b3bea`.

**\`GET /api/fs/list\` response:**

```json
{
    "files": [
        { "name": "/conf.txt",                  "size": 341   },
        { "name": "/spa/assets/index.css.gz",   "size": 1546  },
        { "name": "/spa/assets/index.css",      "size": 4591  },
        { "name": "/spa/assets/index.js.gz",    "size": 10867 },
        { "name": "/spa/assets/index.js",       "size": 29772 },
        { "name": "/spa/index.html.gz",         "size": 285   },
        { "name": "/spa/index.html",            "size": 481   }
    ]
}
```

- Root-level file (\`/conf.txt\`) appears as before ✓
- All \`/spa/\` assets now appear (previously omitted by the flat loop) ✓
- Nested \`/spa/assets/\` subdirectory recurses correctly ✓