### PR TITLE
Preserve /conf.txt across /updatefs LittleFS flash (issue #72 part 1)

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -221,6 +221,11 @@ volatile bool weatherRefreshRequested = false;
 volatile bool otaFromUrlRequested = false;
 String pendingOtaUrl = "";
 
+// /conf.txt contents saved across a /updatefs flash. Read before LittleFS.end(),
+// written back after Update.end() + LittleFS.begin() so the user does not lose
+// API keys and display settings when upgrading the SPA bundle.
+String fsUpdateConfBackup = "";
+
 // Deferred restart. /api/restart and the /update post-flash path set the
 // flag with a "restart not before" deadline. The main loop pulls the
 // trigger after the deadline, giving the async TCP layer time to flush the
@@ -427,6 +432,22 @@ void setup() {
       response->addHeader(F("Connection"), F("close"));
       request->send(response);
       if (ok) {
+        // Mount the new FS and restore /conf.txt so the user's API keys and
+        // settings survive the SPA bundle upgrade.
+        LittleFS.begin();
+        if (!fsUpdateConfBackup.isEmpty()) {
+          File confFile = LittleFS.open("/conf.txt", "w");
+          if (confFile) {
+            confFile.print(fsUpdateConfBackup);
+            confFile.close();
+            Serial.printf_P(PSTR("[OTAFS] Restored /conf.txt (%u bytes)\n"),
+                            (unsigned)fsUpdateConfBackup.length());
+          } else {
+            Serial.println(F("[OTAFS] WARN: could not write /conf.txt to new FS"));
+          }
+          fsUpdateConfBackup = "";
+        }
+        LittleFS.end();
         restartAtMs = millis() + 1000;
         restartRequested = true;
       } else {
@@ -437,6 +458,15 @@ void setup() {
     [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
       if (index == 0) {
         Serial.printf_P(PSTR("[OTAFS] Upload start: %s\n"), filename.c_str());
+        // Save /conf.txt before unmounting so it survives the FS wipe.
+        fsUpdateConfBackup = "";
+        File confFile = LittleFS.open("/conf.txt", "r");
+        if (confFile) {
+          fsUpdateConfBackup = confFile.readString();
+          confFile.close();
+          Serial.printf_P(PSTR("[OTAFS] Saved /conf.txt (%u bytes) for restore\n"),
+                          (unsigned)fsUpdateConfBackup.length());
+        }
         // Unmount before writing raw bytes to the partition.
         LittleFS.end();
         Update.runAsync(true);


### PR DESCRIPTION
## Summary

Fixes the silent config-loss that occurs when upgrading the SPA bundle via `/updatefs`.

Before this change, flashing a new LittleFS image wipes the entire FS partition,
erasing `/conf.txt` and forcing users to re-enter their OpenWeatherMap API key,
calendar URL, display settings, etc. after every SPA upgrade. This made SPA upgrades
painful enough that users would avoid them.

- Read `/conf.txt` into a RAM `String` (`fsUpdateConfBackup`) **before** `LittleFS.end()` in the upload callback
- After `Update.end()` succeeds, remount the new FS and write the backup back to `/conf.txt`
- `LittleFS.end()` again before scheduling the reboot
- First-time installs (no `/conf.txt` yet) are handled gracefully — `fsUpdateConfBackup` stays empty and the restore step is skipped

## Test plan

- [x] All 92 existing tests pass (`make test`)
- [x] Flash a LittleFS image via `/updatefs` with config already set; verify `/api/config` returns the same API keys and settings after reboot
- [x] Flash on a fresh device (no `/conf.txt`); verify it boots normally without errors

Closes part 1 of #72.