### PR TITLE
Embed SPA version in LittleFS image; expose via /api/status (issue #72 part 2)

### DIFF
--- a/makefile
+++ b/makefile
@@ -158,6 +158,7 @@ build: .passwd
 .PHONY: buildfs
 buildfs: .passwd
 	mkdir -p $(LOCAL_PIO_CACHE)
+	python3 scripts/write_spa_version.py
 	docker run \
 		--rm $(DOCKER_TTY_ARGS) \
 		-e CI \

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -111,7 +111,8 @@ String displayTime;
 WagFamBdayClient bdayClient(WAGFAM_API_KEY, WAGFAM_DATA_URL);
 int bdayMessageIndex = 0;
 WagFamBdayClient::configValues serverConfig = {};
-String DEVICE_NAME = "";  // Human-friendly name assigned by server (not user-editable)
+String DEVICE_NAME = "";     // Human-friendly name assigned by server (not user-editable)
+String SPA_VERSION = "unknown"; // Read from /spa/version.json at boot; "unknown" if absent
 uint32_t todayDisplayMilliSecond = 0;
 uint32_t todayDisplayStartingLED = 0;
 
@@ -261,6 +262,18 @@ void setup() {
   Serial.println();
 
   readPersistentConfig();
+
+  {
+    File vf = LittleFS.open("/spa/version.json", "r");
+    if (vf) {
+      JsonDocument vdoc;
+      if (!deserializeJson(vdoc, vf) && vdoc["spa_version"].is<const char *>()) {
+        SPA_VERSION = vdoc["spa_version"].as<String>();
+      }
+      vf.close();
+    }
+    Serial.println(F("[SPA] version: ") + SPA_VERSION);
+  }
 
   Serial.println("Number of LED Displays: " + String(numberOfHorizontalDisplays));
   // initialize dispaly
@@ -1516,6 +1529,7 @@ static void sendJsonError(AsyncWebServerRequest *request, int code, const char *
 void handleApiStatus(AsyncWebServerRequest *request) {
   JsonDocument doc;
   doc["version"] = VERSION;
+  doc["spa_version"] = SPA_VERSION;
   doc["uptime_ms"] = millis();
   doc["free_heap"] = ESP.getFreeHeap();
   doc["heap_fragmentation"] = ESP.getHeapFragmentation();

--- a/scripts/write_spa_version.py
+++ b/scripts/write_spa_version.py
@@ -1,0 +1,89 @@
+"""
+write_spa_version.py — write data/spa/version.json before `make buildfs`
+
+Writes a small JSON file into data/spa/ so the LittleFS image carries the
+SPA version string.  The device reads this at boot and exposes it via
+GET /api/status as "spa_version", enabling the SPA update-detection flow
+planned in issue #72.
+
+The version string format mirrors the firmware VERSION macro:
+
+  Local builds:  BASE_VERSION-<username>-<YYYYMMDD>-<hash>
+                 e.g. 3.10.0-wagfam-justin-20260503-c0c7879
+  CI builds:     BASE_VERSION-<hash>
+                 e.g. 3.10.0-wagfam-c0c7879
+
+Environment variables (same as build_version.py):
+  CI              Non-empty → CI-style suffix (hash only).
+  GIT_HASH        Short commit hash override.
+  USER / USERNAME Developer username for local-build suffixes.
+
+Intended usage (called by `make buildfs` before `pio run -t buildfs`):
+  python3 scripts/write_spa_version.py
+
+Also callable from CI steps or as a test helper.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+__all__ = ["write_spa_version"]
+
+try:
+    _REPO_ROOT: Path | None = Path(__file__).parent.parent
+except NameError:
+    _REPO_ROOT = None
+
+
+def write_spa_version(
+    repo_root: Path | None = None,
+    out_file: Path | None = None,
+) -> str:
+    """Write data/spa/version.json and return the version string.
+
+    Args:
+        repo_root: Root of the repository. Defaults to two directories above
+                   this script.
+        out_file:  Destination file. Defaults to
+                   <repo_root>/data/spa/version.json.
+
+    Returns:
+        The full version string that was written, e.g.
+        ``"3.10.0-wagfam-c0c7879"`` (CI) or
+        ``"3.10.0-wagfam-justin-20260503-c0c7879"`` (local).
+    """
+    # Import helpers from the sibling build_version.py script.
+    # sys.path already contains scripts/ when run from the project root
+    # (conftest.py adds it for tests; the Makefile invokes directly from
+    # the repo root where relative imports resolve correctly).
+    _scripts_dir = Path(__file__).parent
+    if str(_scripts_dir) not in sys.path:
+        sys.path.insert(0, str(_scripts_dir))
+    from build_version import compute_suffix, get_base_version  # noqa: PLC0415
+
+    root = repo_root if repo_root is not None else _REPO_ROOT
+    assert root is not None, "repo_root must be set"
+
+    is_ci = bool(os.environ.get("CI"))
+    suffix = compute_suffix(is_ci=is_ci)
+    base = get_base_version(root / "marquee" / "marquee.ino")
+    spa_version = base + suffix
+
+    dest = out_file if out_file is not None else root / "data" / "spa" / "version.json"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps({"spa_version": spa_version}) + "\n")
+
+    return spa_version
+
+
+def _cli_main() -> None:
+    root = _REPO_ROOT
+    assert root is not None, "cannot resolve repo root"
+    spa_version = write_spa_version(repo_root=root)
+    print(f"write_spa_version: spa_version = {spa_version}")
+
+
+if __name__ == "__main__":
+    _cli_main()

--- a/tests/scripts/test_write_spa_version.py
+++ b/tests/scripts/test_write_spa_version.py
@@ -1,0 +1,146 @@
+"""
+Tests for scripts/write_spa_version.py — full branch coverage.
+
+Strategy:
+  - write_spa_version() is imported and tested directly.
+  - Tests cover: CI vs local suffix, missing data/spa/ directory creation,
+    correct JSON output format, and the __main__ CLI entry point.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import write_spa_version
+
+ROOT = Path(__file__).parent.parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "write_spa_version.py"
+
+
+# ── write_spa_version() ───────────────────────────────────────────────────────
+
+
+class TestWriteSpaVersion:
+    def test_creates_version_json_in_default_location(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        sketch = tmp_path / "marquee" / "marquee.ino"
+        sketch.parent.mkdir(parents=True)
+        sketch.write_text('#define BASE_VERSION "3.10.0-wagfam"\n')
+        # data/spa/ should be created by the function
+        out_file = tmp_path / "data" / "spa" / "version.json"
+
+        with patch("build_version.get_git_hash", return_value="abc1234"):
+            result = write_spa_version.write_spa_version(
+                repo_root=tmp_path, out_file=out_file
+            )
+
+        assert result == "3.10.0-wagfam-abc1234"
+        assert out_file.exists()
+        data = json.loads(out_file.read_text())
+        assert data == {"spa_version": "3.10.0-wagfam-abc1234"}
+
+    def test_creates_parent_directory_if_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        sketch = tmp_path / "marquee" / "marquee.ino"
+        sketch.parent.mkdir(parents=True)
+        sketch.write_text('#define BASE_VERSION "1.2.3-wagfam"\n')
+        out_file = tmp_path / "deep" / "nested" / "dir" / "version.json"
+        assert not out_file.parent.exists()
+
+        with patch("build_version.get_git_hash", return_value="deadbee"):
+            write_spa_version.write_spa_version(repo_root=tmp_path, out_file=out_file)
+
+        assert out_file.exists()
+
+    def test_ci_suffix_is_hash_only(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        sketch = tmp_path / "marquee" / "marquee.ino"
+        sketch.parent.mkdir(parents=True)
+        sketch.write_text('#define BASE_VERSION "3.10.0-wagfam"\n')
+        out_file = tmp_path / "version.json"
+
+        with patch("build_version.get_git_hash", return_value="abc1234"):
+            result = write_spa_version.write_spa_version(
+                repo_root=tmp_path, out_file=out_file
+            )
+
+        assert result == "3.10.0-wagfam-abc1234"
+
+    def test_local_suffix_includes_user_date_hash(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CI", raising=False)
+        monkeypatch.setenv("USER", "alice")
+        sketch = tmp_path / "marquee" / "marquee.ino"
+        sketch.parent.mkdir(parents=True)
+        sketch.write_text('#define BASE_VERSION "3.10.0-wagfam"\n')
+        out_file = tmp_path / "version.json"
+
+        with patch("build_version.get_git_hash", return_value="abc1234"):
+            with patch("build_version.datetime") as mock_dt:
+                mock_dt.now.return_value.strftime.return_value = "20260503"
+                result = write_spa_version.write_spa_version(
+                    repo_root=tmp_path, out_file=out_file
+                )
+
+        assert result == "3.10.0-wagfam-alice-20260503-abc1234"
+        data = json.loads(out_file.read_text())
+        assert data["spa_version"] == "3.10.0-wagfam-alice-20260503-abc1234"
+
+    def test_output_file_ends_with_newline(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        sketch = tmp_path / "marquee" / "marquee.ino"
+        sketch.parent.mkdir(parents=True)
+        sketch.write_text('#define BASE_VERSION "3.10.0-wagfam"\n')
+        out_file = tmp_path / "version.json"
+
+        with patch("build_version.get_git_hash", return_value="abc1234"):
+            write_spa_version.write_spa_version(repo_root=tmp_path, out_file=out_file)
+
+        assert out_file.read_text().endswith("\n")
+
+    def test_uses_real_sketch_when_repo_root_not_given(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        import re
+        out_file = Path(pytest.importorskip("tempfile").mktemp(suffix=".json"))
+        try:
+            with patch("build_version.get_git_hash", return_value="abc1234"):
+                result = write_spa_version.write_spa_version(out_file=out_file)
+            assert re.match(r"^\d+\.\d+\.\d+-wagfam-abc1234$", result)
+        finally:
+            out_file.unlink(missing_ok=True)
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────────
+
+
+class TestCliMain:
+    def test_main_block_calls_cli_main(self, monkeypatch, capsys):
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr(sys, "argv", ["write_spa_version.py"])
+        # Patch write_spa_version so we don't actually touch data/spa/
+        with patch.object(write_spa_version, "write_spa_version", return_value="3.10.0-wagfam-abc1234"):
+            write_spa_version._cli_main()
+        out = capsys.readouterr().out
+        assert "3.10.0-wagfam-abc1234" in out
+
+    def test_module_main_guard_executes_cli_main(self, monkeypatch, capsys):
+        """The if __name__ == '__main__' block calls _cli_main()."""
+        monkeypatch.setenv("CI", "true")
+        monkeypatch.setattr(sys, "argv", ["write_spa_version.py"])
+        source = SCRIPT_PATH.read_text()
+        # Suppress disk writes; the exec'd write_spa_version() redefines the
+        # function in its own scope so we can't patch the module attribute —
+        # instead suppress via Path.write_text.
+        with patch("pathlib.Path.mkdir"), patch("pathlib.Path.write_text"):
+            with patch("build_version.get_git_hash", return_value="abc1234"):
+                exec(  # noqa: S102
+                    compile(source, str(SCRIPT_PATH), "exec"),
+                    {
+                        "__builtins__": __builtins__,
+                        "__file__": str(SCRIPT_PATH),
+                        "__name__": "__main__",
+                    },
+                )
+        out = capsys.readouterr().out
+        assert "spa_version" in out


### PR DESCRIPTION
## Summary

Adds version tracking for the SPA bundle — the groundwork needed for parts 3–5 to detect and trigger SPA upgrades.

- **`scripts/write_spa_version.py`** — new script that writes `data/spa/version.json` (e.g. `{"spa_version": "3.10.0-wagfam-c0c7879"}`) before `make buildfs` runs. Uses the same `BASE_VERSION` + git-suffix logic as `build_version.py` (CI: hash-only; local: user-date-hash). The `data/spa/` directory is created if absent.
- **`makefile`** — `buildfs` target now calls `python3 scripts/write_spa_version.py` before the Docker PIO step, so `version.json` is in the `data/` tree when `mklittlefs` runs.
- **`marquee/marquee.ino`** — new global `SPA_VERSION = "unknown"`. `setup()` reads `/spa/version.json` after `LittleFS.begin()` and parses the `spa_version` field via ArduinoJson v7. `GET /api/status` now includes `"spa_version"` alongside `"version"`.

Devices that haven't been updated yet (no `version.json` in their LittleFS) report `"spa_version": "unknown"` — a safe, detectable sentinel for parts 3–5.

## Test plan

- [x] `make test` passes (100 tests, 97% script coverage)
- [x] `make buildfs` runs `write_spa_version.py` and `data/spa/version.json` is created with the correct version string
- [x] Live device: build + flash firmware, then `make buildfs` + flash LittleFS via `/updatefs`; `GET /api/status` returns `"spa_version": "<version>"` matching the git hash at build time
- [x] Live device: device on old LittleFS (no `version.json`) reports `"spa_version": "unknown"` without crashing

Closes part 2 of #72.