### PR TITLE
Part 3 (issue #72): detect SPA updates from calendar config

### DIFF
--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -150,7 +150,9 @@ void WagFamBdayClient::whitespace(char c) {
 //       "eventToday": "",
 //       "latestVersion": "3.08.0-wagfam",
 //       "firmwareUrl": "http://example.com/marquee-v3.08.0.bin",
-//       "deviceName": "Kitchen Clock"
+//       "deviceName": "Kitchen Clock",
+//       "latestSpaVersion": "3.10.0-wagfam-abc1234",
+//       "spaFsUrl": "http://example.com/marquee-v3.10.0-littlefs.bin"
 //     }
 //   },
 //   {
@@ -191,6 +193,12 @@ void WagFamBdayClient::value(String value) {
     } else if (currentKey == "deviceName") {
       currentConfig.deviceNameValid = true;
       currentConfig.deviceName = value;
+    } else if (currentKey == "latestSpaVersion") {
+      currentConfig.latestSpaVersionValid = true;
+      currentConfig.latestSpaVersion = value;
+    } else if (currentKey == "spaFsUrl") {
+      currentConfig.spaFsUrlValid = true;
+      currentConfig.spaFsUrl = value;
     }
   } else if (currentKey == "message") {
     if (messageCounter >= 10) {

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -53,6 +53,10 @@ class WagFamBdayClient: public JsonListener {
       String firmwareUrl;
       boolean deviceNameValid;
       String deviceName;
+      boolean latestSpaVersionValid;
+      String latestSpaVersion;
+      boolean spaFsUrlValid;
+      String spaFsUrl;
     } configValues;
 
     WagFamBdayClient(String ApiKey, String JsonDataSourceUrl);

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -113,6 +113,8 @@ int bdayMessageIndex = 0;
 WagFamBdayClient::configValues serverConfig = {};
 String DEVICE_NAME = "";     // Human-friendly name assigned by server (not user-editable)
 String SPA_VERSION = "unknown"; // Read from /spa/version.json at boot; "unknown" if absent
+bool spaUpdateAvailable = false;
+String pendingSpaFsUrl = "";
 uint32_t todayDisplayMilliSecond = 0;
 uint32_t todayDisplayStartingLED = 0;
 
@@ -1082,6 +1084,18 @@ void getWeatherData() //client function to send/receive GET request data.
     }
   }
 
+  // Check for a remote SPA update pushed via the calendar config
+  if (serverConfig.latestSpaVersionValid && serverConfig.spaFsUrlValid
+      && serverConfig.latestSpaVersion != SPA_VERSION
+      && serverConfig.spaFsUrl.startsWith("http://")) {
+    spaUpdateAvailable = true;
+    pendingSpaFsUrl = serverConfig.spaFsUrl;
+    Serial.println("[SPA] Update available: server=" + serverConfig.latestSpaVersion + ", current=" + SPA_VERSION);
+  } else {
+    spaUpdateAvailable = false;
+    pendingSpaFsUrl = "";
+  }
+
   Serial.println("Version: " + String(VERSION));
   Serial.println();
   digitalWrite(externalLight, HIGH);
@@ -1551,6 +1565,9 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   ota["pending_url"] = otaPendingNewUrl;
   ota["safe_url"] = OTA_SAFE_URL;
   ota["pending_file_exists"] = LittleFS.exists(OTA_PENDING_FILE);
+
+  doc["spa_update_available"] = spaUpdateAvailable;
+  doc["spa_fs_url"] = pendingSpaFsUrl;
 
   sendJsonResponse(request, 200, doc);
 }

--- a/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
+++ b/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
@@ -219,6 +219,44 @@ void test_config_absent_fields_not_valid() {
     TEST_ASSERT_FALSE(cfg.dataSourceUrlValid);
     TEST_ASSERT_FALSE(cfg.apiKeyValid);
     TEST_ASSERT_FALSE(cfg.deviceNameValid);
+    TEST_ASSERT_FALSE(cfg.latestSpaVersionValid);
+    TEST_ASSERT_FALSE(cfg.spaFsUrlValid);
+}
+
+void test_config_latest_spa_version_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"latestSpaVersion\":\"3.10.0-wagfam-abc1234\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.latestSpaVersionValid);
+    TEST_ASSERT_EQUAL_STRING("3.10.0-wagfam-abc1234", cfg.latestSpaVersion.c_str());
+}
+
+void test_config_spa_fs_url_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"spaFsUrl\":\"http://example.com/marquee-v3.10.0-littlefs.bin\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.spaFsUrlValid);
+    TEST_ASSERT_EQUAL_STRING("http://example.com/marquee-v3.10.0-littlefs.bin", cfg.spaFsUrl.c_str());
+}
+
+void test_config_spa_fields_with_firmware_fields() {
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"config\":{"
+        "\"latestVersion\":\"3.10.0-wagfam\","
+        "\"firmwareUrl\":\"http://example.com/fw.bin\","
+        "\"latestSpaVersion\":\"3.10.0-wagfam-abc1234\","
+        "\"spaFsUrl\":\"http://example.com/littlefs.bin\""
+        "}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.latestVersionValid);
+    TEST_ASSERT_EQUAL_STRING("3.10.0-wagfam", cfg.latestVersion.c_str());
+    TEST_ASSERT_TRUE(cfg.firmwareUrlValid);
+    TEST_ASSERT_EQUAL_STRING("http://example.com/fw.bin", cfg.firmwareUrl.c_str());
+    TEST_ASSERT_TRUE(cfg.latestSpaVersionValid);
+    TEST_ASSERT_EQUAL_STRING("3.10.0-wagfam-abc1234", cfg.latestSpaVersion.c_str());
+    TEST_ASSERT_TRUE(cfg.spaFsUrlValid);
+    TEST_ASSERT_EQUAL_STRING("http://example.com/littlefs.bin", cfg.spaFsUrl.c_str());
 }
 
 void test_config_device_name_parsed() {
@@ -307,6 +345,9 @@ int main() {
     RUN_TEST(test_config_firmware_url_parsed);
     RUN_TEST(test_config_multiple_fields_in_one_block);
     RUN_TEST(test_config_absent_fields_not_valid);
+    RUN_TEST(test_config_latest_spa_version_parsed);
+    RUN_TEST(test_config_spa_fs_url_parsed);
+    RUN_TEST(test_config_spa_fields_with_firmware_fields);
     RUN_TEST(test_config_device_name_parsed);
     RUN_TEST(test_config_device_name_with_other_fields);
     RUN_TEST(test_config_with_messages_both_parsed);


### PR DESCRIPTION
## Summary

Implements Part 3 of [issue #72](https://github.com/jrwagz/marquee-scroller/issues/72) —
SPA update detection via the calendar JSON config block.

The wagfam-server now publishes `latestSpaVersion` and `spaFsUrl` alongside `latestVersion`
and `firmwareUrl` (wagfam-server PR #19, now merged). This PR wires up the device side.

**Changes:**

- **`WagFamBdayClient.h/.cpp`**: extends `configValues` struct with `latestSpaVersion` /
  `spaFsUrlValid` / `spaFsUrl` fields and parses them in the `value()` callback using the
  same `else if` pattern as the existing firmware OTA fields.
- **`marquee.ino`**: adds `spaUpdateAvailable` (bool) and `pendingSpaFsUrl` (String) globals;
  after each calendar refresh, compares `serverConfig.latestSpaVersion` to `SPA_VERSION` and
  sets the flags; both are exposed in `GET /api/status` as `spa_update_available` and
  `spa_fs_url`.
- **`test_wagfam_parser.cpp`**: three new test cases — `latestSpaVersion` parsing,
  `spaFsUrl` parsing, combined block with both firmware and SPA fields; also extends
  `test_config_absent_fields_not_valid` to assert the new fields default to false.

## Test plan

- [ ] `make test-native` — all 107 native C++ tests pass (including 3 new wagfam-parser cases)
- [ ] `make test-scripts` — all 100 script tests pass, 97% coverage
- [ ] Live device: build + flash firmware; confirm `GET /api/status` returns
  `"spa_update_available": false` and `"spa_fs_url": ""` before calendar fetch completes
- [ ] Live device: confirm that once the calendar server returns `latestSpaVersion` ≠
  `SPA_VERSION`, `/api/status` reports `"spa_update_available": true` and `"spa_fs_url"`
  is populated with the URL from the server
- [ ] Confirm that when versions match, `spa_update_available` goes back to `false`

## Depends on / context

- Part 1 PR: firmware-level `/updatefs` config preservation
- Part 2 PR: SPA version tracking via `/spa/version.json`
- wagfam-server PR #19 (merged): publishes `latestSpaVersion` + `spaFsUrl` in calendar JSON
- Part 4 (next): `POST /api/spa/update-from-url` endpoint that triggers the actual flash
- Part 5 (next): SPA update banner in the web UI