### PR TITLE
Add tests/e2e/ — Playwright SPA smoke + diagnostic scripts

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,6 +29,7 @@ help:
 	@echo "  test-native       - Run native C++ unit tests (no device required)"
 	@echo "  test-scripts      - Run Python tests for scripts/ with 100% coverage check"
 	@echo "  test-integration  - Run integration tests against a live device (requires HOST=<ip>)"
+	@echo "  test-e2e          - Browser-driven SPA smoke test (Playwright, requires HOST=<ip>)"
 	@echo "  test              - Run test-native + test-scripts"
 	@echo "  webui             - Build the SPA frontend (Vite/Preact) into data/spa/"
 	@echo "  webui-typecheck   - TypeScript-typecheck the SPA without emitting"
@@ -137,6 +138,23 @@ ifndef HOST
 	$(error HOST is required. Usage: make test-integration HOST=192.168.1.100 [PASSWORD=mypass])
 endif
 	pytest tests/integration/ -v --host $(HOST) $(if $(PASSWORD),--password $(PASSWORD),) $(if $(PORT),--port $(PORT),)
+
+# Browser-driven SPA smoke test against a live device. Requires HOST.
+# Lazily creates a venv at tests/e2e/.venv/ on first run and downloads
+# Chromium (~100MB cached at ~/Library/Caches/ms-playwright/). Not run
+# in CI — there's no live device in CI.
+tests/e2e/.venv/.installed: tests/e2e/requirements.txt
+	python3 -m venv tests/e2e/.venv
+	tests/e2e/.venv/bin/pip install --quiet -r tests/e2e/requirements.txt
+	tests/e2e/.venv/bin/playwright install chromium
+	touch tests/e2e/.venv/.installed
+
+.PHONY: test-e2e
+test-e2e: tests/e2e/.venv/.installed
+ifndef HOST
+	$(error HOST is required. Usage: make test-e2e HOST=192.168.8.161)
+endif
+	tests/e2e/.venv/bin/python tests/e2e/scripts/smoke.py http://$(HOST)/spa/
 
 .PHONY: build
 build: .passwd

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+out/
+__pycache__/
+*.pyc

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,63 @@
+# SPA end-to-end tests (Playwright)
+
+Browser-driven smoke + diagnostic scripts for the Preact SPA at `/spa/`.
+Intended for fast iteration on UI bugs against a live device — not part
+of CI (no live device in CI).
+
+## Setup
+
+One-time, host-side venv (≈100 MB for Chromium):
+
+```bash
+python3 -m venv tests/e2e/.venv
+tests/e2e/.venv/bin/pip install -r tests/e2e/requirements.txt
+tests/e2e/.venv/bin/playwright install chromium
+```
+
+Or via the `make` target which wraps the venv lifecycle:
+
+```bash
+make test-e2e HOST=192.168.8.161
+```
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `scripts/smoke.py` | Walks Status → Settings → Actions; captures console errors, page errors, HTTP 4xx/5xx; screenshots each tab. Returns non-zero if anything is flagged. |
+| `scripts/diagnose_settings.py` | Deep-dive on the Settings tab — tab-state DOM eval, network log, form-section presence check. Pattern to copy when investigating a specific tab. |
+
+Each script accepts an optional URL argument; default is
+`http://192.168.8.161/spa/`.
+
+```bash
+tests/e2e/.venv/bin/python tests/e2e/scripts/smoke.py
+tests/e2e/.venv/bin/python tests/e2e/scripts/smoke.py http://other-clock/spa/
+```
+
+Screenshots and outputs land in `tests/e2e/out/` (gitignored).
+
+## Iteration loop
+
+Describe a UI bug → write or adapt a script under `scripts/` that
+reproduces it → run → read screenshots and console/network logs → fix
+the SPA → re-run.
+
+## Gotchas
+
+**Don't trust `wait_for_load_state("networkidle")` for SPA tests.** It
+fires when the network goes quiet for 500ms, which can land in the gap
+between an `/api/*` response arriving and Preact re-rendering with the
+new state. The result: a screenshot of the loading placeholder with
+all the post-fetch DOM still missing. Always wait for a specific
+content selector instead — e.g. `page.locator(".form-section").first
+.wait_for(state="visible")` for the Settings tab.
+
+**Screenshots can leak credentials.** The Settings tab renders the
+OpenWeatherMap and Calendar API keys in plaintext input fields. Any
+full-page screenshot captures them. Before sharing screenshots in PRs,
+issues, or external chat, redact the secrets — either by overlaying a
+black rect via Playwright's `page.evaluate(() => { ... })` to clear the
+input values before screenshot, or by post-processing the PNG to mask
+the relevant regions. The `redact` helper in `scripts/_helpers.py`
+clears known-sensitive input values for diagnostic-screenshot use.

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,1 @@
+playwright>=1.40

--- a/tests/e2e/scripts/_helpers.py
+++ b/tests/e2e/scripts/_helpers.py
@@ -1,0 +1,35 @@
+"""Shared utilities for the SPA Playwright scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Repo-root-relative output directory. Each script writes screenshots /
+# logs here; gitignored.
+OUT = Path(__file__).resolve().parent.parent / "out"
+OUT.mkdir(parents=True, exist_ok=True)
+
+# CSS selectors of input fields that may contain credentials. The redact()
+# helper clears their .value before screenshotting so shared diagnostic
+# screenshots don't leak secrets.
+SENSITIVE_FIELD_IDS = (
+    "owm-key",
+    "wagfam-key",
+    "webpw",
+)
+
+
+def redact(page) -> None:
+    """Blank out input values that may hold credentials. Run BEFORE
+    `page.screenshot(...)` if the screenshot will be shared externally.
+    The change is purely client-side — values aren't posted unless the
+    user separately submits the form."""
+    page.evaluate(
+        """(ids) => {
+            for (const id of ids) {
+                const el = document.getElementById(id);
+                if (el) el.value = "[REDACTED]";
+            }
+        }""",
+        list(SENSITIVE_FIELD_IDS),
+    )

--- a/tests/e2e/scripts/diagnose_settings.py
+++ b/tests/e2e/scripts/diagnose_settings.py
@@ -1,0 +1,96 @@
+"""
+Deep-dive on the Settings tab — pattern to copy for tab-specific
+investigations.
+
+Captures: every /api/* request + status, every console message, the DOM
+state of the tab bar, and explicit waits for content (not networkidle).
+Saves a redacted screenshot to tests/e2e/out/settings-diagnostic.png.
+
+Usage:
+  python tests/e2e/scripts/diagnose_settings.py [URL]
+"""
+
+import sys
+
+from playwright.sync_api import sync_playwright
+
+from _helpers import OUT, redact
+
+URL = sys.argv[1] if len(sys.argv) > 1 else "http://192.168.8.161/spa/"
+
+console: list[str] = []
+requests: list[str] = []
+
+
+def main() -> int:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(viewport={"width": 480, "height": 800})
+        page = context.new_page()
+        page.on("console", lambda m: console.append(f"[{m.type}] {m.text}"))
+        page.on("pageerror", lambda e: console.append(f"[pageerror] {e}"))
+        page.on(
+            "response",
+            lambda r: requests.append(f"  {r.status} {r.request.method} {r.url}"),
+        )
+
+        page.goto(URL, timeout=15000)
+        page.locator(".stat-grid").wait_for(state="visible", timeout=10000)
+        print("=== After initial load ===")
+        print(_tab_state(page))
+
+        print("\n=== Click Settings ===")
+        before = len(requests)
+        page.get_by_role("button", name="Settings").click()
+        page.locator(".form-section").first.wait_for(state="visible", timeout=10000)
+
+        print("requests during/after click:")
+        for r in requests[before:]:
+            print(r)
+
+        print(_tab_state(page))
+
+        body_text = page.locator("main.container").inner_text()
+        print(f"main content text:\n{'-' * 50}\n{body_text}\n{'-' * 50}")
+
+        sections = page.evaluate(
+            """() => Array.from(document.querySelectorAll('.form-section h2'))
+                          .map(h => h.textContent)"""
+        )
+        print(f"form sections found: {sections}")
+
+        api_config = [r for r in requests if "/api/config" in r]
+        print(f"/api/config calls: {api_config}")
+
+        redact(page)
+        page.screenshot(
+            path=str(OUT / "settings-diagnostic.png"),
+            full_page=True,
+        )
+
+        print("\n=== Click Actions ===")
+        page.get_by_role("button", name="Actions").click()
+        page.locator(".action-card").first.wait_for(state="visible", timeout=10000)
+        print(_tab_state(page))
+
+        print("\n=== console output ===")
+        for c in console:
+            print(c)
+
+        browser.close()
+    return 0
+
+
+def _tab_state(page) -> str:
+    return "tabs: " + str(
+        page.evaluate(
+            """() => Array.from(document.querySelectorAll('.tab')).map(b => ({
+                label: b.textContent,
+                active: b.classList.contains('active')
+            }))"""
+        )
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/scripts/set_calendar_url.py
+++ b/tests/e2e/scripts/set_calendar_url.py
@@ -1,0 +1,140 @@
+"""
+End-to-end test: set the Calendar JSON URL via the SPA Settings form,
+click Save, verify persistence via /api/config.
+
+Exercises the full UI flow: tab switch → input edit → save-bar state
+transitions (idle → saving → ok) → POST /api/config → server roundtrip.
+
+Usage:
+  python tests/e2e/scripts/set_calendar_url.py [URL] [VALUE]
+
+Defaults:
+  URL   = http://192.168.8.161/spa/
+  VALUE = https://wagfam-server.azurewebsites.net/api/v1/calendar
+"""
+
+import json
+import sys
+import urllib.request
+
+from playwright.sync_api import sync_playwright
+
+from _helpers import OUT, redact
+
+SPA_URL = sys.argv[1] if len(sys.argv) > 1 else "http://192.168.8.161/spa/"
+CAL_URL = (
+    sys.argv[2]
+    if len(sys.argv) > 2
+    else "https://wagfam-server.azurewebsites.net/api/v1/calendar"
+)
+DEVICE_BASE = SPA_URL.rstrip("/").rsplit("/spa", 1)[0]
+
+
+def get_config_field(field: str) -> str:
+    """Fetch a single field from /api/config server-side (out-of-band
+    from the browser, so we know what's actually persisted)."""
+    with urllib.request.urlopen(f"{DEVICE_BASE}/api/config", timeout=8) as r:
+        cfg = json.loads(r.read())
+    return cfg.get(field, "<missing>")
+
+
+def main() -> int:
+    print(f"target: {SPA_URL}")
+    print(f"value:  {CAL_URL}")
+
+    before = get_config_field("wagfam_data_url")
+    print(f"\n[before] wagfam_data_url = {before!r}")
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(viewport={"width": 480, "height": 800})
+        page = context.new_page()
+        console: list[str] = []
+        failures: list[str] = []
+        page.on(
+            "console",
+            lambda m: console.append(f"[{m.type}] {m.text}")
+            if m.type in ("error", "warning")
+            else None,
+        )
+        page.on("pageerror", lambda e: console.append(f"[pageerror] {e}"))
+        page.on(
+            "response",
+            lambda r: failures.append(f"HTTP {r.status} {r.request.method} {r.url}")
+            if r.status >= 400
+            else None,
+        )
+
+        # Load + go to Settings.
+        page.goto(SPA_URL, timeout=15000)
+        page.get_by_role("button", name="Settings").click()
+        page.locator(".form-section").first.wait_for(state="visible", timeout=10000)
+        print("\n→ settings tab loaded")
+
+        # Find the Calendar JSON URL input. ID matches `id="wagfam-url"` from
+        # SettingsPage.tsx's TextRow.
+        cal_input = page.locator("#wagfam-url")
+        cal_input.wait_for(state="visible", timeout=5000)
+        existing = cal_input.input_value()
+        print(f"  current value in form: {existing!r}")
+
+        # Save button starts disabled (no draft). Confirm.
+        save_btn = page.get_by_role("button", name="Save")
+        assert save_btn.is_disabled(), "Save button should be disabled before any edits"
+        print("  ✓ Save button correctly disabled before edits")
+
+        # Fill the field.
+        cal_input.fill(CAL_URL)
+        print(f"\n→ filled #wagfam-url with target value")
+
+        # Save button should become enabled after the edit.
+        page.wait_for_function(
+            "document.querySelector('button.btn:not(.btn-danger)').disabled === false",
+            timeout=5000,
+        )
+        print("  ✓ Save button enabled after edit")
+
+        # Look for the unsaved-changes hint.
+        unsaved = page.locator(".save-bar .muted").last.text_content()
+        print(f"  unsaved hint: {unsaved!r}")
+
+        # Click Save and watch for the success state.
+        save_btn.click()
+        print("\n→ clicked Save")
+        # SettingsPage shows .save-ok ("Saved!") when the POST returns 200.
+        page.locator(".save-ok").wait_for(state="visible", timeout=10000)
+        ok_text = page.locator(".save-ok").text_content()
+        print(f"  ✓ {ok_text!r} appeared in save bar")
+
+        # Field should still show the new value, save button should disable again.
+        post_save_value = cal_input.input_value()
+        print(f"  field after save: {post_save_value!r}")
+        post_save_disabled = save_btn.is_disabled()
+        print(f"  save button disabled again: {post_save_disabled}")
+
+        redact(page)
+        page.screenshot(path=str(OUT / "set-calendar-url.png"), full_page=True)
+        browser.close()
+
+    after = get_config_field("wagfam_data_url")
+    print(f"\n[after]  wagfam_data_url = {after!r}")
+
+    if console:
+        print("\nconsole errors/warnings:")
+        for c in console:
+            print(f"  {c}")
+    if failures:
+        print("\nHTTP failures:")
+        for f in failures:
+            print(f"  {f}")
+
+    # Verdict.
+    if after == CAL_URL:
+        print(f"\n✓ device persists wagfam_data_url = {after!r}")
+        return 0
+    print(f"\n✗ persistence mismatch — server reports {after!r}, expected {CAL_URL!r}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e/scripts/smoke.py
+++ b/tests/e2e/scripts/smoke.py
@@ -1,0 +1,116 @@
+"""
+SPA smoke test: load /spa/, walk Status → Settings → Actions, capture
+console errors, page errors, network failures, and one screenshot per
+tab. Intended for fast iteration on UI bugs against a live device.
+
+Each tab waits for a known DOM signal (not networkidle) before
+screenshotting — networkidle fires when the network is quiet, which
+can land BEFORE Preact re-renders post-fetch, producing misleading
+"Loading…" screenshots.
+
+Usage:
+  python tests/e2e/scripts/smoke.py [URL]
+
+Default URL: http://192.168.8.161/spa/
+Outputs to tests/e2e/out/{status,settings,actions}.png
+
+Exit code: 0 if no errors detected, 1 if console/page/HTTP errors found.
+"""
+
+import sys
+
+from playwright.sync_api import ConsoleMessage, Request, sync_playwright
+
+from _helpers import OUT, redact
+
+URL = sys.argv[1] if len(sys.argv) > 1 else "http://192.168.8.161/spa/"
+
+console_msgs: list[str] = []
+page_errors: list[str] = []
+failed_requests: list[str] = []
+
+
+def on_console(msg: ConsoleMessage) -> None:
+    if msg.type in ("error", "warning"):
+        console_msgs.append(f"[{msg.type}] {msg.text}")
+
+
+def on_pageerror(err: Exception) -> None:
+    page_errors.append(str(err))
+
+
+def on_requestfailed(req: Request) -> None:
+    failed_requests.append(f"{req.method} {req.url} — {req.failure}")
+
+
+def on_response(res) -> None:
+    if res.status >= 400:
+        failed_requests.append(f"HTTP {res.status} {res.request.method} {res.url}")
+
+
+# Per-tab DOM signal that, once visible, means the tab content has
+# rendered with real data (not the loading placeholder).
+TABS = [
+    ("Status", ".stat-grid"),
+    ("Settings", ".form-section"),
+    ("Actions", ".action-card"),
+]
+
+
+def main() -> int:
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(viewport={"width": 480, "height": 800})
+        page = context.new_page()
+        page.on("console", on_console)
+        page.on("pageerror", on_pageerror)
+        page.on("requestfailed", on_requestfailed)
+        page.on("response", on_response)
+
+        print(f"→ navigating to {URL}")
+        page.goto(URL, timeout=15000)
+
+        for label, selector in TABS:
+            print(f"→ clicking {label}, waiting for {selector}")
+            page.get_by_role("button", name=label).click()
+            page.locator(selector).first.wait_for(state="visible", timeout=10000)
+            if label == "Settings":
+                redact(page)
+            page.screenshot(path=str(OUT / f"{label.lower()}.png"), full_page=True)
+
+        title = page.title()
+        h1 = page.locator("h1").first.text_content()
+        browser.close()
+
+    print()
+    print(f"page title: {title!r}")
+    print(f"page h1:    {h1!r}")
+    print()
+
+    if console_msgs:
+        print("CONSOLE MESSAGES (errors/warnings):")
+        for m in console_msgs:
+            print(f"  {m}")
+        print()
+    if page_errors:
+        print("PAGE ERRORS (uncaught JS):")
+        for e in page_errors:
+            print(f"  {e}")
+        print()
+    if failed_requests:
+        print("FAILED / 4xx / 5xx REQUESTS:")
+        for r in failed_requests:
+            print(f"  {r}")
+        print()
+
+    if not (console_msgs or page_errors or failed_requests):
+        print("✓ no console errors, page errors, or HTTP failures detected")
+    else:
+        print("✗ issues above")
+
+    print(f"\nscreenshots in {OUT}/")
+    return 1 if (console_msgs or page_errors or failed_requests) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds `tests/e2e/` — browser-driven smoke + diagnostic scripts for the Preact SPA at `/spa/`. Intended for fast iteration on UI bugs against a live device. **Not part of CI** (no live device in CI).

## Layout

```
tests/e2e/
├── README.md                       — setup + iteration loop
├── requirements.txt                — pinned playwright>=1.40
├── .gitignore                      — .venv/, out/
└── scripts/
    ├── _helpers.py                 — OUT path + redact() for credential masking
    ├── smoke.py                    — walk all 3 tabs, capture errors, screenshot each
    └── diagnose_settings.py        — deep-dive pattern (DOM eval, network log)
```

## Make integration

```bash
make test-e2e HOST=192.168.8.161
```

Lazily creates `tests/e2e/.venv/` on first run and downloads chromium (~100MB, cached at `~/Library/Caches/ms-playwright/`). Subsequent runs reuse the venv. Help text updated; deliberately **not** added to `make test` since CI has no live device.

## Two SPA-test gotchas baked into the patterns + README

1. **Don't use `wait_for_load_state("networkidle")` for SPA tests.** It fires when the network goes quiet for 500ms, which can land in the gap between an `/api/*` response arriving and Preact re-rendering with the new state. The result: screenshots of the loading placeholder with all the post-fetch DOM still missing, plus flaky assertions. `smoke.py` waits for tab-specific content selectors instead (`.stat-grid`, `.form-section`, `.action-card`).

2. **Screenshots leak credentials.** The Settings tab renders OWM and Calendar API keys as plaintext inputs; full-page screenshots capture them. `_helpers.redact()` blanks known-sensitive field IDs (`owm-key`, `wagfam-key`, `webpw`) before screenshot — purely client-side, doesn't affect device config. Add new field IDs to `SENSITIVE_FIELD_IDS` when adding new credential inputs to the SPA.

## Verification

```bash
$ make test-e2e HOST=192.168.8.161
→ navigating to http://192.168.8.161/spa/
→ clicking Status, waiting for .stat-grid
→ clicking Settings, waiting for .form-section
→ clicking Actions, waiting for .action-card

page title: 'WagFam CalClock'
page h1:    'WagFam CalClock'

✓ no console errors, page errors, or HTTP failures detected
```

Screenshots in `tests/e2e/out/`. Settings screenshot shows `[REDACTED]` for both API keys; everything else (display sliders, refresh inputs, weather toggles, Save button state) intact.

## Why now

Spent a chat session driving Playwright against my live clock to bug-bash the SPA. Two iteration-blocking issues surfaced (the networkidle race and the credential-leak), and I had no place to put the workspace that survived a `cd ..`. Promoting it from `/tmp/marquee-e2e/` to `tests/e2e/` makes the patterns reusable next time and the gotchas documented in-tree.

## Test plan

- [x] `make test-e2e HOST=192.168.8.161` — green against master HEAD
- [x] `tests/e2e/.venv/bin/python tests/e2e/scripts/diagnose_settings.py` — produces redacted screenshot at `tests/e2e/out/settings-diagnostic.png`
- [x] Verified `redact()` masks both `owm-key` and `wagfam-key` inputs (compared screenshots before/after)
- [x] CI still green (this PR doesn't change anything CI runs)