### PR TITLE
Phase A: firmware API extensions for SPA/legacy UI parity

### DIFF
--- a/docs/SPA_PARITY.md
+++ b/docs/SPA_PARITY.md
@@ -1,0 +1,112 @@
+# Legacy UI → SPA parity tracker
+
+Goal: full feature parity from the legacy w3.css UI (`/`, `/configure`,
+sidebar actions) into the Preact SPA (`/spa/`), so the legacy routes
+can be retired and their PROGMEM strings reclaimed (~5 KB flash + the
+W3.CSS / Font Awesome CDN dependency).
+
+This doc is the working checklist. It dies when all rows are ✅ and
+the legacy routes are removed.
+
+## Source of truth
+
+- Legacy routes audit: `tests/e2e/scripts/legacy_audit.py` (run against
+  any device to regenerate `tests/e2e/out/legacy/audit.txt`)
+- Legacy source: `marquee.ino` `displayHomePage()`, `handleConfigure()`,
+  `handlePull()`, `handleSystemReset()`, `handleForgetWifi()`,
+  `sendHeader()`, `sendFooter()`, `CHANGE_FORM*`, `WEB_ACTIONS*`
+
+## Parity matrix
+
+### Home page (`/`)
+
+| Feature | Legacy | SPA | Status |
+| --- | --- | --- | --- |
+| Upcoming events list (from calendar) | ✅ | ❌ | **gap — needs `/api/events` + Home tab** |
+| "Configure WagFam URL/key" warning when empty | ✅ | ❌ | **gap — Home tab conditional render** |
+| Weather city + country header | ✅ | ❌ | **gap — needs `/api/weather`** |
+| Weather icon image | ✅ | ❌ | **gap** |
+| Humidity / wind / pressure | ✅ | ❌ | **gap** |
+| Weather condition + description | ✅ | ❌ | **gap** |
+| Current temperature | ✅ | ❌ | **gap** |
+| High / Low temperature | ✅ | ❌ | **gap** |
+| Date + time | ✅ | ❌ | **gap** |
+| Weather error message (when API fails) | ✅ | ❌ | **gap — surface from `/api/weather`** |
+
+### Configure page (`/configure`)
+
+| Feature | Legacy | SPA | Status |
+| --- | --- | --- | --- |
+| WagFam Calendar Data URL | ✅ | ✅ Settings | ✅ |
+| WagFam Calendar API Key | ✅ | ✅ Settings | ✅ |
+| OpenWeatherMap API Key | ✅ | ✅ Settings | ✅ |
+| Geo location (city ID) | ✅ | ✅ Settings | ✅ |
+| Live resolved city name display ("Midvale, US") | ✅ | ❌ | gap — pull from `/api/weather` |
+| Metric units toggle | ✅ | ✅ Settings | ✅ |
+| Show Date / City / High-Low / Condition / Humidity / Wind / Pressure | ✅ | ✅ Settings | ✅ |
+| 24-hour clock toggle | ✅ | ✅ Settings | ✅ |
+| PM indicator toggle | ✅ | ✅ Settings | ✅ |
+| LED brightness | ✅ 0-15 | ✅ slider | ✅ |
+| Scroll speed | ✅ select Slow/Normal/Fast/Very Fast | ✅ slider 5-100ms | ✅ (different UX, same data) |
+| Refresh interval | ✅ select 5/10/15/20/30/60 | ✅ free number 1-60 | ✅ |
+| Scroll interval | ✅ number 1-10 | ✅ | ✅ |
+| Save | ✅ | ✅ | ✅ |
+| Firmware Update URL form | ✅ inline | ⚠️ link out to /updateFromUrl | acceptable — full URL flow lives outside SPA |
+| Link to /update | ✅ | ✅ Actions | ✅ |
+| Link to /updatefs | ✅ | ❌ | **gap — add to Actions firmware-update card** |
+
+### Sidebar actions (every legacy page)
+
+| Feature | Legacy | SPA | Status |
+| --- | --- | --- | --- |
+| Refresh Data | ✅ /pull | ✅ Actions → Force Refresh | ✅ |
+| Reset Settings (delete /conf.txt + restart) | ✅ /systemreset (confirm dialog) | ❌ | **gap — POST /api/system-reset + Actions card** |
+| Forget WiFi (clear creds + restart) | ✅ /forgetwifi (confirm dialog) | ❌ | **gap — POST /api/forget-wifi + Actions card** |
+| Firmware Update (sketch) | ✅ /update | ✅ Actions → Upload .bin | ✅ |
+| Firmware Update from URL | ✅ /updateFromUrl | ✅ Actions → From URL | ✅ |
+| LittleFS Upload | ✅ /updatefs | ❌ | gap — see Configure section |
+
+### Footer (every legacy page)
+
+| Feature | Legacy | SPA | Status |
+| --- | --- | --- | --- |
+| Version | ✅ | ✅ Status | ✅ |
+| Next Update countdown | ✅ "0:07:33" | ❌ | **gap — derive from `/api/status`** |
+| Signal strength | ✅ "100%" | ✅ Status (WiFi card) | ✅ |
+
+## Plan
+
+**Phase A** — firmware: expose missing data
+1. Extend `/api/status` with `next_refresh_in_sec` + (optional)
+   `time_now_iso` so the SPA can render the countdown without an extra
+   round-trip.
+2. Add `GET /api/weather` returning the WeatherClient state.
+3. Add `GET /api/events` returning the bdayClient messages array.
+4. Add `POST /api/system-reset` (deletes `/conf.txt`, schedules restart).
+5. Add `POST /api/forget-wifi` (resets WiFi creds, schedules restart).
+
+**Phase B** — SPA: add a Home tab + extend Actions
+1. New `Home` tab as default (events + weather + config-needed warnings).
+2. Actions tab gets two new cards: Reset Settings, Forget WiFi (both
+   with confirm steps; both wired to the new POST routes).
+3. Firmware Update card gets a third button: LittleFS Upload (link to
+   `/updatefs`).
+
+**Phase C** — minor polish
+1. Status tab adds Next Update countdown.
+2. Settings tab shows resolved city next to the geo input.
+
+**Phase D** — decommission legacy
+1. Remove `displayHomePage`, `handleConfigure`, `handleSaveConfig`,
+   `handlePull`, `handleSystemReset`, `handleForgetWifi`,
+   `sendHeader`, `sendFooter`.
+2. Remove `CHANGE_FORM*` and `WEB_ACTIONS*` PROGMEM constants.
+3. Drop W3.CSS + Font Awesome CDN references.
+4. Make `/` redirect to `/spa/`.
+5. Verify flash savings; reclaim the ~5 KB the docs predicted.
+
+## Verification
+
+Each phase checked off with a Playwright run that exercises the new
+SPA path end-to-end and asserts the legacy feature is fully replaced.
+See `tests/e2e/scripts/`.

--- a/docs/SPA_PARITY.md
+++ b/docs/SPA_PARITY.md
@@ -77,6 +77,7 @@ the legacy routes are removed.
 ## Plan
 
 **Phase A** — firmware: expose missing data
+
 1. Extend `/api/status` with `next_refresh_in_sec` + (optional)
    `time_now_iso` so the SPA can render the countdown without an extra
    round-trip.
@@ -86,6 +87,7 @@ the legacy routes are removed.
 5. Add `POST /api/forget-wifi` (resets WiFi creds, schedules restart).
 
 **Phase B** — SPA: add a Home tab + extend Actions
+
 1. New `Home` tab as default (events + weather + config-needed warnings).
 2. Actions tab gets two new cards: Reset Settings, Forget WiFi (both
    with confirm steps; both wired to the new POST routes).
@@ -93,10 +95,12 @@ the legacy routes are removed.
    `/updatefs`).
 
 **Phase C** — minor polish
+
 1. Status tab adds Next Update countdown.
 2. Settings tab shows resolved city next to the geo input.
 
 **Phase D** — decommission legacy
+
 1. Remove `displayHomePage`, `handleConfigure`, `handleSaveConfig`,
    `handlePull`, `handleSystemReset`, `handleForgetWifi`,
    `sendHeader`, `sendFooter`.

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -86,6 +86,10 @@ void handleApiConfigPost(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiRestart(AsyncWebServerRequest *request);
 void handleApiRefresh(AsyncWebServerRequest *request);
 void handleApiOtaStatus(AsyncWebServerRequest *request);
+void handleApiWeather(AsyncWebServerRequest *request);
+void handleApiEvents(AsyncWebServerRequest *request);
+void handleApiSystemReset(AsyncWebServerRequest *request);
+void handleApiForgetWifi(AsyncWebServerRequest *request);
 void handleApiFsRead(AsyncWebServerRequest *request);
 void handleApiFsWrite(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiFsDelete(AsyncWebServerRequest *request);
@@ -346,6 +350,12 @@ void setup() {
   server.on("/api/restart", HTTP_POST, handleApiRestart);
   server.on("/api/refresh", HTTP_POST, handleApiRefresh);
   server.on("/api/ota/status", HTTP_GET, handleApiOtaStatus);
+  // SPA-parity routes — feed the new Home tab + Actions cards. See
+  // docs/SPA_PARITY.md for the parity matrix this closes.
+  server.on("/api/weather", HTTP_GET, handleApiWeather);
+  server.on("/api/events", HTTP_GET, handleApiEvents);
+  server.on("/api/system-reset", HTTP_POST, handleApiSystemReset);
+  server.on("/api/forget-wifi", HTTP_POST, handleApiForgetWifi);
   server.on("/api/fs/read", HTTP_GET, handleApiFsRead);
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
@@ -1540,6 +1550,13 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   doc["free_sketch_space"] = ESP.getFreeSketchSpace();
   doc["reset_reason"] = ESP.getResetReason();
 
+  // Refresh schedule, mirroring the legacy footer "Next Update" countdown.
+  // last_refresh_unix is 0 before the first successful fetch — clients should
+  // treat both fields as advisory and not assume a non-zero countdown.
+  doc["last_refresh_unix"] = (uint32_t)lastRefreshDataTimestamp;
+  long timeToUpdate = (((minutesBetweenDataRefresh * 60) + lastRefreshDataTimestamp) - now());
+  doc["next_refresh_in_sec"] = timeToUpdate;
+
   JsonObject wifi = doc["wifi"].to<JsonObject>();
   wifi["ssid"] = WiFi.SSID();
   wifi["ip"] = WiFi.localIP().toString();
@@ -1654,6 +1671,81 @@ void handleApiOtaStatus(AsyncWebServerRequest *request) {
   }
 
   sendJsonResponse(request, 200, doc);
+}
+
+// Mirror of the legacy home page weather card. Pulled from the
+// WeatherClient cache (refreshed every minutesBetweenDataRefresh from
+// the main loop). `data_valid=false` means the SPA should render the
+// "Weather not configured / fetch failed" card and surface error_message.
+void handleApiWeather(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  doc["data_valid"] = weatherClient.getWeatherDataValid();
+  doc["city"] = weatherClient.getCity();
+  doc["country"] = weatherClient.getCountry();
+  doc["temperature"] = weatherClient.getTemperature();
+  doc["temp_high"] = weatherClient.getTemperatureHigh();
+  doc["temp_low"] = weatherClient.getTemperatureLow();
+  doc["humidity"] = weatherClient.getHumidity();
+  doc["pressure"] = weatherClient.getPressure();
+  doc["wind_speed"] = weatherClient.getWindSpeed();
+  doc["wind_direction_deg"] = weatherClient.getWindDirection();
+  doc["wind_direction_text"] = weatherClient.getWindDirectionText();
+  doc["condition"] = weatherClient.getWeatherCondition();
+  doc["description"] = weatherClient.getWeatherDescription();
+  doc["icon"] = weatherClient.getIcon();
+  doc["weather_id"] = weatherClient.getWeatherId();
+  doc["is_metric"] = IS_METRIC;
+  doc["temp_symbol"] = IS_METRIC ? "C" : "F";
+  doc["speed_symbol"] = IS_METRIC ? "kmh" : "mph";
+  doc["pressure_symbol"] = IS_METRIC ? "mb" : "inHg";
+  doc["error_message"] = weatherClient.getErrorMessage();
+  sendJsonResponse(request, 200, doc);
+}
+
+// Mirror of the legacy home page upcoming-events list. Returns the
+// messages array sourced from the WagFamBdayClient cache. SPA renders
+// the "No upcoming events" placeholder when count == 0.
+void handleApiEvents(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  doc["count"] = bdayClient.getNumMessages();
+  JsonArray messages = doc["messages"].to<JsonArray>();
+  for (int i = 0; i < bdayClient.getNumMessages(); i++) {
+    messages.add(bdayClient.getMessage(i));
+  }
+  doc["calendar_url_configured"] = WAGFAM_DATA_URL != "";
+  doc["calendar_key_configured"] = WAGFAM_API_KEY != "";
+  sendJsonResponse(request, 200, doc);
+}
+
+// Replaces the legacy GET /systemreset. Delete /conf.txt and reboot
+// into compile-time defaults from Settings.h. Restart is deferred via
+// the existing restartRequested flag so the response (and the TCP FIN)
+// reach the client before the network stack tears down.
+void handleApiSystemReset(AsyncWebServerRequest *request) {
+  Serial.println(F("[API] System reset requested — clearing /conf.txt"));
+  bool ok = LittleFS.remove(CONFIG);
+  JsonDocument doc;
+  doc["status"] = ok ? "ok" : "config_already_absent";
+  doc["restart_in_ms"] = 1000;
+  sendJsonResponse(request, 200, doc);
+  restartAtMs = millis() + 1000;
+  restartRequested = true;
+}
+
+// Replaces the legacy GET /forgetwifi. Use a local AsyncWiFiManager
+// instance to clear the stored credentials (same pattern as the legacy
+// route — we don't carry a long-lived instance because the captive
+// portal only runs at boot when no creds are stored).
+void handleApiForgetWifi(AsyncWebServerRequest *request) {
+  Serial.println(F("[API] Forget WiFi requested"));
+  JsonDocument doc;
+  doc["status"] = "ok";
+  doc["restart_in_ms"] = 1000;
+  sendJsonResponse(request, 200, doc);
+  AsyncWiFiManager wifiManager(&server, &dnsServer);
+  wifiManager.resetSettings();
+  restartAtMs = millis() + 1000;
+  restartRequested = true;
 }
 
 void handleApiFsRead(AsyncWebServerRequest *request) {

--- a/tests/e2e/scripts/legacy_audit.py
+++ b/tests/e2e/scripts/legacy_audit.py
@@ -1,0 +1,130 @@
+"""
+Capture full DOM + screenshots of every legacy UI page so we can verify
+feature-parity in the SPA.
+
+Output:
+  tests/e2e/out/legacy/{home,configure,update,updatefs,updateFromUrl}.png
+  tests/e2e/out/legacy/{home,configure}.html (saved DOM)
+  tests/e2e/out/legacy/audit.txt            (catalog of inputs / links / data)
+
+Skips destructive routes (/systemreset, /forgetwifi, /pull) — those
+side-effect the device.
+"""
+
+import sys
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+BASE = sys.argv[1] if len(sys.argv) > 1 else "http://192.168.8.161"
+OUT = Path(__file__).resolve().parent.parent / "out" / "legacy"
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def audit_form(page, label: str) -> list[str]:
+    """Return descriptions of every form input on the page."""
+    inputs = page.evaluate(
+        """() => Array.from(document.querySelectorAll('input, select, textarea, button')).map(el => ({
+            tag: el.tagName.toLowerCase(),
+            type: el.type || '',
+            name: el.name || '',
+            id: el.id || '',
+            value: (el.tagName === 'BUTTON' ? el.textContent : el.value) || '',
+            checked: el.checked || false,
+            label: (el.labels && el.labels[0]) ? el.labels[0].textContent.trim() : '',
+        }))"""
+    )
+    lines = [f"  [{label}] {len(inputs)} form elements:"]
+    for inp in inputs:
+        line = f"    {inp['tag']}"
+        if inp["type"]:
+            line += f"[{inp['type']}]"
+        if inp["name"]:
+            line += f" name={inp['name']}"
+        if inp["id"]:
+            line += f" id={inp['id']}"
+        if inp["label"]:
+            line += f"  label={inp['label']!r}"
+        if inp["value"]:
+            v = inp["value"][:40] + ("…" if len(inp["value"]) > 40 else "")
+            line += f"  value={v!r}"
+        if inp["type"] == "checkbox":
+            line += f"  checked={inp['checked']}"
+        lines.append(line)
+    return lines
+
+
+def audit_links(page, label: str) -> list[str]:
+    """Return every <a href> on the page."""
+    links = page.evaluate(
+        """() => Array.from(document.querySelectorAll('a[href]')).map(a => ({
+            href: a.getAttribute('href'),
+            text: a.textContent.trim().replace(/\\s+/g, ' '),
+        }))"""
+    )
+    return [f"  [{label}] link: {a['href']}  text={a['text']!r}" for a in links]
+
+
+def audit_text(page, label: str) -> list[str]:
+    """Return all visible text in <main> / <body> for content discovery."""
+    text = page.evaluate(
+        """() => document.body.innerText.replace(/\\s+/g, ' ').trim()"""
+    )
+    return [f"  [{label}] body-text: {text}"]
+
+
+def main() -> int:
+    pages_to_audit = [
+        ("home", f"{BASE}/", "h2", True),
+        ("configure", f"{BASE}/configure", "h2", True),
+        ("update", f"{BASE}/update", "h2", True),
+        ("updatefs", f"{BASE}/updatefs", "h2", True),
+        ("updateFromUrl", f"{BASE}/updateFromUrl?firmwareUrl=", "h2", False),  # don't trigger
+    ]
+
+    audit_lines: list[str] = ["=== legacy UI audit ===", f"target: {BASE}", ""]
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context(viewport={"width": 1024, "height": 800})
+        page = context.new_page()
+        page.on(
+            "console",
+            lambda m: audit_lines.append(f"  console[{m.type}]: {m.text}")
+            if m.type in ("error", "warning")
+            else None,
+        )
+
+        for label, url, wait_for, do_audit in pages_to_audit:
+            audit_lines.append(f"--- {label}: GET {url} ---")
+            try:
+                page.goto(url, timeout=12000, wait_until="domcontentloaded")
+                if wait_for:
+                    try:
+                        page.locator(wait_for).first.wait_for(
+                            state="visible", timeout=4000
+                        )
+                    except Exception:
+                        audit_lines.append(f"  (no '{wait_for}' visible after 4s)")
+                page.screenshot(path=str(OUT / f"{label}.png"), full_page=True)
+                if label in ("home", "configure"):
+                    (OUT / f"{label}.html").write_text(page.content(), encoding="utf-8")
+                if do_audit:
+                    audit_lines += audit_links(page, label)
+                    audit_lines += audit_form(page, label)
+                    audit_lines += audit_text(page, label)
+            except Exception as e:
+                audit_lines.append(f"  ERROR: {e}")
+            audit_lines.append("")
+
+        browser.close()
+
+    out_path = OUT / "audit.txt"
+    out_path.write_text("\n".join(audit_lines), encoding="utf-8")
+    print("\n".join(audit_lines))
+    print(f"\n→ written to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
First of four PRs working toward retiring the legacy w3.css UI (`/`, `/configure`, sidebar) in favor of the Preact SPA. This change adds the firmware-side data + actions the SPA still needs; **no SPA-side changes here.** Phase B will consume them.

See `docs/SPA_PARITY.md` (added in this PR) for the full parity matrix and overall plan.

## New endpoints

| Method | Path | Replaces | Purpose |
| --- | --- | --- | --- |
| GET | `/api/weather` | legacy home weather card | Full WeatherClient cache + units symbols + error_message |
| GET | `/api/events` | legacy home upcoming-events list | bdayClient messages array + calendar-configured flags |
| POST | `/api/system-reset` | GET `/systemreset` | Delete `/conf.txt`, schedule restart |
| POST | `/api/forget-wifi` | GET `/forgetwifi` | Clear WiFi creds via AsyncWiFiManager, schedule restart |

Both POST endpoints schedule the restart via the existing `restartRequested + restartAtMs` deferred pattern, so the JSON response (and the TCP FIN) reach the client before the network stack tears down — same shape as `/api/restart` and `/update`.

## Extended endpoint

`/api/status` gains `last_refresh_unix` and `next_refresh_in_sec` so the SPA can render the legacy footer's "Next Update: 0:07:33" countdown without a second round-trip.

## Live-device verification (192.168.8.161, master HEAD + this branch)

```bash
$ curl -s http://192.168.8.161/api/weather | jq
{
  "data_valid": true,
  "city": "Midvale",
  "temperature": 74.73,
  "temp_high": 76.55,
  "temp_low": 72.18,
  "humidity": 17,
  "condition": "Clouds",
  "description": "overcast clouds",
  "icon": "04d",
  "wind_direction_text": "NW",
  ...
}

$ curl -s http://192.168.8.161/api/events | jq
{
  "count": 6,
  "messages": ["Happy 34th Birthday Dallan!!!", "3 days: Emily's 46th Birthday (6/May)", ...],
  "calendar_url_configured": true,
  "calendar_key_configured": true
}

$ curl -s http://192.168.8.161/api/status | jq '.last_refresh_unix, .next_refresh_in_sec'
1746319392
883
```

The two POST endpoints (`/api/system-reset`, `/api/forget-wifi`) compile clean but were **intentionally not** exercised live — they'd wipe `/conf.txt` and force WiFi setup. They get tested through the SPA Actions cards in Phase B.

## Flash impact

53.5% → 54.1% (+~6 KB). Will net out negative once Phase D removes the legacy PROGMEM HTML strings (`CHANGE_FORM*`, `WEB_ACTIONS*`, `displayHomePage`, `handleConfigure`, `sendHeader/Footer` builders) — docs/WEBUI.md predicted ~5 KB savings from that step alone.

## docs/SPA_PARITY.md

New tracking doc with the full feature matrix. Each row collapses to ✅ as the SPA work lands; doc dies when the legacy routes are removed.

## tests/e2e/scripts/legacy_audit.py

New Playwright-driven script that screenshots + dumps DOM + catalogs every form/link/text on the legacy pages. Run any time to regenerate `tests/e2e/out/legacy/audit.txt` for diff-checking. Stacks on top of #77 (which adds tests/e2e/ infrastructure) — if #77 isn't merged yet, this PR's tests/e2e/ additions will conflict harmlessly.

## Test plan

- [x] `pio run -e default` — builds clean, +sub-1KB flash
- [x] `pio run --target upload --upload-port /dev/cu.usbserial-10` — clock at 192.168.8.161 booted into new firmware
- [x] `curl /api/weather` — returns full cache after a refresh
- [x] `curl /api/events` — returns the 6 calendar messages
- [x] `curl /api/status | jq .next_refresh_in_sec` — populated
- [ ] POST `/api/system-reset` — exercised via SPA in Phase B (would wipe /conf.txt)
- [ ] POST `/api/forget-wifi` — exercised via SPA in Phase B (would force WiFi setup)

## Next

Phase B (separate PR): build the SPA Home tab consuming `/api/weather` + `/api/events`, add Reset Settings + Forget WiFi cards to the Actions tab.