### PR TITLE
Add WAGFAM_AUTO_UPDATE_DISABLED build flag + dev env

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -1077,7 +1077,17 @@ void getWeatherData() //client function to send/receive GET request data.
     savePersistentConfig();
   }
 
-  // Check for a remote firmware update pushed via the calendar config
+  // Check for a remote firmware update pushed via the calendar config.
+  //
+  // Build with `-DWAGFAM_AUTO_UPDATE_DISABLED=1` to skip this branch. Useful
+  // when running a locally-built firmware that the calendar server doesn't
+  // know about yet (the server's published latestVersion would otherwise
+  // not match VERSION, and the device would auto-revert to the server's
+  // build at the next calendar refresh — losing local work). Default
+  // behavior is unchanged: the flag must be set explicitly to disable.
+#ifdef WAGFAM_AUTO_UPDATE_DISABLED
+  Serial.println(F("[OTA] Auto-update disabled at build time (WAGFAM_AUTO_UPDATE_DISABLED)"));
+#else
   if (serverConfig.latestVersionValid && serverConfig.firmwareUrlValid
       && serverConfig.latestVersion != String(VERSION)
       && serverConfig.firmwareUrl.startsWith("http://")
@@ -1093,6 +1103,7 @@ void getWeatherData() //client function to send/receive GET request data.
     // If we return here the update failed; continue normal operation
     }
   }
+#endif // WAGFAM_AUTO_UPDATE_DISABLED
 
   // Check for a remote SPA update pushed via the calendar config
   if (serverConfig.latestSpaVersionValid && serverConfig.spaFsUrlValid

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,22 @@ build_flags =
   #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
   '-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'
 
+# Local-development environment: same as `default`, but with the
+# auto-update branch disabled. Use this when running a locally-built
+# firmware that doesn't match the calendar server's published
+# `latestVersion` — without the flag the device auto-reverts to the
+# server's build at the next calendar refresh, losing local work.
+#
+#   pio run -e dev
+#   pio run -e dev --target upload --upload-port /dev/cu.usbserial-XX
+#
+# The default env (used by CI / releases) keeps auto-update on.
+[env:dev]
+extends = env:default
+build_flags =
+  ${env:default.build_flags}
+  -DWAGFAM_AUTO_UPDATE_DISABLED=1
+
 [env:native_test]
 platform = native
 framework =


### PR DESCRIPTION
## Summary
A locally-built firmware that doesn't match the calendar server's published `latestVersion` gets auto-reverted to the server's build at the next calendar refresh — silently losing the local work. Add a build-time flag so dev iteration doesn't get clobbered. Default behavior is unchanged: production builds using `[env:default]` still auto-update; only the new `[env:dev]` env disables it.

## Motivation

Hit this hard while iterating on Phase D. Each test cycle:
1. Build firmware locally with VERSION = `3.10.0-wagfam-dallan-...-a5c49b3` (or whatever local hash)
2. Serial-flash via `pio run --target upload`
3. Within ~30 seconds, calendar refresh fires
4. Server publishes `latestVersion: "3.10.0-wagfam-619dc50"` (master HEAD at last release)
5. String comparison says different → `performAutoUpdate(serverConfig.firmwareUrl)` → device flashes back to master
6. All Phase D testing wiped out

No way to iterate without this.

## Change

**`marquee.ino`** — wrap the auto-update check in an `#ifdef`:

```cpp
#ifdef WAGFAM_AUTO_UPDATE_DISABLED
  Serial.println(F("[OTA] Auto-update disabled at build time (WAGFAM_AUTO_UPDATE_DISABLED)"));
#else
  if (serverConfig.latestVersionValid && serverConfig.firmwareUrlValid
      && serverConfig.latestVersion != String(VERSION)
      && serverConfig.firmwareUrl.startsWith("http://")
      && otaConfirmAt == 0
      && millis() > OTA_CONFIRM_MS) {
    // ... existing performAutoUpdate path ...
  }
#endif
```

**`platformio.ini`** — new `[env:dev]` that extends `[env:default]` with the flag set:

```ini
[env:dev]
extends = env:default
build_flags =
  \${env:default.build_flags}
  -DWAGFAM_AUTO_UPDATE_DISABLED=1
```

CI / release builds use `[env:default]` which is unchanged. Developers use:

```bash
pio run -e dev --target upload --upload-port /dev/cu.usbserial-XX
```

## Verification

Flashed `[env:dev]` to clock at 192.168.8.161:

```
firmware: 3.10.0-wagfam-dallan-20260503-a5c49b3
sketch_size: 556304 (matches dev binary, not master's 564496)
uptime:   15s
```

Triggered `POST /api/refresh`, waited 25s, re-checked:

```
firmware: 3.10.0-wagfam-dallan-20260503-a5c49b3   ← UNCHANGED
uptime:   54s                                       ← climbed continuously
events count: 6                                     ← calendar fetch DID run
```

Calendar response's `latestVersion: "3.10.0-wagfam-619dc50"` mismatched VERSION as expected, but the auto-update branch was skipped and no reboot fired. Flag works.

## Companion gotcha (not fixed here, but worth knowing)

There's a related hazard in `checkOtaRollback()` that's NOT addressed by this flag. If `/ota_pending.txt` is left over from a prior auto-update attempt (which can happen if you serial-flash before the OTA's confirm timer fires), the rollback path runs at boot and re-flashes `safeUrl` — reverting your serial flash even though no auto-update fired in the new firmware.

I hit this once during Phase D testing. Workaround: after a serial flash that gets reverted, the rollback's own cleanup deletes `/ota_pending.txt`, so re-flashing a second time sticks. Long-term, `checkOtaRollback()` could probably check whether the running sketch's hash matches `safeUrl` before rolling back — but that's out of scope here.

## Test plan

- [x] `pio run -e dev` builds clean
- [x] `pio run -e default` still builds clean (unchanged)
- [x] `strings .pio/build/dev/firmware.bin | grep 'Auto-update disabled'` → present
- [x] `strings .pio/build/default/firmware.bin | grep 'Auto-update disabled'` → absent
- [x] Live device: dev binary flashed, calendar refresh triggered with version mismatch, no reboot fired
- [ ] Live device: confirm `[env:default]` build (master) still auto-updates correctly when version mismatches — this is the unchanged default path; if it was already working it still is