### PR TITLE
Part 5 (issue #72): SPA update banner + one-click upgrade flow

### DIFF
--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -63,3 +63,10 @@ export const postForgetWifi = (): Promise<ActionAck> =>
     method: "POST",
     headers: POST_HEADERS,
   });
+
+export const postSpaUpdateFromUrl = (url: string): Promise<ActionAck> =>
+  apiFetch<ActionAck>("/api/spa/update-from-url", {
+    method: "POST",
+    headers: POST_HEADERS,
+    body: JSON.stringify({ url }),
+  });

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -1,11 +1,16 @@
 import { useEffect } from "preact/hooks";
 import { signal, computed } from "@preact/signals";
-import { getStatus } from "../api";
+import { getStatus, getConfig, patchConfig, postSpaUpdateFromUrl } from "../api";
 import type { StatusData } from "../types";
 
 const status = signal<StatusData | null>(null);
 const loading = signal(false);
 const error = signal<string | null>(null);
+
+type SpaUpdateState = "idle" | "updating" | "error";
+const spaUpdateState = signal<SpaUpdateState>("idle");
+const spaUpdateStep = signal("");
+const spaUpdateError = signal("");
 
 const uptimeStr = computed(() => {
   if (!status.value) return "—";
@@ -23,9 +28,68 @@ const heapColor = computed(() => {
   return "var(--red)";
 });
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntilBack(): Promise<void> {
+  // Give the device time to start the flash and initiate reboot.
+  await delay(8_000);
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    try {
+      await getStatus();
+      return;
+    } catch {
+      // device still offline — keep polling
+    }
+    await delay(3_000);
+  }
+  throw new Error("Device did not come back online within 2 minutes.");
+}
+
+async function doSpaUpdate(fsUrl: string) {
+  if (!fsUrl) {
+    spaUpdateState.value = "error";
+    spaUpdateError.value = "No SPA update URL — try forcing a data refresh first.";
+    return;
+  }
+  spaUpdateState.value = "updating";
+  spaUpdateError.value = "";
+  try {
+    // Step 1 — snapshot current config (belt-and-suspenders; Part 4 already
+    // preserves /conf.txt during the FS flash, but re-POST ensures parity).
+    spaUpdateStep.value = "Saving current config…";
+    const savedConfig = await getConfig();
+
+    // Step 2 — queue the FS flash on the device
+    spaUpdateStep.value = "Requesting SPA flash…";
+    await postSpaUpdateFromUrl(fsUrl);
+
+    // Step 3 — wait for the device to reboot with the new FS image
+    spaUpdateStep.value = "Flashing SPA bundle — device will reboot shortly…";
+    await pollUntilBack();
+
+    // Step 4 — re-apply config in case the restore in Part 4 had any issues
+    spaUpdateStep.value = "Restoring config…";
+    await patchConfig(savedConfig);
+
+    // Step 5 — reload into the freshly-flashed SPA
+    spaUpdateStep.value = "Done — reloading…";
+    await delay(1_500);
+    window.location.reload();
+  } catch (e) {
+    spaUpdateState.value = "error";
+    spaUpdateError.value = String(e);
+  }
+}
+
 export function StatusPage() {
   useEffect(() => {
     async function load() {
+      // Don't poll while an update is in flight — the device is intentionally
+      // offline during the flash, and we reload on completion anyway.
+      if (spaUpdateState.value !== "idle") return;
       loading.value = true;
       try {
         status.value = await getStatus();
@@ -46,11 +110,53 @@ export function StatusPage() {
   return (
     <div>
       {loading.value && !d && <p class="muted">Loading…</p>}
-      {error.value && <p class="error-msg">{error.value}</p>}
+      {error.value && spaUpdateState.value === "idle" && (
+        <p class="error-msg">{error.value}</p>
+      )}
+
+      {/* SPA update available banner */}
+      {d?.spa_update_available && d?.spa_fs_url && spaUpdateState.value === "idle" && (
+        <div class="update-banner">
+          <div style={{ flex: 1 }}>
+            <span class="badge">SPA Update Available</span>
+            <span class="muted" style={{ marginLeft: "0.5rem" }}>
+              Current: {d.spa_version || "unknown"}
+            </span>
+          </div>
+          <button class="btn" onClick={() => doSpaUpdate(d.spa_fs_url!)}>
+            Update SPA
+          </button>
+        </div>
+      )}
+
+      {/* SPA update in progress */}
+      {spaUpdateState.value === "updating" && (
+        <div class="update-banner">
+          <span class="spinner" />
+          <span style={{ flex: 1 }}>{spaUpdateStep.value}</span>
+        </div>
+      )}
+
+      {/* SPA update error */}
+      {spaUpdateState.value === "error" && (
+        <div class="update-banner update-banner-error">
+          <span class="error-msg" style={{ flex: 1 }}>{spaUpdateError.value}</span>
+          <button
+            class="btn btn-danger"
+            onClick={() => (spaUpdateState.value = "idle")}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
       {d && (
         <div class="stat-grid">
           <StatCard label="Device" value={d.device_name || d.chip_id} />
           <StatCard label="Version" value={d.version} />
+          {d.spa_version && (
+            <StatCard label="SPA Version" value={d.spa_version} />
+          )}
           <StatCard label="Uptime" value={uptimeStr.value} />
           <StatCard label="Reset reason" value={d.reset_reason} />
 

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -410,6 +410,24 @@ input[type="checkbox"].toggle:checked::after {
   margin-top: 0.1rem;
 }
 
+/* ── Update banner ── */
+
+.update-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-radius: var(--radius);
+}
+
+.update-banner-error {
+  border-color: color-mix(in srgb, var(--red) 30%, transparent);
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+}
+
 /* ── Spinner ── */
 
 @keyframes spin { to { transform: rotate(360deg); } }

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -30,6 +30,10 @@ export interface StatusData {
   next_refresh_in_sec?: number;
   wifi: WifiStatus;
   ota: OtaStatus;
+  // Set by issue #72 parts 2-3 (firmware ≥ 3.10.3-wagfam).
+  spa_version?: string;
+  spa_update_available?: boolean;
+  spa_fs_url?: string;
 }
 
 export interface WeatherData {


### PR DESCRIPTION
## Summary

Closes the last SPA-side item in issue #72: detection and one-click upgrade of the SPA bundle when a newer version is available.

- **`types.ts`** — adds optional `spa_version`, `spa_update_available`, and `spa_fs_url` to `StatusData` (all three are emitted by firmware ≥ 3.10.3-wagfam per Parts 2–3)
- **`api.ts`** — adds `postSpaUpdateFromUrl(url)` wrapper for `POST /api/spa/update-from-url` (Part 4)
- **`styles.css`** — adds `.update-banner` (blue accent strip) and `.update-banner-error` modifier
- **`StatusPage.tsx`** — SPA Version stat card + full update flow:

### Update flow (5 steps, all in-session — no localStorage)

1. `GET /api/config` — snapshot current config
2. `POST /api/spa/update-from-url` — queue the FS flash on the device (returns 202 immediately)
3. Poll `GET /api/status` every 3 s (up to 2 min) until the device comes back after its reboot
4. `POST /api/config` — re-apply the snapshot (belt-and-suspenders over Part 4's built-in conf restore)
5. `window.location.reload()` — land on the freshly-flashed SPA

The auto-refresh interval is suppressed while an update is in flight so connection errors during the intentional reboot don't surface as status-page errors.

## Test plan

- [x] Build passes (`make webui`) — no TypeScript errors
- [x] `make test` — 100 passed, 1 skipped (unchanged)
- [ ] On a device with `spa_update_available: false` — Status tab shows only the SPA Version card, no banner
- [ ] With a mock/real `spa_update_available: true` + `spa_fs_url` — banner appears with current SPA version and "Update SPA" button
- [ ] Clicking "Update SPA" walks through all 5 steps with visible step labels; page reloads into new SPA on success
- [ ] Network failure during polling surfaces as an error banner with "Dismiss" button; dismissing returns to idle state
- [ ] Empty `spa_fs_url` edge case shows error immediately without calling the endpoint