### PR TITLE
Part 6 (issue #72): Auto-publish SPA FS version/URL to server on release

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -158,14 +158,16 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: docker/setup-buildx-action@v4
 
-      - name: Publish firmware binary to simple-web-server image
+      - name: Publish firmware and FS binaries to simple-web-server image
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
           VERSION=$(cat artifacts/VERSION.txt)
-          FILENAME="marquee-scroller-${VERSION}.bin"
-          cp artifacts/firmware.bin "${FILENAME}"
-          printf 'FROM jrwagz/simple-web-server:latest\nCOPY %s /usr/local/apache2/htdocs/%s\n' \
-            "${FILENAME}" "${FILENAME}" > Dockerfile.firmware
+          FW_FILENAME="marquee-scroller-${VERSION}.bin"
+          FS_FILENAME="marquee-scroller-${VERSION}-littlefs.bin"
+          cp artifacts/firmware.bin "${FW_FILENAME}"
+          cp artifacts/littlefs.bin "${FS_FILENAME}"
+          printf 'FROM jrwagz/simple-web-server:latest\nCOPY %s /usr/local/apache2/htdocs/%s\nCOPY %s /usr/local/apache2/htdocs/%s\n' \
+            "${FW_FILENAME}" "${FW_FILENAME}" "${FS_FILENAME}" "${FS_FILENAME}" > Dockerfile.firmware
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --tag jrwagz/simple-web-server:latest \
@@ -206,7 +208,7 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_WAGFAM_SERVER_CREDENTIALS }}
 
-      - name: Notify wagfam-server of new firmware version
+      - name: Notify wagfam-server of new firmware and SPA versions
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: azure/cli@v2
         with:
@@ -216,7 +218,9 @@ jobs:
               --resource-group wagfam-server-group \
               --settings \
                 WAGFAM_FIRMWARE_VERSION="${{ env.FIRMWARE_VERSION }}" \
-                WAGFAM_FIRMWARE_URL="http://files-jrwagz.azurewebsites.net/marquee-scroller-${{ env.FIRMWARE_VERSION }}.bin"
+                WAGFAM_FIRMWARE_URL="http://files-jrwagz.azurewebsites.net/marquee-scroller-${{ env.FIRMWARE_VERSION }}.bin" \
+                WAGFAM_SPA_VERSION="${{ env.FIRMWARE_VERSION }}" \
+                WAGFAM_SPA_FS_URL="http://files-jrwagz.azurewebsites.net/marquee-scroller-${{ env.FIRMWARE_VERSION }}-littlefs.bin"
 
       - name: Wait for wagfam-server restart and restore backup
         if: >-
@@ -225,20 +229,21 @@ jobs:
         env:
           WAGFAM_API_KEY: ${{ secrets.WAGFAM_API_KEY }}
         run: |
-          echo "Polling calendar endpoint until new firmware version is confirmed (up to 5 min)..."
+          echo "Polling calendar endpoint until new firmware and SPA versions are confirmed (up to 5 min)..."
           for i in $(seq 1 30); do
-            REPORTED=$(curl -sf \
+            CALENDAR=$(curl -sf \
                 -H "Authorization: token ${WAGFAM_API_KEY}" \
-                "https://wagfam-server.azurewebsites.net/api/v1/calendar" \
-                | jq -r '.[0].config.latestVersion // ""' 2>/dev/null) || REPORTED=""
-            if [ "$REPORTED" = "${FIRMWARE_VERSION}" ]; then
-              echo "Server is reporting new firmware version ${REPORTED}."
+                "https://wagfam-server.azurewebsites.net/api/v1/calendar" 2>/dev/null) || CALENDAR=""
+            REPORTED=$(echo "$CALENDAR" | jq -r '.[0].config.latestVersion // ""' 2>/dev/null) || REPORTED=""
+            SPA_REPORTED=$(echo "$CALENDAR" | jq -r '.[0].config.latestSpaVersion // ""' 2>/dev/null) || SPA_REPORTED=""
+            if [ "$REPORTED" = "${FIRMWARE_VERSION}" ] && [ "$SPA_REPORTED" = "${FIRMWARE_VERSION}" ]; then
+              echo "Server is reporting new firmware version ${REPORTED} and SPA version ${SPA_REPORTED}."
               break
             fi
-            echo "Attempt ${i}/30: got '${REPORTED}', retrying in 10s..."
+            echo "Attempt ${i}/30: firmware='${REPORTED}' spa='${SPA_REPORTED}', retrying in 10s..."
             sleep 10
             if [ "$i" -eq 30 ]; then
-              echo "ERROR: Server did not report firmware version ${FIRMWARE_VERSION} within 300s" >&2
+              echo "ERROR: Server did not report firmware+SPA version ${FIRMWARE_VERSION} within 300s" >&2
               exit 1
             fi
           done

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.10.0-wagfam"
+#define BASE_VERSION "3.11.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else


### PR DESCRIPTION
## Summary

Closes the final part of #72 by extending the release CI pipeline to automatically push `WAGFAM_SPA_VERSION` and `WAGFAM_SPA_FS_URL` to the wagfam-server alongside the existing firmware vars whenever a new version tag is pushed.

- **Extend Docker image**: `littlefs.bin` is now copied into the `simple-web-server` image alongside `firmware.bin`, making `marquee-scroller-<VERSION>-littlefs.bin` available at `files-jrwagz.azurewebsites.net`
- **Set Azure app settings**: "Notify wagfam-server" step now also sets `WAGFAM_SPA_VERSION` and `WAGFAM_SPA_FS_URL` so the server publishes `latestSpaVersion`/`spaFsUrl` in its calendar JSON response
- **Extend post-restart polling**: The backup-restore wait loop now checks both `latestVersion` and `latestSpaVersion` in the calendar endpoint before declaring the server ready and restoring the backup
- **Version bump**: `BASE_VERSION` → `3.11.0-wagfam`

## Test plan

- [x] Verify CI passes on this branch (lint, test, build, webui steps)
- [ ] Tag a release and confirm the "Publish firmware and FS binaries" step uploads both `.bin` and `-littlefs.bin` to the Docker image
- [ ] Confirm `files-jrwagz.azurewebsites.net/marquee-scroller-<VERSION>-littlefs.bin` is reachable after deploy
- [ ] Confirm wagfam-server calendar JSON includes `latestSpaVersion` and `spaFsUrl` after the Azure settings update
- [ ] Confirm the polling step succeeds when both fields match the release version