### PR TITLE
Fix ERR_TOO_MANY_REDIRECTS on /spa/index.html; bump to 3.11.2 (issue #89)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,12 +127,14 @@ the LittleFS partition was empty. Two implications:
    runtime fallback: if the file is missing, render a clear error page
    that names the deploy step the user is missing, not a 302 to `/`.
    The pattern is `handleNotFound()` in `marquee.ino` — it first checks
-   whether `/spa/index.html` exists on LittleFS. If the SPA is installed,
-   it redirects to `/spa/index.html` (handles client-side routes and the
-   ESPAsyncWebServer serveStatic default-file bug for bare `/spa/` URLs).
-   If the SPA is absent, it returns a "SPA bundle not installed" page
-   that explicitly links `/updatefs` as the easiest fix, instead of
-   falling through to the legacy redirect-home behavior.
+   whether `/spa/index.html` exists on LittleFS. If the SPA is installed
+   and the request is not already `/spa/index.html`, it redirects to
+   `/spa/index.html` so the JS router can handle client-side routes (e.g.
+   `/spa/settings`). If the SPA is absent, it returns a "SPA bundle not
+   installed" page that explicitly links `/updatefs` as the easiest fix,
+   instead of falling through to the legacy redirect-home behavior.
+   `serveStatic` with `.setDefaultFile("index.html")` handles bare `/spa`
+   and `/spa/` directly — no explicit redirect routes are needed for those.
 **When dropping a third-party route registrar, audit every HTTP method it
 registered.** Libraries that "set up" an endpoint often register more than
 one method on it. The canonical example: ESP8266HTTPUpdateServer used to

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "3.11.1-wagfam"
+#define BASE_VERSION "3.11.2-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -526,21 +526,12 @@ void setup() {
       }
     });
 
-  // Redirect bare /spa and /spa/ to /spa/index.html. ESPAsyncWebServer's
-  // serveStatic default-file resolution does not fire reliably for bare
-  // directory requests on ESP8266/LittleFS — the handler's canHandle() returns
-  // false and the request falls through to onNotFound. These explicit routes
-  // take priority over serveStatic and ensure both /spa and /spa/ load the SPA.
-  server.on("/spa", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->redirect("/spa/index.html");
-  });
-  server.on("/spa/", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->redirect("/spa/index.html");
-  });
-
   // SPA frontend — bundle is built into data/spa/ by `make webui` and flashed
   // to LittleFS. AsyncWebServer's serveStatic auto-detects .gz siblings and
   // serves them with Content-Encoding: gzip when the client advertises it.
+  // setDefaultFile serves /spa/index.html for bare /spa and /spa/ requests
+  // via the _isDir path in AsyncStaticWebHandler::_getFile() — no explicit
+  // redirect routes needed for those.
   // Cache for 10 min — short enough that a UI bugfix lands within a reasonable
   // window after reflashing the FS.
   server.serveStatic("/spa", LittleFS, "/spa/")
@@ -1265,10 +1256,11 @@ void redirectHome(AsyncWebServerRequest *request) {
 // falls through to the legacy redirect-home behavior.
 void handleNotFound(AsyncWebServerRequest *request) {
   if (request->url().startsWith("/spa")) {
-    if (LittleFS.exists(F("/spa/index.html"))) {
-      // SPA is installed — a specific sub-path wasn't found, or this is a
-      // client-side route. Redirect to the SPA root and let the JS router
-      // handle it.
+    if (LittleFS.exists(F("/spa/index.html")) && request->url() != "/spa/index.html") {
+      // SPA is installed — a client-side route that doesn't exist as a real
+      // file fell through. Redirect to the SPA root and let the JS router
+      // handle it. Guard against /spa/index.html itself to avoid a redirect
+      // loop (AsyncCallbackWebHandler prefix-matches /spa against /spa/*).
       request->redirect("/spa/index.html");
       return;
     }


### PR DESCRIPTION
Closes #89

## Root cause

PR #88 added `server.on("/spa", HTTP_GET, ...)` to redirect bare `/spa` and
`/spa/` to `/spa/index.html`. However, `AsyncCallbackWebHandler::canHandle()`
uses prefix-match semantics (from
[WebHandlerImpl.h:121](https://github.com/jrwagz/marquee-scroller/blob/master/.pio/libdeps/default/ESPAsyncWebServer-esphome/src/WebHandlerImpl.h#L121)):

```cpp
else if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))
    return false;
```

A handler registered for `/spa` matches any URL that equals `/spa` **or
starts with `/spa/`**. This means the redirect handler also matched
`/spa/index.html` — redirecting it back to itself — infinite loop.

The fix in PR #88 was also unnecessary: `serveStatic` with
`.setDefaultFile("index.html")` already handles bare `/spa` and `/spa/`
correctly. When the static path ends with `/`, `_isDir = true` is set in
the constructor; `AsyncStaticWebHandler::_getFile()` then skips the
direct-file check for empty/trailing-slash paths and goes straight to the
default file (`/spa/index.html`). No explicit redirect routes are needed.

## Fix

1. **Remove** the two `server.on("/spa", ...)` redirect routes introduced in #88
2. **Guard** `handleNotFound` so it never redirects `/spa/index.html` to itself
   (belt-and-suspenders: prevents a future loop if `serveStatic` ever fails to
   serve `/spa/index.html` for some reason)
3. **Correct** CLAUDE.md — remove the false claim about a `serveStatic`
   default-file bug; document what actually happens

## Verified on device (192.168.13.106, running 3.11.2)

```
GET /spa             → 200  (served directly, no redirect)
GET /spa/            → 200  (served directly, no redirect)
GET /spa/index.html  → 200  (served directly, no redirect, no loop)
```

`curl -sL --max-redirs 5` confirms zero intermediate redirects for all three.

## Test plan

- [x] `GET /spa/index.html` returns 200 — no redirect loop (issue #89)
- [x] `GET /spa` and `GET /spa/` return 200 directly
- [x] Verify on device after OTA: SPA loads in browser from all three URLs
- [ ] Navigate to a client-side route directly (e.g. `/spa/settings`) — verify
  it still redirects to `/spa/index.html` and the SPA loads
- [ ] Verify that without SPA installed, `/spa/` still shows the "SPA bundle not
  installed" 404 page