### PR TITLE
Show available SPA version alongside current in update banner

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "4.0.0-wagfam"
+#define BASE_VERSION "4.0.1-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -112,6 +112,7 @@ String DEVICE_NAME = "";     // Human-friendly name assigned by server (not user
 String SPA_VERSION = "unknown"; // Read from /spa/version.json at boot; "unknown" if absent
 bool spaUpdateAvailable = false;
 String pendingSpaFsUrl = "";
+String pendingSpaVersion = ""; // Server-published latest SPA version when an update is pending
 bool otaFsFromUrlRequested = false;
 String pendingOtaFsUrl = "";
 uint32_t todayDisplayMilliSecond = 0;
@@ -1071,10 +1072,12 @@ void getWeatherData() //client function to send/receive GET request data.
       && serverConfig.spaFsUrl.startsWith("http://")) {
     spaUpdateAvailable = true;
     pendingSpaFsUrl = serverConfig.spaFsUrl;
+    pendingSpaVersion = serverConfig.latestSpaVersion;
     Serial.println("[SPA] Update available: server=" + serverConfig.latestSpaVersion + ", current=" + SPA_VERSION);
   } else {
     spaUpdateAvailable = false;
     pendingSpaFsUrl = "";
+    pendingSpaVersion = "";
   }
 
   Serial.println("Version: " + String(VERSION));
@@ -1442,6 +1445,7 @@ void handleApiStatus(AsyncWebServerRequest *request) {
 
   doc["spa_update_available"] = spaUpdateAvailable;
   doc["spa_fs_url"] = pendingSpaFsUrl;
+  doc["spa_latest_version"] = pendingSpaVersion;
 
   sendJsonResponse(request, 200, doc);
 }

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -121,6 +121,9 @@ export function StatusPage() {
             <span class="badge">SPA Update Available</span>
             <span class="muted" style={{ marginLeft: "0.5rem" }}>
               Current: {d.spa_version || "unknown"}
+              {d.spa_latest_version && (
+                <> {"→ Available: "}{d.spa_latest_version}</>
+              )}
             </span>
           </div>
           <button class="btn" onClick={() => doSpaUpdate(d.spa_fs_url!)}>

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -34,6 +34,7 @@ export interface StatusData {
   spa_version?: string;
   spa_update_available?: boolean;
   spa_fs_url?: string;
+  spa_latest_version?: string;
 }
 
 export interface WeatherData {


### PR DESCRIPTION
## Summary

When a SPA update is pending, the update banner on the Status page now shows **both** the current version and the version that's available to install, instead of just the current one.

Before:
> **SPA Update Available** &nbsp; Current: 4.0.0-wagfam

After:
> **SPA Update Available** &nbsp; Current: 4.0.0-wagfam → Available: 4.0.1-wagfam

## Changes

**Firmware** (`marquee/marquee.ino`)
- Add `pendingSpaVersion` global, set/cleared on the same code path as `pendingSpaFsUrl` when a SPA update is detected from the calendar config (the server-published `latestSpaVersion` was already parsed into `serverConfig.latestSpaVersion`; this just retains it).
- Expose it via `GET /api/status` as `spa_latest_version`.
- Bump `BASE_VERSION` 4.0.0-wagfam → 4.0.1-wagfam (patch).

**SPA** (`webui/src/`)
- Add optional `spa_latest_version?: string` to `StatusData`.
- `StatusPage.tsx` appends `→ Available: <version>` to the existing banner muted-text span when `spa_latest_version` is set. Backwards-compatible: older firmware that omits the field renders the original "Current: …" text only.

No new components, no new styles — reuses the existing banner row.

## Test plan

- [x] `make webui-typecheck` passes
- [x] `make webui` builds cleanly (45 KB raw / 15 KB gzip — unchanged)
- [ ] Flash a device, wait for the calendar fetch to detect a SPA update, confirm banner shows both versions
- [ ] Confirm an older firmware build (without `spa_latest_version`) still renders the banner with "Current: …" only