### PR TITLE
Fix SPA update silently failing to apply; surface errors in UI

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "4.0.1-wagfam"
+#define BASE_VERSION "4.0.2-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -115,6 +115,14 @@ String pendingSpaFsUrl = "";
 String pendingSpaVersion = ""; // Server-published latest SPA version when an update is pending
 bool otaFsFromUrlRequested = false;
 String pendingOtaFsUrl = "";
+
+// SPA-FS OTA status, surfaced via /api/status so the SPA UI can detect
+// silent failures of the deferred flash run by doOtaFsFlash(). Value
+// progresses idle → queued → downloading → flashing → restoring-conf,
+// then reset to idle on the post-reboot setup() (RAM-only state). On
+// any failure point, set to "failed" with a diagnostic in spaOtaError.
+String spaOtaStatus = "idle";
+String spaOtaError = "";
 uint32_t todayDisplayMilliSecond = 0;
 uint32_t todayDisplayStartingLED = 0;
 
@@ -799,11 +807,34 @@ void performAutoUpdate(const String &firmwareUrl) {
   Serial.printf_P(PSTR("[OTA] Auto-update failed.\n"));
 }
 
+// Helper: record a SPA OTA failure, log it to serial, and reset HTTP/FS
+// state. The caller still returns afterwards — keep this side-effect-only
+// so the failure path stays straight-line and easy to audit.
+static void spaOtaFail(const __FlashStringHelper *stage, const String &detail,
+                       HTTPClient *http) {
+  String stageStr = String(stage);
+  spaOtaStatus = "failed";
+  spaOtaError = stageStr + (detail.length() ? ": " + detail : String());
+  Serial.print(F("[OTAFS] FAIL ("));
+  Serial.print(stageStr);
+  Serial.print(F("): "));
+  Serial.println(detail);
+  if (http) http->end();
+  // Always remount the (still-old) FS so the device stays usable; a no-op
+  // if it's already mounted.
+  LittleFS.begin();
+}
+
 // Streams a LittleFS image from fsUrl, writes it to the FS partition via
 // Update.begin(U_FS), then restores /conf.txt on the new FS before rebooting.
 // Call only from the main loop — the HTTP download blocks for several seconds.
 // Never returns on success — the device reboots after a successful flash.
+// On any failure, sets spaOtaStatus="failed" + spaOtaError so the SPA poll
+// loop in StatusPage can surface it instead of silently returning success.
 static void doOtaFsFlash(const String &fsUrl) {
+  spaOtaStatus = "downloading";
+  spaOtaError = "";
+
   // Back up /conf.txt before unmounting LittleFS.
   String confBackup = "";
   {
@@ -816,43 +847,56 @@ static void doOtaFsFlash(const String &fsUrl) {
     }
   }
 
-  // Open the HTTP connection and validate the response.
+  // Open the HTTP connection and validate the response. Follow redirects so
+  // mirrors that 30x to a different path (e.g. Azure App Service HTTPS-only
+  // mode, host moves) don't manifest as a silent 302 != 200 abort.
   WiFiClient httpClient;
   HTTPClient http;
   http.begin(httpClient, fsUrl);
+  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
   int code = http.GET();
   if (code != HTTP_CODE_OK) {
-    Serial.printf_P(PSTR("[OTAFS] HTTP %d — aborting\n"), code);
-    http.end();
+    spaOtaFail(F("http"), "HTTP " + String(code) + " from " + fsUrl, &http);
     return;
   }
   int contentLength = http.getSize();
   Serial.printf_P(PSTR("[OTAFS] Content-Length: %d\n"), contentLength);
+  if (contentLength <= 0) {
+    spaOtaFail(F("http"),
+               "missing or invalid Content-Length (" + String(contentLength) + ")",
+               &http);
+    return;
+  }
 
   // Unmount LittleFS before writing raw bytes to the partition.
   LittleFS.end();
   uint32_t fsPartSize = (uint32_t)((size_t)&_FS_end - (size_t)&_FS_start);
-  uint32_t updateSize = (contentLength > 0) ? (uint32_t)contentLength : fsPartSize;
-  if (!Update.begin(updateSize, U_FS)) {
-    Update.printError(Serial);
-    http.end();
-    LittleFS.begin();
+  if ((uint32_t)contentLength > fsPartSize) {
+    String detail = "image " + String(contentLength) +
+                    " > FS partition " + String(fsPartSize);
+    spaOtaFail(F("size"), detail, &http);
     return;
   }
+  // Mirror /updatefs upload handler: enable async writes so the inner write
+  // loop doesn't stall while the prior sector finishes erasing.
+  Update.runAsync(true);
+  if (!Update.begin((uint32_t)contentLength, U_FS)) {
+    spaOtaFail(F("Update.begin"), Update.getErrorString(), &http);
+    return;
+  }
+  spaOtaStatus = "flashing";
 
   // Stream the HTTP body into the Update writer.
   WiFiClient *stream = http.getStreamPtr();
   uint8_t buf[512];
   uint32_t written = 0;
-  while (http.connected() && (contentLength < 0 || (int)written < contentLength)) {
+  while (http.connected() && (int)written < contentLength) {
     size_t avail = stream->available();
     if (avail) {
       size_t toRead = min(avail, sizeof(buf));
       size_t got = stream->readBytes(buf, toRead);
       if (Update.write(buf, got) != got) {
-        Update.printError(Serial);
-        http.end();
-        LittleFS.begin();
+        spaOtaFail(F("Update.write"), Update.getErrorString(), &http);
         return;
       }
       written += got;
@@ -862,13 +906,23 @@ static void doOtaFsFlash(const String &fsUrl) {
   http.end();
   Serial.printf_P(PSTR("[OTAFS] Streamed %u bytes\n"), written);
 
+  // Premature disconnect: loop exited because http.connected() went false
+  // before we received the whole body. Update.end() would fail anyway, but
+  // surfacing a more specific message helps debug flaky upstream hosts.
+  if ((int)written < contentLength) {
+    spaOtaFail(F("download"),
+               "truncated at " + String(written) + "/" + String(contentLength) + " bytes",
+               nullptr);
+    return;
+  }
+
   if (!Update.end(true)) {
-    Update.printError(Serial);
-    LittleFS.begin();
+    spaOtaFail(F("Update.end"), Update.getErrorString(), nullptr);
     return;
   }
 
   // Remount the new FS and restore /conf.txt.
+  spaOtaStatus = "restoring-conf";
   LittleFS.begin();
   if (!confBackup.isEmpty()) {
     File cf = LittleFS.open("/conf.txt", "w");
@@ -878,6 +932,8 @@ static void doOtaFsFlash(const String &fsUrl) {
       Serial.printf_P(PSTR("[OTAFS] Restored /conf.txt (%u bytes)\n"),
                       (unsigned)confBackup.length());
     } else {
+      // Don't fail the whole update — the SPA's post-reboot patchConfig step
+      // re-applies settings — but log it loudly so it's visible.
       Serial.println(F("[OTAFS] WARN: could not write /conf.txt to new FS"));
     }
   }
@@ -1447,6 +1503,13 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   doc["spa_fs_url"] = pendingSpaFsUrl;
   doc["spa_latest_version"] = pendingSpaVersion;
 
+  // SPA-FS OTA progress, so the SPA's update flow can detect a silent
+  // failure instead of treating "device responded to /api/status" as proof
+  // the flash worked. RAM-only; resets to "idle" on every boot.
+  JsonObject spaOta = doc["spa_ota"].to<JsonObject>();
+  spaOta["status"] = spaOtaStatus;
+  spaOta["error"] = spaOtaError;
+
   sendJsonResponse(request, 200, doc);
 }
 
@@ -1577,6 +1640,8 @@ void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json
 
   pendingOtaFsUrl = url;
   otaFsFromUrlRequested = true;
+  spaOtaStatus = "queued";
+  spaOtaError = "";
 
   JsonDocument doc;
   doc["status"] = "update queued";

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -32,20 +32,48 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function pollUntilBack(): Promise<void> {
-  // Give the device time to start the flash and initiate reboot.
-  await delay(8_000);
-  const deadline = Date.now() + 120_000;
+// Wait for the deferred SPA flash to either succeed (device reboots back
+// to spa_ota.status === "idle") or fail (spa_ota.status === "failed").
+// Older firmware that pre-dates spa_ota tracking falls back to the legacy
+// "first successful poll wins" behavior so this remains backward-compatible.
+async function waitForUpdateOutcome(): Promise<void> {
+  // Give the device time to enter the flash path before we start polling.
+  await delay(5_000);
+  const deadline = Date.now() + 180_000;
+  let observedActivity = false;
   while (Date.now() < deadline) {
     try {
-      await getStatus();
-      return;
-    } catch {
-      // device still offline — keep polling
+      const s = await getStatus();
+      const ota = s.spa_ota?.status;
+
+      if (ota === "failed") {
+        throw new Error(
+          `SPA update failed during ${s.spa_ota?.error || "unknown stage"}.`,
+        );
+      }
+
+      if (ota === undefined) {
+        // Firmware predates spa_ota — restore legacy behavior.
+        return;
+      }
+
+      if (ota !== "idle") {
+        observedActivity = true;
+      } else if (observedActivity) {
+        // Returned to idle after activity → device rebooted into new FS.
+        return;
+      }
+    } catch (e) {
+      // Throws from "failed" branch propagate as real errors.
+      if (e instanceof Error && e.message.startsWith("SPA update failed")) {
+        throw e;
+      }
+      // Otherwise: device offline (rebooting) — record + keep polling.
+      observedActivity = true;
     }
-    await delay(3_000);
+    await delay(2_000);
   }
-  throw new Error("Device did not come back online within 2 minutes.");
+  throw new Error("Timed out waiting for SPA update outcome (3 min).");
 }
 
 async function doSpaUpdate(fsUrl: string) {
@@ -66,9 +94,12 @@ async function doSpaUpdate(fsUrl: string) {
     spaUpdateStep.value = "Requesting SPA flash…";
     await postSpaUpdateFromUrl(fsUrl);
 
-    // Step 3 — wait for the device to reboot with the new FS image
+    // Step 3 — wait for the device to reboot with the new FS image, OR
+    // surface a failure from the deferred flash (silent failures used to
+    // pass through here as apparent success — see issue: SPA update apply
+    // path silent failure).
     spaUpdateStep.value = "Flashing SPA bundle — device will reboot shortly…";
-    await pollUntilBack();
+    await waitForUpdateOutcome();
 
     // Step 4 — re-apply config in case the restore in Part 4 had any issues
     spaUpdateStep.value = "Restoring config…";

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -35,6 +35,16 @@ export interface StatusData {
   spa_update_available?: boolean;
   spa_fs_url?: string;
   spa_latest_version?: string;
+  // SPA-FS OTA progress for the deferred /api/spa/update-from-url flash.
+  // Optional so the SPA still renders against firmware that predates the
+  // tracking; in that case the StatusPage falls back to legacy polling.
+  spa_ota?: SpaOtaState;
+}
+
+export interface SpaOtaState {
+  // "idle" | "queued" | "downloading" | "flashing" | "restoring-conf" | "failed"
+  status: string;
+  error: string;
 }
 
 export interface WeatherData {


### PR DESCRIPTION
## Symptom

A user reported that after clicking the **Update SPA** button in the SPA
Status tab, the clock appears to apply the update (banner clears, page
reloads), but `/api/status` continues to report the OLD `spa_version`.
Diagnostic check via `/api/fs/read?path=/spa/version.json` confirmed the
file on disk is still the old version — meaning the FS image was never
actually written. `/api/status` was not lying; the apply path itself was
silently failing.

## Root cause

`doOtaFsFlash()` in [marquee/marquee.ino](marquee/marquee.ino) had **five
silent failure modes**, all logging only to Serial and returning without
any signal to the caller or user:

1. **HTTP non-200 response** (incl. 30x redirects). `HTTPClient` on
   ESP8266 does **not** follow redirects by default. If the upstream host
   ever 30x'd, we returned before downloading anything.
2. **Missing/invalid `Content-Length`**. The function used
   `(contentLength > 0) ? contentLength : fsPartSize` and proceeded
   anyway, so a missing header would size `Update.begin` against the
   whole partition and the loop's `contentLength < 0` branch would never
   exit cleanly.
3. **`Update.begin(size, U_FS)` failure** (e.g., size > partition,
   internal error). Returned silently; only `Update.printError` to
   Serial.
4. **Premature TCP disconnect mid-download**. The `while
   (http.connected() && written < contentLength)` loop exited early when
   the connection dropped, then `Update.end(true)` failed because not
   enough bytes had been written. The user never learned why.
5. **`Update.write` / `Update.end` failure**. Same pattern — Serial-only,
   no surfacing.

The frontend's `pollUntilBack()` in [`webui/src/pages/StatusPage.tsx`](webui/src/pages/StatusPage.tsx)
treated "first successful `/api/status` response" as proof of success.
Because every silent failure leaves the device online and responsive
(the FS is just unchanged), the SPA's update flow couldn't tell the
difference between "device rebooted into new FS" and "flash failed and
the device never rebooted." It cheerfully ran `patchConfig` and
`window.location.reload()`, and the user came back to the same old SPA.

## Fix

### Apply path hardening — [marquee/marquee.ino](marquee/marquee.ino)

- **Follow redirects.** `http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS)`
  on the `HTTPClient` so a 30x doesn't masquerade as failure. Defense in
  depth — Azure App Service has an HTTPS-only mode that 301s, and any
  future host migration could introduce redirects.
- **Reject bad `Content-Length` up front** instead of falling back to
  partition size.
- **Reject oversize images** before unmounting the FS, so we don't end
  up with the FS unmounted and no flash to write.
- **Validate `written == contentLength` after the loop.** A premature
  disconnect now reports `truncated at X/Y bytes`, not a generic
  `Update.end` error.
- **`Update.runAsync(true)`** to match `/updatefs` upload handler — was
  inconsistent.

### Status surfacing — `spaOtaStatus` / `spaOtaError`

New globals:

```text
idle → queued → downloading → flashing → restoring-conf → (reboot → idle)
                                              │
                                              └─ failed (with diagnostic in spaOtaError)
```

- Reset to `queued` / `""` on `/api/spa/update-from-url` POST.
- Set at each stage of `doOtaFsFlash`.
- On any failure point, set to `failed` + a stage-tagged error string
  via the new `spaOtaFail()` helper. The helper also logs to Serial
  (existing behavior) and remounts LittleFS so the device stays usable.
- Exposed via `/api/status` as `spa_ota: {status, error}`.

State is RAM-only. A successful flash reboots, `setup()` initializes
to `"idle"`. A failed flash leaves the diagnostic in place until the
next `/api/spa/update-from-url` POST or device reboot.

### Frontend — [webui/src/pages/StatusPage.tsx](webui/src/pages/StatusPage.tsx)

- Replaces `pollUntilBack` with `waitForUpdateOutcome`:
  - Throws `SPA update failed during <stage>: <detail>` if `spa_ota.status === "failed"`.
  - Returns success only after observing activity (in-flight status or
    device offline) **and then** status returning to `idle` — i.e., the
    device actually rebooted. Prevents the legacy "first successful
    poll" false positive.
  - Falls back to legacy behavior when `spa_ota` is absent (older
    firmware), so this stays backward-compatible.
- Bumped poll cadence (3s → 2s) and total timeout (2 min → 3 min) since
  the new logic is willing to wait through in-flight states.

### Failure modes mapped

| Where | Old behavior | New behavior |
| --- | --- | --- |
| Non-200 HTTP response | `Serial.println`, return | `failed: http: HTTP <code> from <url>` |
| Missing `Content-Length` | proceed with partition-sized loop | `failed: http: missing or invalid Content-Length (...)` |
| Image > partition | erase begin → likely corrupt FS | `failed: size: image X > FS partition Y` (before unmount) |
| `Update.begin` fail | `printError`, return | `failed: Update.begin: <reason>` |
| `Update.write` fail | `printError`, return | `failed: Update.write: <reason>` |
| Premature disconnect | `Update.end` fails generically | `failed: download: truncated at X/Y bytes` |
| `Update.end` fail | `printError`, return | `failed: Update.end: <reason>` |
| `/conf.txt` restore fail | `Serial.println` only | unchanged (intentionally non-fatal — the SPA's `patchConfig` step re-applies settings, so failing the whole update here would be a regression) |

Each path also keeps its existing Serial log line, prefixed with
`[OTAFS] FAIL (<stage>): <detail>` for grep-ability.

### Version

`BASE_VERSION` 4.0.1-wagfam → 4.0.2-wagfam.

## Test plan

- [x] `make build` — firmware compiles, RAM 45.1%, Flash 53.3% (was
  53.0%, ~330 bytes growth from new state + frontend wiring).
- [x] `make webui-typecheck` — passes.
- [x] `make test` — 91 / 91 (native + scripts).
- [ ] **Live device repro** (the original bug — hardware-only):
  1. Note `/api/status`'s current `spa_version`.
  2. Click **Update SPA** in the SPA Status tab.
  3. Either: device reboots, page reloads, `/api/status` returns the
     new version (success path).
  4. Or: SPA shows red "SPA update failed during \<stage\>" banner with
     a real diagnostic, `/api/status` returns `spa_ota.status: "failed"`
     and `spa_ota.error: "<stage>: <detail>"`.
- [ ] **Force-failure repro**: `curl -X POST -H 'Content-Type: application/json'
  -d '{"url":"http://files-jrwagz.azurewebsites.net/does-not-exist.bin"}'
  http://<ip>/api/spa/update-from-url`, then `curl http://<ip>/api/status |
  jq .spa_ota` — should show `{"status":"failed","error":"http: HTTP 404 from ..."}`.

## Callout for human review

I could not determine the **exact** root cause on the user's specific device
without serial logs (any of #1–#5 above could fit). The fix is therefore
defensive at every known failure point rather than targeted at one. If
serial logs from the next failed attempt (after this lands) point at a
specific stage, we can narrow further. Keeping the change scoped to
visibility + hardening means we'll see the actual stage next time.