### PR TITLE
Auto-apply SPA updates from calendar channel; bump to 4.1.0-wagfam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -399,17 +399,35 @@ returned race-flaky results when the target file was being updated; see the
 
 ## OTA Update Architecture
 
-ArduinoOTA was removed in v3.08.0-wagfam. Updates are now delivered three ways:
+ArduinoOTA was removed in v3.08.0-wagfam. Updates are now delivered six ways
+(three for the firmware sketch, three for the SPA / LittleFS image):
 
-| Method | Trigger | Rollback |
-| --- | --- | --- |
-| Web upload (`/update`) | Manual via browser | No (use `/updateFromUrl` to revert) |
-| URL update (`/updateFromUrl`) | Manual via web form | Boot-confirmation rollback |
-| Auto-update (calendar JSON) | `latestVersion` != `VERSION` | Boot-confirmation rollback |
+| Target | Method | Trigger | Rollback |
+| --- | --- | --- | --- |
+| Sketch | Web upload (`/update`) | Manual via browser | No (use `/updateFromUrl` to revert) |
+| Sketch | URL update (`/updateFromUrl`) | Manual via web form | Boot-confirmation rollback |
+| Sketch | Auto-update (calendar JSON) | `latestVersion` != `VERSION`, gated by `WAGFAM_AUTO_UPDATE_DISABLED` | Boot-confirmation rollback |
+| LittleFS / SPA | Web upload (`/updatefs`) | Manual via browser | No |
+| LittleFS / SPA | URL update (`POST /api/spa/update-from-url`) | SPA "Update SPA" button | No |
+| LittleFS / SPA | Auto-update (calendar JSON) | `latestSpaVersion` != `SPA_VERSION`, gated by `WAGFAM_AUTO_UPDATE_DISABLED` | No |
 
-**Boot-confirmation rollback:** Before every flash, a `/ota_pending.txt` record is written to LittleFS
-with the current safe URL. If the device reboots twice without confirming (5 min stable uptime),
-`checkOtaRollback()` re-flashes the previous firmware. See `docs/OTA_STRATEGY.md` for full details.
+**Compile-time gate.** A single flag, `WAGFAM_AUTO_UPDATE_DISABLED`, gates *both*
+the sketch auto-update branch and the SPA auto-apply branch in `getWeatherData()`.
+Set via PlatformIO `-DWAGFAM_AUTO_UPDATE_DISABLED=1` (enabled in `[env:dev]` for
+local builds). The flag controls only the *automatic trigger* — SPA detection
+(`spa_update_available` in `/api/status`) and the manual "Update SPA" button in
+the SPA banner remain functional in every build configuration. The auto-apply
+SPA path also shares the same `OTA_CONFIRM_MS` / `otaConfirmAt` gates as
+firmware auto-update, so a SPA flash never fires inside the firmware-flash
+boot-confirmation window.
+
+**Boot-confirmation rollback** applies to sketch flashes only. Before every
+sketch flash, a `/ota_pending.txt` record is written to LittleFS with the
+current safe URL. If the device reboots twice without confirming (5 min stable
+uptime), `checkOtaRollback()` re-flashes the previous firmware. SPA flashes
+intentionally do not participate (a bad SPA bundle is a soft failure: the
+sketch still boots, the API works, and `/api/spa/update-from-url` can re-flash
+a known-good URL). See `docs/OTA_STRATEGY.md` for full details.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ customized as a family calendar + weather clock for a Wemos D1 Mini (ESP8266) wi
 - **WagFam Calendar** — scrolls upcoming family events/birthdays fetched from a private JSON endpoint;
   animated border on event days
 - Configured entirely through a web interface (no re-flashing required for settings changes)
-- OTA firmware updates via web interface (file upload or URL)
+- OTA firmware updates via web interface (file upload or URL), plus optional
+  calendar-driven auto-update for both the firmware sketch and the SPA bundle
+  (gated by a single compile-time flag, `WAGFAM_AUTO_UPDATE_DISABLED`)
 - Configurable scroll speed, brightness, and refresh interval
 
 ## Hardware

--- a/docs/OTA_STRATEGY.md
+++ b/docs/OTA_STRATEGY.md
@@ -153,6 +153,36 @@ Auto-update is skipped if any of these conditions are true:
 | `firmwareUrl` does not start with `http://` | HTTPS not supported |
 | `otaConfirmAt != 0` | A previous update is still pending confirmation |
 | `millis() < OTA_CONFIRM_MS` | Device booted too recently; let it stabilize first |
+| `WAGFAM_AUTO_UPDATE_DISABLED` defined | Compile-time opt-out |
+
+### SPA Auto-Update
+
+The same calendar-JSON channel also delivers SPA (LittleFS) updates. The
+`config` block can include `latestSpaVersion` and `spaFsUrl`; when they differ
+from the device's compiled `SPA_VERSION` and a `littlefs.bin` URL is provided,
+`getWeatherData()` queues an SPA flash via the same deferred-flash mechanism
+the manual "Update SPA" button uses (`otaFsFromUrlRequested = true`), which
+the main loop picks up and runs through `doOtaFsFlash()`.
+
+Differences from sketch auto-update:
+
+- **Same compile flag.** `WAGFAM_AUTO_UPDATE_DISABLED` gates both. There is no
+  separate SPA flag.
+- **Detection always runs.** Even when `WAGFAM_AUTO_UPDATE_DISABLED` is set,
+  `spa_update_available` and `spa_latest_version` in `/api/status` are still
+  populated, so the SPA banner / manual "Update SPA" button keep working.
+  Only the *automatic trigger* is gated.
+- **No rollback.** SPA flashes don't write `/ota_pending.txt` and don't
+  participate in `checkOtaRollback()`. A bad SPA bundle is a soft failure: the
+  sketch still boots, `/api/*` still works, and the user can re-flash via the
+  banner or `POST /api/spa/update-from-url`.
+- **Shared OTA gates.** The auto-trigger reuses `otaConfirmAt == 0` and
+  `millis() > OTA_CONFIRM_MS`, so a SPA flash never fires inside the
+  firmware-flash boot-confirmation window — at most one auto-flash per cycle
+  across firmware + SPA.
+- **Same trusted-domain check.** `isTrustedFirmwareDomain()` validates the
+  `spaFsUrl` against `WAGFAM_TRUSTED_FIRMWARE_DOMAINS` plus the calendar source
+  domain, identical to firmware.
 
 ---
 

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,7 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 
-#define BASE_VERSION "4.0.2-wagfam"
+#define BASE_VERSION "4.1.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -1122,7 +1122,12 @@ void getWeatherData() //client function to send/receive GET request data.
   }
 #endif // WAGFAM_AUTO_UPDATE_DISABLED
 
-  // Check for a remote SPA update pushed via the calendar config
+  // Check for a remote SPA update pushed via the calendar config. Detection
+  // (setting spaUpdateAvailable / pendingSpaFsUrl / pendingSpaVersion) is
+  // *always* performed regardless of WAGFAM_AUTO_UPDATE_DISABLED — those
+  // flags drive the manual "Update SPA" button in the SPA banner, which must
+  // remain functional in every build configuration. Only the *automatic*
+  // trigger below is gated by the compile flag.
   if (serverConfig.latestSpaVersionValid && serverConfig.spaFsUrlValid
       && serverConfig.latestSpaVersion != SPA_VERSION
       && serverConfig.spaFsUrl.startsWith("http://")) {
@@ -1135,6 +1140,32 @@ void getWeatherData() //client function to send/receive GET request data.
     pendingSpaFsUrl = "";
     pendingSpaVersion = "";
   }
+
+  // Auto-apply the SPA update if one was just detected. Mirrors the firmware
+  // auto-update branch above: same compile-time flag, same OTA confirmation
+  // gates (so a SPA flash never fires inside the firmware-flash confirmation
+  // window), same trusted-domain check. Defers the actual flash to the main
+  // loop's existing handler at processEverySecond() (which calls
+  // doOtaFsFlash()) by setting otaFsFromUrlRequested — same path the manual
+  // /api/spa/update-from-url endpoint uses.
+#ifndef WAGFAM_AUTO_UPDATE_DISABLED
+  if (spaUpdateAvailable && pendingSpaFsUrl.length() > 0
+      && otaConfirmAt == 0 && millis() > OTA_CONFIRM_MS
+      && !otaFsFromUrlRequested) {
+    if (!isTrustedFirmwareDomain(pendingSpaFsUrl, WAGFAM_DATA_URL, WAGFAM_TRUSTED_FIRMWARE_DOMAINS)) {
+      Serial.println(F("[SEC] Rejected SPA FS URL — domain not allowlisted and does not match calendar source"));
+    } else {
+      Serial.println("[SPA] Auto-applying SPA update: " + pendingSpaVersion);
+      pendingOtaFsUrl = pendingSpaFsUrl;
+      otaFsFromUrlRequested = true;
+      // Mirror handleApiSpaUpdateFromUrl: surface progress via /api/status
+      // spa_ota.{status,error} so the SPA waitForUpdateOutcome() poll picks
+      // up auto-applied flashes the same way it does manual ones.
+      spaOtaStatus = "queued";
+      spaOtaError = "";
+    }
+  }
+#endif // WAGFAM_AUTO_UPDATE_DISABLED
 
   Serial.println("Version: " + String(VERSION));
   Serial.println();

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -36,6 +36,7 @@ function delay(ms: number): Promise<void> {
 // to spa_ota.status === "idle") or fail (spa_ota.status === "failed").
 // Older firmware that pre-dates spa_ota tracking falls back to the legacy
 // "first successful poll wins" behavior so this remains backward-compatible.
+// Polls every 2 s per the agreed cadence in PR #92 decision #6.
 async function waitForUpdateOutcome(): Promise<void> {
   // Give the device time to enter the flash path before we start polling.
   await delay(5_000);
@@ -85,27 +86,27 @@ async function doSpaUpdate(fsUrl: string) {
   spaUpdateState.value = "updating";
   spaUpdateError.value = "";
   try {
-    // Step 1 — snapshot current config (belt-and-suspenders; Part 4 already
-    // preserves /conf.txt during the FS flash, but re-POST ensures parity).
+    // Step 1 — snapshot current config (belt-and-suspenders; doOtaFsFlash
+    // already preserves /conf.txt during the FS flash, but re-POST ensures
+    // parity).
     spaUpdateStep.value = "Saving current config…";
     const savedConfig = await getConfig();
 
-    // Step 2 — queue the FS flash on the device
+    // Step 2 — queue the FS flash on the device.
     spaUpdateStep.value = "Requesting SPA flash…";
     await postSpaUpdateFromUrl(fsUrl);
 
     // Step 3 — wait for the device to reboot with the new FS image, OR
     // surface a failure from the deferred flash (silent failures used to
-    // pass through here as apparent success — see issue: SPA update apply
-    // path silent failure).
+    // pass through here as apparent success — see PR #94).
     spaUpdateStep.value = "Flashing SPA bundle — device will reboot shortly…";
     await waitForUpdateOutcome();
 
-    // Step 4 — re-apply config in case the restore in Part 4 had any issues
+    // Step 4 — re-apply config in case the restore had any issues.
     spaUpdateStep.value = "Restoring config…";
     await patchConfig(savedConfig);
 
-    // Step 5 — reload into the freshly-flashed SPA
+    // Step 5 — reload into the freshly-flashed SPA.
     spaUpdateStep.value = "Done — reloading…";
     await delay(1_500);
     window.location.reload();
@@ -163,11 +164,20 @@ export function StatusPage() {
         </div>
       )}
 
-      {/* SPA update in progress */}
+      {/* SPA update in progress — full-page modal blocks interaction
+          while the device flashes LittleFS and reboots. */}
       {spaUpdateState.value === "updating" && (
-        <div class="update-banner">
-          <span class="spinner" />
-          <span style={{ flex: 1 }}>{spaUpdateStep.value}</span>
+        <div class="modal-overlay" role="dialog" aria-modal="true">
+          <div class="modal-card">
+            <h2 class="modal-title">
+              <span class="spinner" /> Updating SPA…
+            </h2>
+            <p class="modal-step">{spaUpdateStep.value}</p>
+            <p class="modal-hint">
+              The device will reboot. This page will reload automatically once
+              the new SPA version is reported. Do not close this tab.
+            </p>
+          </div>
         </div>
       )}
 

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -442,3 +442,44 @@ input[type="checkbox"].toggle:checked::after {
   animation: spin 0.6s linear infinite;
   vertical-align: -0.1em;
 }
+
+/* ── Update modal (full-page overlay during SPA flash) ── */
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--bg) 85%, black);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  max-width: 28rem;
+  width: 100%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.modal-title {
+  font-size: 1.15rem;
+  margin: 0 0 0.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.modal-step {
+  margin: 0.75rem 0;
+}
+
+.modal-hint {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary

Implements the design proposed in [#92](https://github.com/jrwagz/marquee-scroller/pull/92), with all 8 decisions resolved per the inline review feedback.

When the calendar JSON publishes a `latestSpaVersion` / `spaFsUrl` that differs from the device's compiled `SPA_VERSION`, `getWeatherData()` now queues an SPA flash via the same deferred-flash mechanism the existing `POST /api/spa/update-from-url` endpoint uses (`otaFsFromUrlRequested = true` → main loop's existing handler picks it up → `doOtaFsFlash()`). No new flash code path is introduced. The auto-apply path also seeds `spaOtaStatus = "queued"` so the device-side `spa_ota` tracking added in [#94](https://github.com/jrwagz/marquee-scroller/pull/94) surfaces auto-applied flashes the same way it surfaces manual ones.

**Bumps minor: `4.0.1-wagfam` → `4.1.0-wagfam`** (new feature on top of an existing surface; no breaking changes to endpoints or wire format).

## Resolved decisions (from PR #92 review)

- **#1 B** — reuse the existing `WAGFAM_AUTO_UPDATE_DISABLED` ifdef. One flag covers both firmware and SPA auto-apply.
- **#2 A** — manual "Update SPA" button stays visible whenever an update is detected, regardless of the compile flag. Detection logic (setting `spa_update_available`, `pendingSpaFsUrl`, `pendingSpaVersion`) runs unconditionally; only the *automatic trigger* is gated.
- **#3 A** — no runtime control. Filed [#95](https://github.com/jrwagz/marquee-scroller/issues/95) as a future feature.
- **#4 A** — no rollback for SPA flashes (status quo).
- **#5 A** — domain allowlist only (`isTrustedFirmwareDomain()`, same as firmware). Filed [#96](https://github.com/jrwagz/marquee-scroller/issues/96) for SHA256/signing as a future feature covering both paths.
- **#6 B** — pre-flash modal with `/api/status` poll every 2 s. Reuses `waitForUpdateOutcome()` from [#94](https://github.com/jrwagz/marquee-scroller/pull/94) (already meets the 2 s cadence and additionally surfaces real failures via `spa_ota.status === \"failed\"` with the failing stage). Replaces the prior inline banner with a full-page modal so the user understands the device is rebooting and the page will reload automatically.
- **#7 A** — share `otaConfirmAt == 0` and `millis() > OTA_CONFIRM_MS` gates with firmware auto-update. A SPA flash will never fire inside the firmware-flash boot-confirmation window.
- **#8 A** — no new heartbeat field.

## Compile-time matrix

| Build configuration | Detection | Manual button | Firmware auto-apply | SPA auto-apply |
| --- | --- | --- | --- | --- |
| Default | yes | yes | yes | yes |
| `-DWAGFAM_AUTO_UPDATE_DISABLED=1` (env:dev) | yes | yes | no | no |

## Files

- [`marquee/marquee.ino`](https://github.com/jrwagz/marquee-scroller/blob/feat/spa-auto-update/marquee/marquee.ino) — bumped `BASE_VERSION` to `4.1.0-wagfam`; added `#ifndef WAGFAM_AUTO_UPDATE_DISABLED` block in `getWeatherData()` immediately after the existing SPA-detection block. Auto-apply queues `otaFsFromUrlRequested = true` (and seeds `spaOtaStatus = \"queued\"`) only after passing the trusted-domain check, OTA confirmation gates, and a `!otaFsFromUrlRequested` re-entrancy check.
- `webui/src/pages/StatusPage.tsx` — manual update flow now uses a full-page modal during flash and calls `waitForUpdateOutcome()` (from PR #94, polls every 2 s, surfaces failures).
- `webui/src/styles.css` — adds `.modal-overlay` / `.modal-card` / `.modal-title` / `.modal-step` / `.modal-hint`.
- `CLAUDE.md`, `README.md`, `docs/OTA_STRATEGY.md` — document the new behavior, including the \"detection always runs / auto-trigger gated\" distinction.

## Test plan

- [x] `make lint` passes (markdown + python)
- [x] `make test` passes (native + scripts, 91 tests, 96.89% coverage)
- [x] `pio run -e default` builds clean (RAM 45.1% / Flash 53.4%)
- [x] `pio run -e dev` builds clean with `WAGFAM_AUTO_UPDATE_DISABLED=1` — confirms the `#ifndef` block compiles out
- [x] `make webui-typecheck` passes
- [x] `make webui` builds the SPA bundle
- [x] Rebased clean on top of latest master (5b4db43, includes #93/#94/#98)
- [ ] **Live device verification** (requires owner — see [`docs/LIVE_DEVICE_TESTING.md`](https://github.com/jrwagz/marquee-scroller/blob/feat/spa-auto-update/docs/LIVE_DEVICE_TESTING.md)):
  - [ ] Device on default build (auto-update enabled): publish a new `latestSpaVersion` + `spaFsUrl` via the calendar server; verify device auto-applies on next refresh and reboots into the new SPA
  - [ ] Device on `[env:dev]` build: publish same; verify device does *not* auto-apply but the SPA banner shows the available version and the \"Update SPA\" button still works manually
  - [ ] During manual update: verify the modal appears, blocks interaction, reloads automatically once `spa_ota.status` returns to `idle`
  - [ ] Verify SPA flash does not fire inside the 5-minute boot-confirmation window after a firmware flash

## Follow-ups

- [#95](https://github.com/jrwagz/marquee-scroller/issues/95) — runtime opt-out toggle for end-users (decision #3)
- [#96](https://github.com/jrwagz/marquee-scroller/issues/96) — SHA256/signed image verification (decision #5)