### PR TITLE
Remove unused test/ directory of stale OTA fixtures

### DIFF
--- a/test/ota_test_noupdate.json
+++ b/test/ota_test_noupdate.json
@@ -1,9 +1,0 @@
-[
-  {
-    "config": {
-      "latestVersion": "3.08.0-wagfam",
-      "firmwareUrl": "http://192.168.1.156:8080/firmware_v3.09.bin"
-    }
-  },
-  { "message": "OTA TEST: no update expected (version matches)" }
-]

--- a/test/ota_test_v309.json
+++ b/test/ota_test_v309.json
@@ -1,9 +1,0 @@
-[
-  {
-    "config": {
-      "latestVersion": "3.09.0-wagfam",
-      "firmwareUrl": "http://1ac81b1457a5d4.lhr.life/firmware_v3.09.bin"
-    }
-  },
-  { "message": "OTA TEST: auto-update to v3.09 in progress" }
-]

--- a/test/ota_test_v310.json
+++ b/test/ota_test_v310.json
@@ -1,9 +1,0 @@
-[
-  {
-    "config": {
-      "latestVersion": "3.10.0-wagfam",
-      "firmwareUrl": "http://1ac81b1457a5d4.lhr.life/firmware_v3.10.bin"
-    }
-  },
-  { "message": "OTA TEST: auto-update to v3.10 in progress" }
-]


### PR DESCRIPTION
## Summary

Deletes the top-level `test/` directory (distinct from `tests/`), which held three OTA test JSON fixtures from the v3.08 / v3.09 development phase:

- `test/ota_test_noupdate.json`
- `test/ota_test_v309.json`
- `test/ota_test_v310.json`

They reference `latestVersion=3.08.0-wagfam` and a hardcoded LAN IP `192.168.1.156`, and aren't wired into any test runner. Confirmed via `grep -r 'ota_test'` and a broader `\btest/` path scan across `*.md`, `*.py`, `*.ino`, `*.cpp`, `*.h`, `*.ts`, `*.tsx`, `*.yaml`, `*.yml`, `*.ini`, and `makefile` — both empty.

Cleanup candidate #2 from [PR #93](https://github.com/jrwagz/marquee-scroller/pull/93)'s review; merging per the directed-feedback follow-up.

## Test plan

- [x] Lint + tests still pass (no source code touched).
- [x] Confirm `git grep ota_test` returns nothing on this branch.