### PR TITLE
Add CORS layer to JSON API for cross-origin upgrade-tool access

### DIFF
--- a/marquee/CorsSupport.cpp
+++ b/marquee/CorsSupport.cpp
@@ -1,0 +1,45 @@
+#include "CorsSupport.h"
+
+#include "OriginAllowlist.h"
+
+void setCorsHeaders(AsyncWebServerRequest *request, AsyncWebServerResponse *response) {
+  if (request == nullptr || response == nullptr) return;
+  if (!request->hasHeader("Origin")) return;
+
+  String origin = request->getHeader("Origin")->value();
+  if (!isOriginAllowed(origin, WAGFAM_CORS_ALLOWED_ORIGINS)) return;
+
+  // Echo the matched origin back. Browsers compare the response's ACAO
+  // header against the request's Origin byte-for-byte; a wildcard would
+  // also satisfy that check but loses the ability to use credentials,
+  // and the explicit echo is the safer pattern (no risk of accidentally
+  // allowing an origin we didn't intend to).
+  response->addHeader(F("Access-Control-Allow-Origin"), origin);
+
+  // The JSON API uses these methods. DELETE is for /api/fs/delete; we
+  // include it in the per-handler list rather than per-method so any
+  // future endpoint that needs it doesn't have to update the CORS layer.
+  response->addHeader(F("Access-Control-Allow-Methods"),
+                      F("GET, POST, DELETE, OPTIONS"));
+
+  // Content-Type is required for the JSON-body POST endpoints. Authorization
+  // isn't currently required by the firmware (LAN endpoints are open) but
+  // listing it now means a future "require token on writes" change won't
+  // need a separate CORS update.
+  response->addHeader(F("Access-Control-Allow-Headers"),
+                      F("Content-Type, Authorization"));
+
+  // 5 minute preflight cache — keeps the browser from re-OPTIONSing every
+  // single fetch during a capture/restore round-trip in the upgrade flow.
+  response->addHeader(F("Access-Control-Max-Age"), F("300"));
+
+  // Vary: Origin tells caches the response varies by request origin so
+  // they don't serve a cached ACAO from one origin to another.
+  response->addHeader(F("Vary"), F("Origin"));
+}
+
+void handleCorsPreflight(AsyncWebServerRequest *request) {
+  AsyncWebServerResponse *response = request->beginResponse(204);
+  setCorsHeaders(request, response);
+  request->send(response);
+}

--- a/marquee/CorsSupport.h
+++ b/marquee/CorsSupport.h
@@ -1,0 +1,82 @@
+#ifndef CORS_SUPPORT_H
+#define CORS_SUPPORT_H
+
+#include <Arduino.h>
+#include <ESPAsyncWebServer.h>
+
+// Comma-separated allowlist of origins permitted to call the JSON API
+// cross-origin. Override at build time, e.g.:
+//   pio run --build-flag '-DWAGFAM_CORS_ALLOWED_ORIGINS="\"https://x,http://y\""'
+// Empty string = no CORS (all cross-origin requests blocked, fail closed).
+//
+// Default covers:
+//   - https://wagfam-server.azurewebsites.net   (production HTTPS, /admin/)
+//   - http://wagfam-server.azurewebsites.net    (production HTTP, /lan/)
+//   - http://localhost:8000                     (local dev server)
+//
+// Defined here (not Settings.h) because Settings.h is variable-definition-
+// heavy and including it from CorsSupport.cpp would duplicate every global
+// at link time. CorsSupport stays self-contained.
+#ifndef WAGFAM_CORS_ALLOWED_ORIGINS
+#define WAGFAM_CORS_ALLOWED_ORIGINS \
+  "https://wagfam-server.azurewebsites.net," \
+  "http://wagfam-server.azurewebsites.net," \
+  "http://localhost:8000"
+#endif
+
+// CORS support for the JSON API endpoints (issue: jrwagz/wagfam-server #upgrade-tool).
+//
+// The wagfam-server's `/lan/` upgrade page (and the `/admin/` PWA) is hosted
+// on a different origin than the clock — `wagfam-server.azurewebsites.net`
+// vs `192.168.x.x` — so any cross-origin XHR from those pages to the clock's
+// JSON API gets blocked by the browser unless the clock returns the right
+// CORS headers. Without this layer, capture/restore of `/conf.txt` from the
+// upgrade page is impossible: the page can't `fetch('http://<ip>/api/config')`
+// to read it, can't `fetch(..., {method:'POST', body: JSON})` to write it,
+// and even the OPTIONS preflight fails (firmware otherwise 302-redirects
+// unmatched OPTIONS to /spa/).
+//
+// What this layer does:
+//
+//   * `isOriginAllowed(origin, allowlist)` — pure helper, testable on host.
+//     Returns true iff `origin` matches one entry of the comma-separated
+//     allowlist (whitespace-tolerant, exact match — browsers require an
+//     exact echoed origin in `Access-Control-Allow-Origin`, no wildcards
+//     when credentials may be involved).
+//
+//   * `setCorsHeaders(request, response)` — call from any handler before
+//     `request->send(response)`. Reads the request's `Origin` header,
+//     checks against `WAGFAM_CORS_ALLOWED_ORIGINS`, and if it matches,
+//     attaches `Access-Control-Allow-Origin: <echoed origin>` plus the
+//     methods/headers the JSON API supports.  No-op when the request has
+//     no Origin header (same-origin requests from /spa/) or when the
+//     origin isn't whitelisted (request still works, browser just refuses
+//     to expose the response — fail closed for the cross-origin case).
+//
+//   * `handleCorsPreflight(request)` — registered as the HTTP_OPTIONS
+//     handler for each /api/* endpoint.  Returns 204 with the CORS
+//     headers attached (via `setCorsHeaders` on a 204 response).  Without
+//     this, the firmware's `onNotFound` redirects OPTIONS to /spa/, which
+//     is a 302 the browser refuses to treat as a successful preflight.
+//
+// Why an allowlist (not wildcard `*`):
+//   `Access-Control-Allow-Origin: *` would let *any* page on the user's
+//   home network read `/api/config` (which contains the WAGFAM_API_KEY
+//   and OWM_API_KEY) by simply guessing or scanning the clock's IP.
+//   That's a real attack on a family LAN.  Whitelisting the wagfam-server
+//   origins keeps the API readable from our admin tools and unreadable
+//   from anything else.  Build-time configurable via the
+//   WAGFAM_CORS_ALLOWED_ORIGINS macro in Settings.h.
+
+// `isOriginAllowed` lives in OriginAllowlist.h — split out so the native
+// test target can include it without dragging in ESPAsyncWebServer.
+
+// Attach CORS headers to a response if the request's Origin is allowed.
+// No-op if Origin is missing (same-origin requests) or not in the allowlist.
+void setCorsHeaders(AsyncWebServerRequest *request, AsyncWebServerResponse *response);
+
+// Register as the HTTP_OPTIONS handler for /api/* paths to handle
+// browser preflight requests.  Returns 204 with CORS headers.
+void handleCorsPreflight(AsyncWebServerRequest *request);
+
+#endif

--- a/marquee/OriginAllowlist.cpp
+++ b/marquee/OriginAllowlist.cpp
@@ -1,0 +1,35 @@
+#include "OriginAllowlist.h"
+
+namespace {
+
+// Trim ASCII whitespace from both ends. Inline-static so this file can be
+// `#include`d directly by the native test target without symbol clashes.
+String trimAscii(const String &s) {
+  int start = 0;
+  int end = s.length();
+  while (start < end && (s[start] == ' ' || s[start] == '\t')) start++;
+  while (end > start && (s[end - 1] == ' ' || s[end - 1] == '\t')) end--;
+  if (start == 0 && end == (int)s.length()) return s;
+  return s.substring(start, end);
+}
+
+}  // namespace
+
+bool isOriginAllowed(const String &origin, const char *allowlist) {
+  if (origin.length() == 0) return false;
+  if (allowlist == nullptr || allowlist[0] == '\0') return false;
+
+  String list(allowlist);
+  int searchStart = 0;
+  while (searchStart < (int)list.length()) {
+    int comma = list.indexOf(',', searchStart);
+    int end = (comma == -1) ? list.length() : comma;
+    String entry = trimAscii(list.substring(searchStart, end));
+    if (entry.length() > 0 && entry == origin) {
+      return true;
+    }
+    if (comma == -1) break;
+    searchStart = comma + 1;
+  }
+  return false;
+}

--- a/marquee/OriginAllowlist.h
+++ b/marquee/OriginAllowlist.h
@@ -1,0 +1,22 @@
+#ifndef ORIGIN_ALLOWLIST_H
+#define ORIGIN_ALLOWLIST_H
+
+#include <Arduino.h>
+
+// Pure helper, no AsyncWebServer dependency, exercised in
+// tests/native/test_origin_allowlist/.
+//
+// Returns true iff `origin` matches one entry of the comma-separated
+// `allowlist`. Whitespace around list entries is tolerated so the
+// build flag string can be human-readable; the comparison itself is
+// strict (exact match — browsers compare ACAO byte-for-byte).
+//
+// Empty origin or empty allowlist always returns false (fail closed).
+//
+// Lives in its own translation unit so the native test target can
+// `#include "OriginAllowlist.cpp"` without dragging in
+// ESPAsyncWebServer (which CorsSupport.cpp depends on for the runtime
+// header-attaching part).
+bool isOriginAllowed(const String &origin, const char *allowlist);
+
+#endif

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,6 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 #include "ConfigUpdateVerify.h"
+#include "CorsSupport.h"
 #include "HwVerifyTest.h"
 
 #define BASE_VERSION "4.2.0-wagfam"
@@ -371,6 +372,23 @@ void setup() {
   server.on("/api/fs/read", HTTP_GET, handleApiFsRead);
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
+
+  // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
+  // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
+  // and the browser refuses to treat that as a successful preflight.
+  // Each endpoint that can be called cross-origin from the wagfam-server
+  // upgrade/admin pages needs its own OPTIONS registration. See
+  // marquee/CorsSupport.cpp for the rationale.
+  static const char *kJsonApiPaths[] = {
+      "/api/status", "/api/config", "/api/restart", "/api/refresh",
+      "/api/ota/status", "/api/weather", "/api/events",
+      "/api/system-reset", "/api/forget-wifi",
+      "/api/fs/read", "/api/fs/write", "/api/fs/delete", "/api/fs/list",
+      "/api/spa/update-from-url",
+  };
+  for (size_t i = 0; i < sizeof(kJsonApiPaths) / sizeof(kJsonApiPaths[0]); i++) {
+    server.on(kJsonApiPaths[i], HTTP_OPTIONS, handleCorsPreflight);
+  }
 
   // JSON-body POST endpoints. AsyncWebServer doesn't populate request->arg("plain")
   // for JSON bodies, so these go through AsyncCallbackJsonWebHandler which parses
@@ -1567,6 +1585,12 @@ void centerPrint(const String &msg, boolean extraStuff) {
 static void sendJsonResponse(AsyncWebServerRequest *request, int code, JsonDocument &doc) {
   AsyncResponseStream *response = request->beginResponseStream(F("application/json"));
   response->setCode(code);
+  // Attach CORS headers if the request's Origin is whitelisted. Same-origin
+  // requests (no Origin header — the SPA at /spa/ talking to /api/* on the
+  // same host) get nothing extra; cross-origin requests from the wagfam-
+  // server /lan/ + /admin/ pages get the headers they need to read the
+  // response. See marquee/CorsSupport.cpp for the rationale.
+  setCorsHeaders(request, response);
   serializeJson(doc, *response);
   request->send(response);
 }

--- a/tests/native/test_origin_allowlist/test_origin_allowlist.cpp
+++ b/tests/native/test_origin_allowlist/test_origin_allowlist.cpp
@@ -1,0 +1,160 @@
+// Native unit test for `isOriginAllowed`, the pure helper that gates which
+// HTTP `Origin` headers are echoed back in `Access-Control-Allow-Origin`
+// (issue: jrwagz/wagfam-server upgrade-tool work).
+//
+// We test the helper here on the host (no ESP8266 hardware needed) because
+// it's a tight little string-comparison routine that's easy to get wrong:
+//   - the wildcard-vs-exact distinction matters (browsers reject mismatched
+//     ACAO when credentials are involved)
+//   - whitespace around comma-separated list entries is human-friendly to
+//     allow but easy to mishandle
+//   - empty inputs must fail closed
+// A bug here silently breaks every cross-origin call from the wagfam-server
+// upgrade page, which is hard to debug without unit coverage.
+
+#include <unity.h>
+#include "Arduino.h"
+
+// Include the pure helper directly. It has no AsyncWebServer dependency,
+// which is why it's split out from CorsSupport.cpp — that file pulls in
+// ESPAsyncWebServer.h for the runtime header-attaching part, and we don't
+// want to stub that just to test the string-matching logic.
+#include "OriginAllowlist.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+// ── Match cases ─────────────────────────────────────────────────────────────
+
+void test_exact_match_single_entry() {
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        "https://wagfam-server.azurewebsites.net"));
+}
+
+void test_match_first_entry_in_list() {
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        "https://wagfam-server.azurewebsites.net,http://localhost:8000"));
+}
+
+void test_match_last_entry_in_list() {
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "http://localhost:8000",
+        "https://wagfam-server.azurewebsites.net,http://localhost:8000"));
+}
+
+void test_match_middle_entry() {
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "http://wagfam-server.azurewebsites.net",
+        "https://wagfam-server.azurewebsites.net,"
+        "http://wagfam-server.azurewebsites.net,"
+        "http://localhost:8000"));
+}
+
+void test_whitespace_around_entries_tolerated() {
+    // Build flag strings sometimes get padded for readability — make sure
+    // we don't fail because of a stray space the editor inserted.
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        " https://wagfam-server.azurewebsites.net , http://localhost:8000 "));
+}
+
+// ── Reject cases ────────────────────────────────────────────────────────────
+
+void test_rejects_unknown_origin() {
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://evil.example.com",
+        "https://wagfam-server.azurewebsites.net,http://localhost:8000"));
+}
+
+void test_rejects_substring_match() {
+    // "https://wagfam-server.azurewebsites.net" is in the allowlist; an
+    // attacker page on "evil.com/wagfam-server.azurewebsites.net" must NOT
+    // match it just because the path contains the allowed string.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://evil.com/wagfam-server.azurewebsites.net",
+        "https://wagfam-server.azurewebsites.net"));
+}
+
+void test_rejects_prefix_match() {
+    // "https://wagfam-server.azurewebsites.net.evil.com" shares a prefix
+    // but is a different host. Must not match.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net.evil.com",
+        "https://wagfam-server.azurewebsites.net"));
+}
+
+void test_rejects_scheme_mismatch() {
+    // http:// and https:// are different origins for CORS purposes.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "http://wagfam-server.azurewebsites.net",
+        "https://wagfam-server.azurewebsites.net"));
+}
+
+void test_rejects_port_mismatch() {
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "http://localhost:9000",
+        "http://localhost:8000"));
+}
+
+// ── Empty / malformed inputs ────────────────────────────────────────────────
+
+void test_empty_origin_fails_closed() {
+    // Browsers send no Origin for same-origin requests; we treat that as
+    // "don't attach CORS headers" rather than "allow." Same-origin requests
+    // don't need CORS anyway.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "",
+        "https://wagfam-server.azurewebsites.net"));
+}
+
+void test_empty_allowlist_fails_closed() {
+    // Operators set the allowlist to "" to disable cross-origin access.
+    // No origin should match.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        ""));
+}
+
+void test_null_allowlist_fails_closed() {
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        nullptr));
+}
+
+void test_allowlist_of_only_commas() {
+    // Pathological but possible: e.g., `,,,`. None of the empty entries
+    // should match.
+    TEST_ASSERT_FALSE(isOriginAllowed(
+        "https://wagfam-server.azurewebsites.net",
+        ",,,"));
+}
+
+void test_trailing_comma_doesnt_break_earlier_match() {
+    TEST_ASSERT_TRUE(isOriginAllowed(
+        "http://localhost:8000",
+        "http://localhost:8000,"));
+}
+
+// ── Entry point ─────────────────────────────────────────────────────────────
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_exact_match_single_entry);
+    RUN_TEST(test_match_first_entry_in_list);
+    RUN_TEST(test_match_last_entry_in_list);
+    RUN_TEST(test_match_middle_entry);
+    RUN_TEST(test_whitespace_around_entries_tolerated);
+    RUN_TEST(test_rejects_unknown_origin);
+    RUN_TEST(test_rejects_substring_match);
+    RUN_TEST(test_rejects_prefix_match);
+    RUN_TEST(test_rejects_scheme_mismatch);
+    RUN_TEST(test_rejects_port_mismatch);
+    RUN_TEST(test_empty_origin_fails_closed);
+    RUN_TEST(test_empty_allowlist_fails_closed);
+    RUN_TEST(test_null_allowlist_fails_closed);
+    RUN_TEST(test_allowlist_of_only_commas);
+    RUN_TEST(test_trailing_comma_doesnt_break_earlier_match);
+    return UNITY_END();
+}


### PR DESCRIPTION
@jrwagz — draft for your vacation review. Pairs with an upcoming wagfam-server PR that uses these CORS-enabled endpoints from `/lan/` to fix the legacy → 4.x config-wipe.

## Why

After PR #100 hardware-verified, you flagged that legacy → 4.x upgrades wipe `/conf.txt`. We diagnosed (in the PR #100 thread) that the wipe happens during firmware-boot's `LittleFS.begin()` fallback to `format()` when it can't mount the SPIFFS-formatted partition — _before_ /updatefs's preservation logic even runs.

The cleanest fix is to have the upgrade tool capture `/conf.txt` from the clock _before_ the upgrade and restore it _after_. That requires the wagfam-server's `/lan/` page (a different origin from the clock) to call `GET /api/config` and `POST /api/config` cross-origin. Today every such call is blocked: the firmware sets no CORS headers, and OPTIONS preflights get 302-redirected to `/spa/`.

This PR adds origin-whitelisted CORS to the JSON API so that capture/restore becomes possible.

## What's in the diff

- `marquee/OriginAllowlist.{h,cpp}` — pure helper `isOriginAllowed(origin, allowlist)`. No AsyncWebServer dependency, exhaustively tested on the host.
- `marquee/CorsSupport.{h,cpp}` — runtime header attachment + OPTIONS preflight handler.
- `marquee/marquee.ino`:
  - `sendJsonResponse` (the choke point every JSON API funnels through) now calls `setCorsHeaders` before `request->send`. Single-line change, covers all 14 endpoints.
  - `setup()` registers `handleCorsPreflight` as the HTTP_OPTIONS handler for every `/api/*` path.
- Build-flag macro `WAGFAM_CORS_ALLOWED_ORIGINS` lives in `CorsSupport.h` (not Settings.h) so CorsSupport.cpp can stay self-contained — Settings.h has variable definitions that would link-fail when included from a second translation unit.

Default allowlist:
- `https://wagfam-server.azurewebsites.net` (prod HTTPS, /admin/ PWA)
- `http://wagfam-server.azurewebsites.net` (prod HTTP, /lan/ upgrade page)
- `http://localhost:8000` (local dev)

## Why allowlist, not wildcard

`Access-Control-Allow-Origin: *` would let _any_ page on the user's home network read `/api/config` (which contains `WAGFAM_API_KEY`, `OWM_API_KEY`) by guessing the clock IP. That's a real attack on a family LAN. The whitelist echoes the matched origin back, satisfies our admin tools' CORS checks, and leaves everything else dark.

## Tests

- 15 new native tests (`tests/native/test_origin_allowlist/`) covering exact match, list iteration, whitespace tolerance, substring/prefix/scheme/port mismatch rejection, empty/null/malformed inputs.
- 122 native test cases total passing (existing 107 + 15 new).
- `make lint` clean.

## Hardware verified on the connected D1 mini

```
$ curl -i -X OPTIONS http://192.168.8.161/api/config \
    -H "Origin: https://wagfam-server.azurewebsites.net" \
    -H "Access-Control-Request-Method: POST"
HTTP/1.1 204 No Content
Access-Control-Allow-Origin: https://wagfam-server.azurewebsites.net
Access-Control-Allow-Methods: GET, POST, DELETE, OPTIONS
Access-Control-Allow-Headers: Content-Type, Authorization
Access-Control-Max-Age: 300
Vary: Origin

$ curl -i http://192.168.8.161/api/config -H "Origin: <allowed>"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://wagfam-server.azurewebsites.net
... full CORS headers + JSON body

$ curl -i -X POST http://192.168.8.161/api/config \
    -H "Origin: <allowed>" -H "Content-Type: application/json" \
    -d '{"display_intensity": 9}'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://wagfam-server.azurewebsites.net
{"status":"config updated"}
```

And the disallowed-origin case:

```
$ curl -i -X OPTIONS http://192.168.8.161/api/config \
    -H "Origin: https://evil.example.com" \
    -H "Access-Control-Request-Method: POST"
HTTP/1.1 204 No Content
(no Access-Control-* headers — browser will refuse the response)
```

## Size impact

- +1.4 KB flash (CORS helpers + 14 OPTIONS handler entries)
- 0 RAM delta

## What's left for the full upgrade-tool fix

Server-side `/lan/` page enhancement (separate PR, drafting next): admin auth, capture config before upgrade via `GET /api/config`, store in localStorage, restore via `POST /api/config` after the LittleFS push completes. With this firmware change, that PR can be done entirely client-side without further firmware changes. Will cross-link both PRs when the second one's up.