### PR TITLE
Runtime opt-out toggle for auto-update (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,20 +406,29 @@ ArduinoOTA was removed in v3.08.0-wagfam. Updates are now delivered six ways
 | --- | --- | --- | --- |
 | Sketch | Web upload (`/update`) | Manual via browser | No (use `/updateFromUrl` to revert) |
 | Sketch | URL update (`/updateFromUrl`) | Manual via web form | Boot-confirmation rollback |
-| Sketch | Auto-update (calendar JSON) | `latestVersion` != `VERSION`, gated by `WAGFAM_AUTO_UPDATE_DISABLED` | Boot-confirmation rollback |
+| Sketch | Auto-update (calendar JSON) | `latestVersion` != `VERSION`, gated by `WAGFAM_AUTO_UPDATE_DISABLED` + runtime `AUTO_UPDATE_ENABLED` | Boot-confirmation rollback |
 | LittleFS / SPA | Web upload (`/updatefs`) | Manual via browser | No |
 | LittleFS / SPA | URL update (`POST /api/spa/update-from-url`) | SPA "Update SPA" button | No |
-| LittleFS / SPA | Auto-update (calendar JSON) | `latestSpaVersion` != `SPA_VERSION`, gated by `WAGFAM_AUTO_UPDATE_DISABLED` | No |
+| LittleFS / SPA | Auto-update (calendar JSON) | `latestSpaVersion` != `SPA_VERSION`, gated by same compile + runtime flags | No |
 
-**Compile-time gate.** A single flag, `WAGFAM_AUTO_UPDATE_DISABLED`, gates *both*
-the sketch auto-update branch and the SPA auto-apply branch in `getWeatherData()`.
-Set via PlatformIO `-DWAGFAM_AUTO_UPDATE_DISABLED=1` (enabled in `[env:dev]` for
-local builds). The flag controls only the *automatic trigger* — SPA detection
-(`spa_update_available` in `/api/status`) and the manual "Update SPA" button in
-the SPA banner remain functional in every build configuration. The auto-apply
-SPA path also shares the same `OTA_CONFIRM_MS` / `otaConfirmAt` gates as
-firmware auto-update, so a SPA flash never fires inside the firmware-flash
-boot-confirmation window.
+**Two layered gates.** The auto-update path is controlled by two flags applied
+in order (issue #95):
+
+1. **Compile-time:** `WAGFAM_AUTO_UPDATE_DISABLED`. Set via PlatformIO
+   `-DWAGFAM_AUTO_UPDATE_DISABLED=1` (enabled in `[env:dev]`). Force-disables
+   auto-update; the runtime toggle is ignored. Surfaced as
+   `auto_update_compile_disabled` in `GET /api/config` so the SPA can show
+   the user that the build flag is in effect.
+2. **Runtime:** `AUTO_UPDATE_ENABLED` boolean in `/conf.txt`, exposed as
+   `auto_update_enabled` in `GET /api/config` and writable via
+   `POST /api/config`. SPA Settings tab → "Allow automatic updates" checkbox.
+   Defaults to `true`, so existing clocks keep auto-updating after upgrading.
+
+Both gate only the *automatic trigger* — SPA detection (`spa_update_available`
+in `/api/status`) and the manual "Update SPA" button in the SPA banner remain
+functional in every configuration. The auto-apply SPA path also shares the
+same `OTA_CONFIRM_MS` / `otaConfirmAt` gates as firmware auto-update, so a
+SPA flash never fires inside the firmware-flash boot-confirmation window.
 
 **Boot-confirmation rollback** applies to sketch flashes only. Before every
 sketch flash, a `/ota_pending.txt` record is written to LittleFS with the

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ customized as a family calendar + weather clock for a Wemos D1 Mini (ESP8266) wi
   animated border on event days
 - Configured entirely through a web interface (no re-flashing required for settings changes)
 - OTA firmware updates via web interface (file upload or URL), plus optional
-  calendar-driven auto-update for both the firmware sketch and the SPA bundle
-  (gated by a single compile-time flag, `WAGFAM_AUTO_UPDATE_DISABLED`)
+  calendar-driven auto-update for both the firmware sketch and the SPA bundle.
+  Gated by `WAGFAM_AUTO_UPDATE_DISABLED` at compile time and an
+  `auto_update_enabled` runtime toggle in the SPA Settings tab (issue #95)
 - Configurable scroll speed, brightness, and refresh interval
 
 ## Hardware

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -109,6 +109,14 @@ int minutesBetweenScrolling = 1; // Time in minutes between scrolling data (defa
 int displayScrollSpeed = 25; // In milliseconds -- Configurable by the web UI (slow = 35, normal = 25, fast = 15, very fast = 5)
 // The : will always flash on and off as a seconds indicator
 
+// Issue #95: runtime opt-out for both firmware and SPA auto-update. Layered
+// on top of the existing WAGFAM_AUTO_UPDATE_DISABLED compile flag — when the
+// compile flag is set, AUTO_UPDATE_ENABLED is ignored (force-disabled). When
+// the compile flag is NOT set, the runtime toggle gates auto-update.
+// Default true preserves the prior behavior for clocks upgrading from a
+// build that didn't have this setting.
+boolean AUTO_UPDATE_ENABLED = true;
+
 
 // Display Settings
 // CLK -> D5 (SCK)

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -42,6 +42,17 @@
 #define OTA_PENDING_FILE "/ota_pending.txt"
 #define OTA_CONFIRM_MS (5UL * 60UL * 1000UL)  // 5 minutes of stable uptime to confirm an update
 
+// Compile-time auto-update kill switch (issue #95). Resolves to a
+// `constexpr bool` rather than `#ifdef`/`#endif` so the call sites can use
+// plain `if (AUTO_UPDATE_COMPILE_DISABLED) ...` and the runtime toggle
+// (`AUTO_UPDATE_ENABLED` from Settings.h) sits beside it without nested
+// preprocessor blocks.
+#ifdef WAGFAM_AUTO_UPDATE_DISABLED
+constexpr bool AUTO_UPDATE_COMPILE_DISABLED = true;
+#else
+constexpr bool AUTO_UPDATE_COMPILE_DISABLED = false;
+#endif
+
 //declaring prototypes
 void setup();
 void loop();
@@ -1178,16 +1189,27 @@ void getWeatherData() //client function to send/receive GET request data.
 
   // Check for a remote firmware update pushed via the calendar config.
   //
-  // Build with `-DWAGFAM_AUTO_UPDATE_DISABLED=1` to skip this branch. Useful
-  // when running a locally-built firmware that the calendar server doesn't
-  // know about yet (the server's published latestVersion would otherwise
-  // not match VERSION, and the device would auto-revert to the server's
-  // build at the next calendar refresh — losing local work). Default
-  // behavior is unchanged: the flag must be set explicitly to disable.
-#ifdef WAGFAM_AUTO_UPDATE_DISABLED
-  Serial.println(F("[OTA] Auto-update disabled at build time (WAGFAM_AUTO_UPDATE_DISABLED)"));
-#else
-  if (serverConfig.latestVersionValid && serverConfig.firmwareUrlValid
+  // Two layered controls (issue #95):
+  //   - WAGFAM_AUTO_UPDATE_DISABLED build flag (AUTO_UPDATE_COMPILE_DISABLED):
+  //     force-disables auto-update, ignoring the runtime toggle. Useful for
+  //     locally-built firmware that the calendar server doesn't know about
+  //     (the server's latestVersion wouldn't match VERSION, and the device
+  //     would auto-revert to the server's build at the next refresh —
+  //     losing local work).
+  //   - AUTO_UPDATE_ENABLED runtime config: user-controlled toggle, exposed
+  //     via the SPA Settings tab and persisted in /conf.txt. Default true,
+  //     so existing clocks keep auto-updating after upgrading to a build
+  //     that has this setting.
+  //
+  // Detection of an available SPA update (below) is *always* performed
+  // regardless of either gate — those flags drive the manual "Update SPA"
+  // button, which must remain functional in every configuration. Only the
+  // *automatic* trigger is gated.
+  if (AUTO_UPDATE_COMPILE_DISABLED) {
+    Serial.println(F("[OTA] Auto-update disabled at build time (WAGFAM_AUTO_UPDATE_DISABLED)"));
+  } else if (!AUTO_UPDATE_ENABLED) {
+    Serial.println(F("[OTA] Auto-update disabled at runtime (AUTO_UPDATE_ENABLED=false)"));
+  } else if (serverConfig.latestVersionValid && serverConfig.firmwareUrlValid
       && serverConfig.latestVersion != String(VERSION)
       && serverConfig.firmwareUrl.startsWith("http://")
       && otaConfirmAt == 0
@@ -1202,14 +1224,13 @@ void getWeatherData() //client function to send/receive GET request data.
     // If we return here the update failed; continue normal operation
     }
   }
-#endif // WAGFAM_AUTO_UPDATE_DISABLED
 
   // Check for a remote SPA update pushed via the calendar config. Detection
   // (setting spaUpdateAvailable / pendingSpaFsUrl / pendingSpaVersion) is
-  // *always* performed regardless of WAGFAM_AUTO_UPDATE_DISABLED — those
-  // flags drive the manual "Update SPA" button in the SPA banner, which must
-  // remain functional in every build configuration. Only the *automatic*
-  // trigger below is gated by the compile flag.
+  // *always* performed regardless of either auto-update gate — those flags
+  // drive the manual "Update SPA" button in the SPA banner, which must
+  // remain functional in every configuration. Only the *automatic* trigger
+  // below is gated.
   if (serverConfig.latestSpaVersionValid && serverConfig.spaFsUrlValid
       && serverConfig.latestSpaVersion != SPA_VERSION
       && serverConfig.spaFsUrl.startsWith("http://")) {
@@ -1224,14 +1245,15 @@ void getWeatherData() //client function to send/receive GET request data.
   }
 
   // Auto-apply the SPA update if one was just detected. Mirrors the firmware
-  // auto-update branch above: same compile-time flag, same OTA confirmation
-  // gates (so a SPA flash never fires inside the firmware-flash confirmation
-  // window), same trusted-domain check. Defers the actual flash to the main
-  // loop's existing handler at processEverySecond() (which calls
-  // doOtaFsFlash()) by setting otaFsFromUrlRequested — same path the manual
-  // /api/spa/update-from-url endpoint uses.
-#ifndef WAGFAM_AUTO_UPDATE_DISABLED
-  if (spaUpdateAvailable && pendingSpaFsUrl.length() > 0
+  // auto-update branch above: same compile-time flag and same runtime toggle
+  // (issue #95), same OTA confirmation gates (so a SPA flash never fires
+  // inside the firmware-flash confirmation window), same trusted-domain
+  // check. Defers the actual flash to the main loop's existing handler at
+  // processEverySecond() (which calls doOtaFsFlash()) by setting
+  // otaFsFromUrlRequested — same path the manual /api/spa/update-from-url
+  // endpoint uses.
+  if (!AUTO_UPDATE_COMPILE_DISABLED && AUTO_UPDATE_ENABLED
+      && spaUpdateAvailable && pendingSpaFsUrl.length() > 0
       && otaConfirmAt == 0 && millis() > OTA_CONFIRM_MS
       && !otaFsFromUrlRequested) {
     if (!isTrustedFirmwareDomain(pendingSpaFsUrl, WAGFAM_DATA_URL, WAGFAM_TRUSTED_FIRMWARE_DOMAINS)) {
@@ -1247,7 +1269,6 @@ void getWeatherData() //client function to send/receive GET request data.
       spaOtaError = "";
     }
   }
-#endif // WAGFAM_AUTO_UPDATE_DISABLED
 
   Serial.println("Version: " + String(VERSION));
   Serial.println();
@@ -1396,6 +1417,7 @@ void savePersistentConfig() {
     f.println("OTA_SAFE_URL=" + OTA_SAFE_URL);
     f.println("DEVICE_NAME=" + DEVICE_NAME);
     f.println("LAST_APPLIED_CONFIG_VERSION=" + String(lastAppliedConfigVersion));
+    f.println("AUTO_UPDATE_ENABLED=" + String(AUTO_UPDATE_ENABLED ? 1 : 0));
   }
   f.close();
   // Apply current settings to hardware and clients directly.
@@ -1492,6 +1514,9 @@ void readPersistentConfig() {
     } else if (key == "LAST_APPLIED_CONFIG_VERSION") {
       lastAppliedConfigVersion = value.toInt();
       Serial.println("LAST_APPLIED_CONFIG_VERSION=" + String(lastAppliedConfigVersion));
+    } else if (key == "AUTO_UPDATE_ENABLED") {
+      AUTO_UPDATE_ENABLED = value.toInt() != 0;
+      Serial.println("AUTO_UPDATE_ENABLED=" + String(AUTO_UPDATE_ENABLED ? 1 : 0));
     }
   }
   fr.close();
@@ -1653,6 +1678,11 @@ void handleApiConfigGet(AsyncWebServerRequest *request) {
   doc["show_highlow"] = SHOW_HIGHLOW;
   doc["ota_safe_url"] = OTA_SAFE_URL;
   doc["device_name"] = DEVICE_NAME;
+  // Issue #95: runtime auto-update toggle. `auto_update_enabled` is the
+  // user-controllable boolean; `auto_update_compile_disabled` is read-only
+  // and lets the SPA show "force-disabled at build time" when applicable.
+  doc["auto_update_enabled"] = AUTO_UPDATE_ENABLED;
+  doc["auto_update_compile_disabled"] = AUTO_UPDATE_COMPILE_DISABLED;
 
   sendJsonResponse(request, 200, doc);
 }
@@ -1683,6 +1713,11 @@ static void applyConfigJson(JsonObject json) {
   if (json["show_highlow"].is<bool>()) SHOW_HIGHLOW = json["show_highlow"].as<bool>();
   if (json["device_name"].is<const char*>()) DEVICE_NAME = json["device_name"].as<String>();
   if (json["ota_safe_url"].is<const char*>()) OTA_SAFE_URL = json["ota_safe_url"].as<String>();
+  // Issue #95. The compile-flag-disabled case is reported back to the SPA
+  // via the read-only `auto_update_compile_disabled` field but isn't itself
+  // settable here — runtime writes always land, the compile flag just
+  // overrides them in the auto-update gate above.
+  if (json["auto_update_enabled"].is<bool>()) AUTO_UPDATE_ENABLED = json["auto_update_enabled"].as<bool>();
 }
 
 void handleApiConfigPost(AsyncWebServerRequest *request, JsonVariant &json) {

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -47,6 +47,10 @@ const DEFAULTS: ConfigData = {
   show_highlow: false,
   ota_safe_url: "",
   device_name: "",
+  // Issue #95: default-on so a clock that just upgraded to a build with
+  // this setting keeps auto-updating until the user explicitly opts out.
+  auto_update_enabled: true,
+  auto_update_compile_disabled: false,
 };
 
 const config = signal<ConfigData | null>(null);
@@ -299,6 +303,15 @@ export function SettingsPage() {
         />
       </div>
 
+      <div class="form-section">
+        <h2>Updates</h2>
+        <AutoUpdateRow
+          enabled={cfg.auto_update_enabled !== false}
+          compileDisabled={!!cfg.auto_update_compile_disabled}
+          onChange={(v) => setVal("auto_update_enabled", v)}
+        />
+      </div>
+
       <div class="save-bar">
         <button
           class="btn"
@@ -346,6 +359,41 @@ function ToggleRow({
         onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
       />
     </label>
+  );
+}
+
+function AutoUpdateRow({
+  enabled,
+  compileDisabled,
+  onChange,
+}: {
+  enabled: boolean;
+  compileDisabled: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  // When the firmware is built with WAGFAM_AUTO_UPDATE_DISABLED, the runtime
+  // toggle is force-overridden by the compile flag. Render the checkbox
+  // disabled (and unchecked, to reflect the effective state) and surface
+  // the build-flag note so the user understands why the toggle won't move.
+  return (
+    <div class="form-row" style="flex-direction: column; align-items: stretch;">
+      <label class="toggle-row" for="auto-update" style="width: 100%;">
+        <span class="form-label">Allow automatic updates</span>
+        <input
+          id="auto-update"
+          type="checkbox"
+          class="toggle"
+          checked={!compileDisabled && enabled}
+          disabled={compileDisabled}
+          onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+        />
+      </label>
+      <p class="form-note muted" style="margin-top: 4px;">
+        {compileDisabled
+          ? "Force-disabled at build time (WAGFAM_AUTO_UPDATE_DISABLED). The runtime toggle is ignored until the firmware is rebuilt without that flag."
+          : "Covers both firmware and SPA. The manual \"Update\" button in the SPA banner stays available either way."}
+      </p>
+    </div>
   );
 }
 

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -104,4 +104,13 @@ export interface ConfigData {
   show_highlow: boolean;
   ota_safe_url: string;
   device_name: string;
+  // Issue #95: runtime auto-update toggle. `auto_update_enabled` is the
+  // user-controllable boolean (default true) shown in Settings. The
+  // optional `auto_update_compile_disabled` is read-only metadata: when
+  // true, the firmware was built with WAGFAM_AUTO_UPDATE_DISABLED and the
+  // runtime toggle is ignored — the UI reflects this with a disabled
+  // checkbox + explanatory note. Both are optional so the SPA still
+  // renders against firmware that predates the field.
+  auto_update_enabled?: boolean;
+  auto_update_compile_disabled?: boolean;
 }


### PR DESCRIPTION
## Summary

Closes #95. Adds a user-controllable runtime toggle for both firmware and
SPA auto-update, layered on top of the existing
`WAGFAM_AUTO_UPDATE_DISABLED` compile flag.

- New \`AUTO_UPDATE_ENABLED\` boolean in \`/conf.txt\` (default true so
  existing clocks keep auto-updating after upgrade).
- \`GET /api/config\` exposes both \`auto_update_enabled\` (rw) and
  \`auto_update_compile_disabled\` (read-only).
- \`POST /api/config\` accepts \`auto_update_enabled\`; the compile-flag field
  is ignored (it's compile-time).
- SPA Settings → **Updates** section adds an "Allow automatic updates"
  checkbox. When the build flag is set, the checkbox renders disabled with
  a "Force-disabled at build time" note so the user knows why it won't move.
- Replaced the \`#ifdef WAGFAM_AUTO_UPDATE_DISABLED\` blocks in
  \`getWeatherData()\` with a \`constexpr bool AUTO_UPDATE_COMPILE_DISABLED\`
  so the call sites can use plain \`if/else\` against both gates.

## Layering rules

| Compile flag | Runtime toggle | Behavior |
|---|---|---|
| set | (anything) | force-disabled, toggle ignored |
| unset | true | auto-update enabled (default) |
| unset | false | auto-update disabled |

Detection (\`spa_update_available\`, manual "Update SPA" button, firmware
update banner) remains always-on regardless of either gate — only the
automatic trigger is affected.

## Merge order

This PR is independent of PR #101 (CORS) — touches different parts of
\`marquee.ino\`. Either order is fine. Suggested overall sequence across
the open work:

1. wagfam-server #32 — \`/lan/\` admin upgrade tool
2. wagfam-server #34 — server-side admin gate (stacks on #32)
3. **this PR** — auto-update toggle (independent, standalone)
4. marquee-scroller #101 — CORS layer (independent of this)

## Test plan

- [x] \`pio run -e default\` (compile flag unset) — builds clean
- [x] \`pio run -e dev\` (compile flag set) — builds clean
- [x] 107 native tests pass
- [x] SPA \`tsc --noEmit\` clean
- [x] markdownlint + ruff clean
- [ ] CI green
- [ ] Hardware smoke: flash a clock with the new firmware + SPA → toggle
      "Allow automatic updates" off in Settings → confirm \`/conf.txt\`
      persists \`AUTO_UPDATE_ENABLED=0\` → wait for next calendar refresh →
      confirm serial log shows \`[OTA] Auto-update disabled at runtime
      (AUTO_UPDATE_ENABLED=false)\` and no firmware update fires when the
      server publishes a different version.