### PR TITLE
Verify firmware/SPA SHA256 before flashing (#96 phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,18 @@ and tolerates missing ones:
 Up to 10 calendar `{"message": "..."}` entries are supported; they cycle
 through the marquee scroll.
 
+#### Pre-flash SHA256 verification (issue #96 phase A)
+
+When the server publishes `firmwareSha256` (alongside `firmwareUrl`) and/or
+`spaFsSha256` (alongside `spaFsUrl`) in the `config` block, the firmware
+streams the downloaded bytes through SHA256 and refuses to flash on
+mismatch. When the field is absent (older server), the firmware logs
+`[OTA] No expected SHA256 from server; skipping verification` and proceeds
+— forward-compat with deployments where the server hasn't been upgraded
+yet. See `verifyOtaSha256()` in `marquee/marquee.ino` and
+[`docs/OTA_STRATEGY.md`](docs/OTA_STRATEGY.md) for the verifier and its
+failure modes.
+
 ### Device Heartbeat
 
 Each calendar fetch includes device telemetry as URL query parameters (`chip_id`, `version`,

--- a/docs/OTA_STRATEGY.md
+++ b/docs/OTA_STRATEGY.md
@@ -129,12 +129,18 @@ and `firmwareUrl` in the `config` block:
   {
     "config": {
       "latestVersion": "3.08.0-wagfam",
-      "firmwareUrl": "http://example.com/marquee-v3.08.0.bin"
+      "firmwareUrl": "http://example.com/marquee-v3.08.0.bin",
+      "firmwareSha256": "deadbeef…64-hex-chars…00ff"
     }
   },
   { "message": "Justin's Birthday - 3 days away" }
 ]
 ```
+
+`firmwareSha256` (and the parallel `spaFsSha256` for the SPA-FS path) is
+optional (issue #96 phase A). When present, the device pre-fetches the
+binary, computes its SHA256, and aborts the flash on mismatch. When absent
+(older server), the device skips the check and proceeds — forward-compat.
 
 When `getWeatherData()` processes the server response, it compares `latestVersion`
 against the compiled `VERSION` macro. If they differ and all guard conditions pass,

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -198,6 +198,10 @@ void WagFamBdayClient::value(String value) {
     } else if (currentKey == "firmwareUrl") {
       currentConfig.firmwareUrlValid = true;
       currentConfig.firmwareUrl = value;
+    } else if (currentKey == "firmwareSha256") {
+      // Issue #96 phase A: pre-flash hash check.
+      currentConfig.firmwareSha256Valid = true;
+      currentConfig.firmwareSha256 = value;
     } else if (currentKey == "deviceName") {
       currentConfig.deviceNameValid = true;
       currentConfig.deviceName = value;
@@ -207,6 +211,9 @@ void WagFamBdayClient::value(String value) {
     } else if (currentKey == "spaFsUrl") {
       currentConfig.spaFsUrlValid = true;
       currentConfig.spaFsUrl = value;
+    } else if (currentKey == "spaFsSha256") {
+      currentConfig.spaFsSha256Valid = true;
+      currentConfig.spaFsSha256 = value;
     } else if (currentKey == "trollMessage") {
       // Issue #99: server tells us to display only this string and ignore
       // the regular calendar messages. cleanText() to handle smart quotes

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -59,12 +59,21 @@ class WagFamBdayClient: public JsonListener {
       String latestVersion;
       boolean firmwareUrlValid;
       String firmwareUrl;
+      // Issue #96 phase A: SHA256 hex of the firmware bin at firmwareUrl,
+      // published by the server. When valid, the firmware verifies this
+      // before flashing; when missing, verification is skipped (forward-
+      // compat with older server builds that don't publish the field).
+      boolean firmwareSha256Valid;
+      String firmwareSha256;
       boolean deviceNameValid;
       String deviceName;
       boolean latestSpaVersionValid;
       String latestSpaVersion;
       boolean spaFsUrlValid;
       String spaFsUrl;
+      // Issue #96 phase A: SHA256 hex of the SPA-FS bin at spaFsUrl.
+      boolean spaFsSha256Valid;
+      String spaFsSha256;
       // Issue #99: troll message override. When non-empty, marquee.ino
       // displays this string exclusively and skips the calendar messages.
       boolean trollMessageValid;

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -69,7 +69,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.4.0-wagfam"
+#define BASE_VERSION "4.4.1-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -36,6 +36,7 @@
 #include <Fonts/Org_01.h>
 #include "WagfamFont.h"
 #include "ClockStyles.h"
+#include <bearssl/bearssl_hash.h>  // br_sha256_* for OTA SHA256 verification (issue #96)
 
 // Scroller font registry (issue #106). Index 0 is the Adafruit_GFX builtin
 // 5x7 fixed-width font (passed as nullptr to setFont). Other entries are
@@ -115,9 +116,13 @@ void scrollMessageWait(const String &msg);
 void centerPrint(const String &msg, bool extraStuff = false);
 void renderClockFace(bool isRefresh = false);
 String EncodeUrlSpecialChars(const char *msg);
-void performAutoUpdate(const String &firmwareUrl);
+void performAutoUpdate(const String &firmwareUrl, const String &expectedSha256);
 void checkOtaRollback();
 static void doOtaFlash(const String &firmwareUrl);
+// Issue #96 phase A: pre-flash SHA256 verification. Streams `url`, hashes
+// the bytes, compares to `expectedHex`. Empty `expectedHex` returns true
+// (forward-compat with older server that doesn't publish hashes).
+static bool verifyOtaSha256(const String &url, const String &expectedHex);
 
 void handleUpdateFromUrl(AsyncWebServerRequest *request);
 
@@ -139,7 +144,7 @@ void handleApiFsWrite(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiFsDelete(AsyncWebServerRequest *request);
 void handleApiFsList(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
-static void doOtaFsFlash(const String &fsUrl);
+static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
 
 // LED Settings
 int spacer = 1;  // dots between letters
@@ -172,8 +177,10 @@ String SPA_VERSION = "unknown"; // Read from /spa/version.json at boot; "unknown
 bool spaUpdateAvailable = false;
 String pendingSpaFsUrl = "";
 String pendingSpaVersion = ""; // Server-published latest SPA version when an update is pending
+String pendingSpaFsSha256 = ""; // Server-published SHA256 of pendingSpaFsUrl (issue #96 phase A); empty if server didn't publish one
 bool otaFsFromUrlRequested = false;
 String pendingOtaFsUrl = "";
+String pendingOtaFsSha256 = ""; // Expected SHA256 carried alongside pendingOtaFsUrl. Empty for the manual /api/spa/update-from-url path (no server-side hash to verify against) and for older-server cases.
 
 // SPA-FS OTA status, surfaced via /api/status so the SPA UI can detect
 // silent failures of the deferred flash run by doOtaFsFlash(). Value
@@ -740,14 +747,16 @@ void processEverySecond() {
   // (ESPhttpUpdate.updateSpiffs() reboots internally before we can restore it).
   if (otaFsFromUrlRequested && pendingOtaFsUrl.length() > 0) {
     String url = pendingOtaFsUrl;
+    String sha = pendingOtaFsSha256;
     otaFsFromUrlRequested = false;
     pendingOtaFsUrl = "";
+    pendingOtaFsSha256 = "";
     digitalWrite(externalLight, LOW);
     matrix.fillScreen(LOW);
     scrollMessageWait(F("   ...Updating SPA..."));
     centerPrint(F("..."));
     Serial.printf_P(PSTR("[OTAFS] Starting deferred FS update from URL: %s\n"), url.c_str());
-    doOtaFsFlash(url);
+    doOtaFsFlash(url, sha);
     // Only reached on failure — doOtaFsFlash reboots the device on success.
     digitalWrite(externalLight, HIGH);
   }
@@ -917,10 +926,24 @@ void handleUpdateFromUrl(AsyncWebServerRequest *request) {
 }
 
 // Trigger an OTA update from the given HTTP URL (called from the auto-update path).
-// Writes a rollback record to LittleFS before flashing so crash-loop recovery is possible.
-// On ESPhttpUpdate success the device reboots; this function only returns on failure.
-void performAutoUpdate(const String &firmwareUrl) {
+//
+// Phase A SHA256 verification (issue #96): if `expectedSha256` is non-empty,
+// pre-fetch the firmware bytes and verify their SHA256 against the value
+// before invoking the actual flash. On mismatch (or fetch failure) we abort
+// without touching the sketch partition. An empty `expectedSha256` skips the
+// check, preserving compatibility with older server builds that don't
+// publish the field.
+//
+// Writes a rollback record to LittleFS before flashing so crash-loop
+// recovery is possible. On ESPhttpUpdate success the device reboots; this
+// function only returns on failure.
+void performAutoUpdate(const String &firmwareUrl, const String &expectedSha256) {
   Serial.printf_P(PSTR("[OTA] Auto-update from: %s\n"), firmwareUrl.c_str());
+
+  if (!verifyOtaSha256(firmwareUrl, expectedSha256)) {
+    Serial.println(F("[OTA] Pre-flight SHA256 verification failed; aborting auto-update"));
+    return;
+  }
 
   matrix.fillScreen(LOW);
   scrollMessageWait(F("   ...Auto Updating..."));
@@ -930,6 +953,86 @@ void performAutoUpdate(const String &firmwareUrl) {
 
   // Only reached on failure
   Serial.printf_P(PSTR("[OTA] Auto-update failed.\n"));
+}
+
+// Pre-flight SHA256 of an OTA download (issue #96 phase A).
+//
+// Streams the bytes at `url` through SHA256 and compares the resulting hex
+// digest to `expectedHex` (case-insensitive). Returns true on match OR when
+// `expectedHex` is empty (forward-compat: older server doesn't publish a
+// hash, so we skip the check). Returns false on any fetch error or hash
+// mismatch — caller MUST abort.
+//
+// Trade-off: this doubles the network bandwidth on auto-update because we
+// fetch once for hashing and ESPhttpUpdate fetches again for the actual
+// flash. That's a few hundred KB extra per update, negligible on our
+// fleet. The alternative (replacing ESPhttpUpdate with manual streaming
+// so we hash + flash in one pass) is a much larger surgery on the OTA
+// flow; the bandwidth cost buys us a localized, low-risk change.
+static bool verifyOtaSha256(const String &url, const String &expectedHex) {
+  if (expectedHex.length() == 0) {
+    Serial.println(F("[OTA] No expected SHA256 from server; skipping verification"));
+    return true;
+  }
+
+  WiFiClient httpClient;
+  HTTPClient http;
+  http.begin(httpClient, url);
+  http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
+  int code = http.GET();
+  if (code != HTTP_CODE_OK) {
+    Serial.printf_P(PSTR("[OTA] SHA256 pre-fetch HTTP %d for %s\n"), code, url.c_str());
+    http.end();
+    return false;
+  }
+
+  br_sha256_context shaCtx;
+  br_sha256_init(&shaCtx);
+
+  WiFiClient *stream = http.getStreamPtr();
+  uint8_t buf[512];
+  int contentLength = http.getSize();
+  int totalRead = 0;
+  while (http.connected() && (contentLength <= 0 || totalRead < contentLength)) {
+    size_t avail = stream->available();
+    if (avail) {
+      size_t toRead = min(avail, sizeof(buf));
+      size_t got = stream->readBytes(buf, toRead);
+      br_sha256_update(&shaCtx, buf, got);
+      totalRead += got;
+    } else if (contentLength > 0 && totalRead >= contentLength) {
+      break;
+    }
+    yield();
+  }
+  http.end();
+
+  if (contentLength > 0 && totalRead < contentLength) {
+    Serial.printf_P(PSTR("[OTA] SHA256 pre-fetch truncated at %d/%d bytes\n"),
+                    totalRead, contentLength);
+    return false;
+  }
+
+  uint8_t digest[32];
+  br_sha256_out(&shaCtx, digest);
+
+  char actualHex[65];
+  for (int i = 0; i < 32; i++) {
+    snprintf(&actualHex[i * 2], 3, "%02x", digest[i]);
+  }
+  actualHex[64] = '\0';
+
+  if (!String(actualHex).equalsIgnoreCase(expectedHex)) {
+    Serial.print(F("[OTA] SHA256 mismatch! expected="));
+    Serial.print(expectedHex);
+    Serial.print(F(" actual="));
+    Serial.println(actualHex);
+    return false;
+  }
+  Serial.print(F("[OTA] SHA256 verified ("));
+  Serial.print(String(actualHex).substring(0, 16));
+  Serial.println(F("...)"));
+  return true;
 }
 
 // Helper: record a SPA OTA failure, log it to serial, and reset HTTP/FS
@@ -956,9 +1059,17 @@ static void spaOtaFail(const __FlashStringHelper *stage, const String &detail,
 // Never returns on success — the device reboots after a successful flash.
 // On any failure, sets spaOtaStatus="failed" + spaOtaError so the SPA poll
 // loop in StatusPage can surface it instead of silently returning success.
-static void doOtaFsFlash(const String &fsUrl) {
+static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256) {
   spaOtaStatus = "downloading";
   spaOtaError = "";
+
+  // Issue #96 phase A: pre-flight SHA256 against the server-published hash.
+  // Done before LittleFS.end() so a hash failure leaves the existing FS
+  // intact and the device keeps working with its current SPA bundle.
+  if (!verifyOtaSha256(fsUrl, expectedSha256)) {
+    spaOtaFail(F("sha256"), "downloaded SPA bundle hash didn't match server", nullptr);
+    return;
+  }
 
   // Back up /conf.txt before unmounting LittleFS.
   String confBackup = "";
@@ -1304,7 +1415,8 @@ void getWeatherData() //client function to send/receive GET request data.
       Serial.println(F("[SEC] Rejected firmware URL — domain not allowlisted and does not match calendar source"));
     } else {
     Serial.println("[OTA] Server version: " + serverConfig.latestVersion + ", current: " + String(VERSION));
-    performAutoUpdate(serverConfig.firmwareUrl);
+    String fwSha = serverConfig.firmwareSha256Valid ? serverConfig.firmwareSha256 : String();
+    performAutoUpdate(serverConfig.firmwareUrl, fwSha);
     // If we return here the update failed; continue normal operation
     }
   }
@@ -1321,11 +1433,13 @@ void getWeatherData() //client function to send/receive GET request data.
     spaUpdateAvailable = true;
     pendingSpaFsUrl = serverConfig.spaFsUrl;
     pendingSpaVersion = serverConfig.latestSpaVersion;
+    pendingSpaFsSha256 = serverConfig.spaFsSha256Valid ? serverConfig.spaFsSha256 : String();
     Serial.println("[SPA] Update available: server=" + serverConfig.latestSpaVersion + ", current=" + SPA_VERSION);
   } else {
     spaUpdateAvailable = false;
     pendingSpaFsUrl = "";
     pendingSpaVersion = "";
+    pendingSpaFsSha256 = "";
   }
 
   // Auto-apply the SPA update if one was just detected. Mirrors the firmware
@@ -1345,6 +1459,7 @@ void getWeatherData() //client function to send/receive GET request data.
     } else {
       Serial.println("[SPA] Auto-applying SPA update: " + pendingSpaVersion);
       pendingOtaFsUrl = pendingSpaFsUrl;
+      pendingOtaFsSha256 = pendingSpaFsSha256;
       otaFsFromUrlRequested = true;
       // Mirror handleApiSpaUpdateFromUrl: surface progress via /api/status
       // spa_ota.{status,error} so the SPA waitForUpdateOutcome() poll picks
@@ -1991,6 +2106,10 @@ void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json
   }
 
   pendingOtaFsUrl = url;
+  // Manual SPA update from the SPA Settings tab: the user supplies the URL
+  // directly, so there is no server-published hash to verify against.
+  // doOtaFsFlash treats an empty expectedSha256 as "skip verification."
+  pendingOtaFsSha256 = "";
   otaFsFromUrlRequested = true;
   spaOtaStatus = "queued";
   spaOtaError = "";

--- a/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
+++ b/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
@@ -259,6 +259,51 @@ void test_config_spa_fields_with_firmware_fields() {
     TEST_ASSERT_EQUAL_STRING("http://example.com/littlefs.bin", cfg.spaFsUrl.c_str());
 }
 
+// Issue #96 phase A: SHA256 hash fields next to their respective URLs.
+
+void test_config_firmware_sha256_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"config\":{"
+        "\"firmwareUrl\":\"http://example.com/fw.bin\","
+        "\"firmwareSha256\":\"deadbeef00112233445566778899aabbccddeeff0011223344556677889900ff\""
+        "}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.firmwareSha256Valid);
+    TEST_ASSERT_EQUAL_STRING(
+        "deadbeef00112233445566778899aabbccddeeff0011223344556677889900ff",
+        cfg.firmwareSha256.c_str());
+}
+
+void test_config_spa_fs_sha256_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"config\":{"
+        "\"spaFsUrl\":\"http://example.com/littlefs.bin\","
+        "\"spaFsSha256\":\"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\""
+        "}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.spaFsSha256Valid);
+    TEST_ASSERT_EQUAL_STRING(
+        "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+        cfg.spaFsSha256.c_str());
+}
+
+void test_config_sha256_absent_when_not_published() {
+    // Older server doesn't publish the hash fields; the parser must leave
+    // them invalid so verifyOtaSha256 falls through to the skip-verification
+    // path (forward compat).
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"config\":{"
+        "\"firmwareUrl\":\"http://example.com/fw.bin\","
+        "\"spaFsUrl\":\"http://example.com/littlefs.bin\""
+        "}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_FALSE(cfg.firmwareSha256Valid);
+    TEST_ASSERT_FALSE(cfg.spaFsSha256Valid);
+}
+
 void test_config_device_name_parsed() {
     WagFamBdayClient client("", "");
     feed_json(client, "[{\"config\":{\"deviceName\":\"Kitchen Clock\"}}]");
@@ -347,6 +392,9 @@ int main() {
     RUN_TEST(test_config_absent_fields_not_valid);
     RUN_TEST(test_config_latest_spa_version_parsed);
     RUN_TEST(test_config_spa_fs_url_parsed);
+    RUN_TEST(test_config_firmware_sha256_parsed);
+    RUN_TEST(test_config_spa_fs_sha256_parsed);
+    RUN_TEST(test_config_sha256_absent_when_not_published);
     RUN_TEST(test_config_spa_fields_with_firmware_fields);
     RUN_TEST(test_config_device_name_parsed);
     RUN_TEST(test_config_device_name_with_other_fields);


### PR DESCRIPTION
## Summary

Phase A of #96, firmware side. Reads \`firmwareSha256\` / \`spaFsSha256\` from the calendar response and verifies the downloaded bytes before flashing. On mismatch (or any pre-flight fetch failure) the update aborts without touching the sketch partition or the LittleFS partition.

- Parser (\`WagFamBdayClient\`): two new fields + validity flags, parsed alongside the existing \`firmwareUrl\` / \`spaFsUrl\` keys.
- New \`verifyOtaSha256(url, expectedHex)\` helper in \`marquee.ino\` — streams the bytes at \`url\` through BearSSL \`br_sha256_*\`, compares hex digests, returns false on mismatch. Empty \`expectedHex\` returns true (forward-compat).
- \`performAutoUpdate(url, expectedSha256)\` runs the pre-flight before \`doOtaFlash\`.
- \`doOtaFsFlash(url, expectedSha256)\` runs the pre-flight before LittleFS.end() / Update.begin(), so a failed verification leaves the existing FS intact.
- New globals \`pendingSpaFsSha256\` / \`pendingOtaFsSha256\` carry the expected hash through the deferred SPA-flash queue. Manual \`/api/spa/update-from-url\` writes an empty hash (no server-published hash to verify against).

## Forward compat

When the server doesn't publish the hash field (older build, or before #36 lands and is deployed), \`firmwareSha256Valid\` stays false and \`verifyOtaSha256\` falls through to the skip-verification path with a serial log. So this PR is safe to land even before the server-side counterpart (#36) is deployed — clocks just keep auto-updating without the verification pass until the server starts publishing hashes.

## Bandwidth trade-off

Pre-flight is a separate fetch from the actual flash. That doubles the network bandwidth on auto-update — a few hundred KB extra per update, negligible on our scale. The alternative (replacing ESPhttpUpdate with manual streaming so we hash + flash in one pass) is a much larger surgery on the OTA flow; this approach buys a localized, low-risk change.

## Merge order

This is the **firmware half** of #96. Pair PR is wagfam-server #36 (server publishes the hashes). Order:

1. Land + deploy wagfam-server #36 first.
2. Then land + ship this PR.
3. After both are deployed: clocks running new firmware will verify; clocks running older firmware will ignore the new field.

If we want to land this PR before #36 deploys, that's also fine — clocks won't see the field, will skip verification, and behave exactly as before.

Suggested overall sequence across the open work:

1. wagfam-server #32 — \`/lan/\` admin upgrade tool
2. wagfam-server #34 — server-side admin gate (stacks on #32)
3. marquee-scroller #102 — auto-update toggle (independent)
4. marquee-scroller #101 — CORS layer (independent)
5. wagfam-server #35 — calendar caching (independent)
6. wagfam-server #36 — server publishes SHA256
7. **this PR** — firmware verifies SHA256 (deploy #36 first for verification to actually fire)

## Test plan

- [x] 3 new native parser tests (firmware hash parsed, SPA hash parsed, absent → not valid)
- [x] 110 native tests pass total
- [x] \`pio run -e default\` — RAM 45.9% / Flash 53.9%, clean build
- [x] markdownlint + ruff clean
- [x] CI green
- [ ] Hardware smoke (after server #36 is deployed): trigger a real auto-update against published bin → confirm serial log shows \`[OTA] SHA256 verified (...)\` followed by the flash.
- [ ] Hardware smoke negative (after server #36 is deployed): publish a bin with a deliberately wrong SHA256 → confirm serial log shows \`[OTA] SHA256 mismatch! ...\` and the device does NOT flash.