### PR TITLE
Refresh README calendar example with already-merged config fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,15 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
   {
     "config": {
       "eventToday": "1",
-      "deviceName": "Kitchen Clock"
+      "deviceName": "Kitchen Clock",
+      "latestVersion": "4.2.0-wagfam-7918f29",
+      "firmwareUrl": "http://files.example.com/marquee-4.2.0-wagfam-7918f29.bin",
+      "latestSpaVersion": "4.2.0-wagfam-7918f29",
+      "spaFsUrl": "http://files.example.com/marquee-4.2.0-wagfam-7918f29-littlefs.bin",
+      "trollMessage": "Go Cougars!",
+      "configUpdateVersion": 3,
+      "configUpdatePayload": "{\"display_intensity\":8}",
+      "configUpdateSignature": "..."
     }
   },
   { "message": "Justin's Birthday - 3 days away" },
@@ -170,10 +178,20 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
 ]
 ```
 
-- Up to 10 messages are supported; they cycle through the marquee scroll
-- The `config` block is optional; if present, `eventToday: 1` enables an animated dot border around the clock display
-  for the day
-- The `config` block can also remotely update `dataSourceUrl`, `apiKey`, and `deviceName` on the device
+The `config` block fields are all optional; the firmware ignores unknown keys
+and tolerates missing ones:
+
+| Field | What the firmware does with it |
+| --- | --- |
+| `eventToday` | `1` enables an animated dot border around the clock display for the day |
+| `deviceName` | Stored on the device and shown in the SPA |
+| `latestVersion` + `firmwareUrl` | When `latestVersion` differs from the firmware's compiled-in `VERSION`, auto-update fires (subject to compile-time + runtime opt-out flags — see "Features"). HTTP only; HTTPS not supported by ESP8266HTTPUpdate without large heap cost |
+| `latestSpaVersion` + `spaFsUrl` | Same model as firmware, but for the LittleFS partition (SPA bundle). `/conf.txt` is preserved across the flash |
+| `trollMessage` | When non-empty the clock displays *only* this string and ignores calendar messages. RAM-only on the clock — a power cycle clears it. Issue #99 |
+| `configUpdateVersion` + `configUpdatePayload` + `configUpdateSignature` | A signed remote config update. Clock verifies the ECDSA-P256 signature against its embedded public key over the canonical payload bytes; applies iff the version is strictly greater than `LAST_APPLIED_CONFIG_VERSION`. Issue #99 |
+
+Up to 10 calendar `{"message": "..."}` entries are supported; they cycle
+through the marquee scroll.
 
 ### Device Heartbeat
 


### PR DESCRIPTION
The README's WagFam Calendar example only documented the original two fields (`eventToday` + `deviceName`). Several fields have shipped since but never made it into the docs:

- `latestVersion` + `firmwareUrl` — firmware auto-update path
- `latestSpaVersion` + `spaFsUrl` — SPA auto-update path (issue #72)
- `trollMessage` — issue #99
- `configUpdateVersion` / `configUpdatePayload` / `configUpdateSignature` — issue #99 ECDSA-signed remote config updates

This PR documents what's already in production. No firmware code change.

## Deliberately not in this PR

`firmwareSha256` / `spaFsSha256` (issue #96 phase A) live on the [PR #103](https://github.com/jrwagz/marquee-scroller/pull/103) branch — they roll back naturally if that PR doesn't merge.

## Test plan

- [x] `make lint` — markdownlint clean
- No code changed.