### PR TITLE
Add separate clock-face style registry with 10 new styles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ All firmware source lives in [marquee/](marquee/):
 | [MdnsHelpers.h/.cpp](marquee/MdnsHelpers.h) | DNS-safe hostname sanitization for mDNS bringup (extracted so it's testable under tests/native/) |
 | [timeNTP.h/.cpp](marquee/timeNTP.h) | NTP time sync; exposes `timeNTPsetup()`, `getNtpTime()`, and `set_timeZoneSec()` |
 | [timeStr.h/.cpp](marquee/timeStr.h) | Time formatting helpers (zero-pad, day/month names, etc.) |
+| [ClockStyles.h](marquee/ClockStyles.h) | Selectable clock-face render styles, registry with 12h/24h compatibility flags, and per-style render functions (Mega, Stack, Pulse, Frame, etc.) |
 
 The SPA frontend lives in [`webui/`](webui/) — Vite + Preact + signals + TypeScript.
 See [`docs/WEBUI.md`](docs/WEBUI.md) for the build pipeline and deploy story. Bundle is

--- a/README.md
+++ b/README.md
@@ -170,11 +170,37 @@ Tall. Together they share the same `marquee/WagfamFont.h` PROGMEM bank generated
 | 13 | Inverse | Tall inverted in the top h-1 rows — stylized "block-art" aesthetic, not strict legibility |
 | 14 | Stencil | Tall with 1-pixel "bridge" cuts in the middle of every long vertical stroke |
 
-The clock face always uses Classic; only the marquee scroll changes. The selection persists
-in `/conf.txt` (`scrollFont=` key) and is exposed via `display_font` on `/api/config`. The
-six hand-designed custom fonts (Block, Tall, Bold, Slim, Outline, Digi) and the five derived
-ones (Italic, Serif, Pixel, Inverse, Stencil) all live in `marquee/WagfamFont.h`; re-run
-`scripts/gen_wagfam_font.py` after editing the GLYPHS dicts or the procedural transforms.
+The marquee font selection persists in `/conf.txt` (`scrollFont=` key) and is exposed via
+`display_font` on `/api/config`. The six hand-designed custom fonts (Block, Tall, Bold, Slim,
+Outline, Digi) and the five derived ones (Italic, Serif, Pixel, Inverse, Stencil) all live
+in `marquee/WagfamFont.h`; re-run `scripts/gen_wagfam_font.py` after editing the GLYPHS dicts
+or the procedural transforms.
+
+### Clock face style
+
+The clock face has its own selectable rendering — separate from the marquee font, since the
+clock only ever shows ten digits + a colon (and an AM/PM marker in 12-hour mode), which lets
+each style optimize layout for that constrained alphabet. Selection persists as `clockStyle=`
+in `/conf.txt` and is exposed as `display_clock_style` on `/api/config`. Render functions
+live in [`marquee/ClockStyles.h`](marquee/ClockStyles.h).
+
+| ID | Name | 12h | 24h | Notes |
+| --- | --- | --- | --- | --- |
+| 0 | Classic | ✓ | ✓ | Default — Adafruit 5x7 digits, blinking colon, top-right PM dot |
+| 1 | Mega | ✓ | ✗ | Bespoke 5x8 digits filling the full matrix height |
+| 2 | Banner | ✓ | ✓ | Classic digits + horizontal rule across the bottom row, corner notches up top |
+| 3 | Pulse | ✓ | ✓ | Classic digits with an animated heartbeat colon (alternates dot ↔ square every 500 ms) |
+| 4 | Stack | ✓ | ✗ | Hour digits in the top half, minute digits in the bottom half, custom 3x4 micro-digits |
+| 5 | Frame | ✓ | ✓ | Classic time inside a 1-pixel rectangular border |
+| 6 | Suffix | ✓ | ✗ | Classic digits at left, "AM"/"PM" rendered with TomThumb at right |
+| 7 | Inverse | ✓ | ✗ | Solid 32x7 plate with the time digits carved out as negative space |
+| 8 | Stencil | ✓ | ✓ | Bespoke 5x8 digits with a 1-pixel "bridge" cut at the midline of every vertical stem |
+| 9 | Italic | ✓ | ✗ | Bespoke 5x8 digits with the upper half row-shifted right by 1 column |
+| 10 | Dotted | ✓ | ✓ | Bespoke 5x8 digits with a `(x*7+y*13)%5==0` halftone speckle |
+
+Styles flagged as 12h-only fall back to **Classic** at render time when the device is in
+24-hour mode (no manual switching needed). The SPA Settings tab shows a hint when a 12h-only
+style is paired with a 24-hour clock.
 
 ### API Keys
 

--- a/marquee/ClockStyles.h
+++ b/marquee/ClockStyles.h
@@ -1,0 +1,693 @@
+// Clock face render styles — separate registry from the marquee scroller fonts
+// because the clock display has different constraints: only ten digits, a
+// colon, and (in 12-hour mode) an AM/PM marker. Knowing the exact glyph set
+// lets each style optimize layout and use pixels we couldn't on a general
+// scrolling font.
+//
+// Per-frame the main loop dispatches `centerPrint(displayTime, true)` through
+// renderClock(); the selected style's `render(...)` clears the matrix, draws
+// the time creatively, draws the optional event-day border, and writes the
+// frame. Styles with `supports24h == false` are skipped (Classic falls back)
+// when the device is in 24-hour mode.
+#pragma once
+
+#include <Adafruit_GFX.h>
+
+// Forward declarations from marquee.ino / Settings.h — let render() functions
+// read live state without us having to plumb every global through the function
+// pointer. Types here MUST match the originals exactly or the linker will pick
+// a different symbol — `boolean` (Arduino's uint8_t typedef) for the booleans,
+// uint32_t for the dot-walker counters, plain int for the spacing constants.
+extern Max72xxPanel matrix;
+extern boolean WAGFAM_EVENT_TODAY;
+extern boolean IS_PM;
+extern boolean IS_24HOUR;
+extern int width;            // 6 — Adafruit builtin 5x7 char advance
+extern uint32_t todayDisplayMilliSecond;
+extern uint32_t todayDisplayStartingLED;
+extern int TODAY_DISPLAY_DOT_SPACING;
+extern int TODAY_DISPLAY_DOT_SPEED_MS;
+
+// Render callback signature. ``hour12`` is 1..12 (always — the renderer
+// converts back to 24h itself if it cares); ``isPM`` is meaningful only when
+// the style is 12h-only. ``isRefresh`` mirrors centerPrint's existing flag —
+// when the device is mid-data-refresh we hold the colon visible so the frame
+// stays readable. ``eventDay`` triggers the dotted border.
+typedef void (*ClockRenderFn)(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                              bool isPM, bool isRefresh, bool eventDay);
+
+struct ClockStyle {
+  const char *name;        // user-facing label
+  bool supports12h;        // safe to use when IS_24HOUR == false
+  bool supports24h;        // safe to use when IS_24HOUR == true
+  ClockRenderFn render;
+};
+
+
+// ── Shared helpers ──────────────────────────────────────────────────────────
+
+// Animated event-day border, lifted from centerPrint() so every style can
+// opt in. Same math: walk a "starting LED" cursor around the U-shaped border
+// (left edge top→bottom, bottom edge left→right, right edge bottom→top) and
+// light up every TODAY_DISPLAY_DOT_SPACING-th pixel.
+inline void drawEventDayBorder() {
+  todayDisplayMilliSecond = millis() % (TODAY_DISPLAY_DOT_SPACING * TODAY_DISPLAY_DOT_SPEED_MS);
+  todayDisplayStartingLED = todayDisplayMilliSecond / TODAY_DISPLAY_DOT_SPEED_MS;
+  for (int i = 0; i < (matrix.height() * 2 + matrix.width() - 2); i++) {
+    if ((i % TODAY_DISPLAY_DOT_SPACING) == (int)todayDisplayStartingLED) {
+      if (i < matrix.height()) {
+        matrix.drawPixel(0, i, HIGH);
+      } else if (i < (matrix.height() + matrix.width() - 2)) {
+        matrix.drawPixel(i - (matrix.height() - 1), matrix.height() - 1, HIGH);
+      } else {
+        matrix.drawPixel(matrix.width() - 1,
+                         (matrix.height() - 1) - (i - (matrix.height() + matrix.width() - 2)),
+                         HIGH);
+      }
+    }
+  }
+}
+
+// Draw the standard PM dot at the top-right corner — same position as
+// centerPrint's existing logic so styles that fall through to Classic don't
+// have to duplicate the math.
+inline void drawPmDotIfNeeded(bool isPM) {
+  if (!IS_24HOUR && IS_PM && isPM) {
+    matrix.drawPixel(matrix.width() - 1, 6, HIGH);
+  }
+}
+
+
+// ── Style 0: Classic (existing centerPrint behavior) ────────────────────────
+//
+// Mirrors the original code path so every other style's render() can fall
+// back to this when 24h/12h compatibility doesn't match. The fixed-pitch 6px
+// `width` advance is read from the global so a future tweak there doesn't
+// drift this copy.
+
+inline void renderClassicTime(const char *text, bool isRefresh) {
+  matrix.setFont();
+  int x = (matrix.width() - ((int)strlen(text) * width)) / 2;
+  matrix.setCursor(x, 0);
+  matrix.print(text);
+  (void)isRefresh;
+}
+
+inline void formatHHMM(char *buf, uint8_t h, uint8_t m, bool blinkColon, bool isRefresh) {
+  // Two-character hour, blinkable colon, two-character minute. Mirrors
+  // hourMinutes() / secondsIndicator() so every style has the same canonical
+  // text to start from.
+  if (h < 10) { buf[0] = ' '; buf[1] = '0' + h; }
+  else        { buf[0] = '0' + (h / 10); buf[1] = '0' + (h % 10); }
+  bool colonOn = isRefresh || !blinkColon || ((second() % 2) != 0);
+  buf[2] = colonOn ? ':' : ' ';
+  buf[3] = '0' + (m / 10);
+  buf[4] = '0' + (m % 10);
+  buf[5] = '\0';
+}
+
+inline void renderClassic(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                          bool isPM, bool isRefresh, bool eventDay) {
+  char buf[6];
+  formatHHMM(buf, IS_24HOUR ? hour24 : hour12, minute, /*blinkColon=*/true, isRefresh);
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+  renderClassicTime(buf, isRefresh);
+}
+
+
+// ── Style 2: Banner (12h + 24h) ─────────────────────────────────────────────
+//
+// Classic digits centered at row 0, framed by horizontal lines on the very
+// top (row 0 stays empty for the digits) and very bottom (row 7) that span
+// the full 32-pixel width. To avoid clobbering the digits the bars sit on
+// rows 0 and 7; the Classic font draws into rows 0..6, so we only paint the
+// bottom bar at row 7. The top is rendered as 2-pixel notches at the ends.
+
+inline void renderBanner(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                         bool isPM, bool isRefresh, bool eventDay) {
+  char buf[6];
+  formatHHMM(buf, IS_24HOUR ? hour24 : hour12, minute, /*blinkColon=*/true, isRefresh);
+  // Bottom rule across the whole display.
+  for (int x = 0; x < matrix.width(); x++) matrix.drawPixel(x, 7, HIGH);
+  // Top corner notches — draw two pixels on each end of row 0 so the digits
+  // have visual "brackets" without obscuring the colon/digits area.
+  matrix.drawPixel(0, 0, HIGH);
+  matrix.drawPixel(1, 0, HIGH);
+  matrix.drawPixel(matrix.width() - 2, 0, HIGH);
+  matrix.drawPixel(matrix.width() - 1, 0, HIGH);
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+  renderClassicTime(buf, isRefresh);
+}
+
+
+// ── Style 3: Pulse (12h + 24h) ──────────────────────────────────────────────
+//
+// Same digits as Classic, but the colon is replaced with a pulse: every
+// 500 ms it alternates between a small dot (·) at row 3 and a larger square
+// (▪) spanning rows 2..4. Reads as a heartbeat between the hours and minutes
+// without burning the natural colon-blink that secondsIndicator() does.
+
+inline void renderPulse(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                        bool isPM, bool isRefresh, bool eventDay) {
+  // Build the time string with a SPACE in the colon slot — we draw the pulse
+  // ourselves on top, so the font's colon would just collide.
+  char buf[6];
+  formatHHMM(buf, IS_24HOUR ? hour24 : hour12, minute, /*blinkColon=*/false, isRefresh);
+  buf[2] = ' ';
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+  renderClassicTime(buf, isRefresh);
+  // Pulse position: dead-center of the displayed text. The colon character
+  // sat at index 2 of the 5-char string, so it occupies cols x..x+5 where
+  // x = renderClassicTime's start + 2 * width. We re-derive that here.
+  int textWidth = 5 * width;
+  int textStart = (matrix.width() - textWidth) / 2;
+  int colonX = textStart + 2 * width + 1;  // +1 to land on the colon's center
+  bool big = ((millis() / 500) % 2) == 0;
+  if (big) {
+    matrix.fillRect(colonX, 2, 3, 3, HIGH);
+  } else {
+    matrix.drawPixel(colonX + 1, 3, HIGH);
+  }
+}
+
+
+// ── Style 5: Frame (12h + 24h) ──────────────────────────────────────────────
+//
+// Time inside a 1-pixel rectangular border. The Classic digits are 7 tall
+// so they fit inside a 32x8 box with row 7 as the bottom edge and row 0
+// reserved for the top edge — but row 0 is also the top of the digits, so
+// we use row 7 as the BOTTOM edge and skip a top edge (the natural "chin"
+// of 5x7 digits already creates a visual ceiling). Side edges sit at col 0
+// and col 31 from row 0..6.
+
+inline void renderFrame(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                        bool isPM, bool isRefresh, bool eventDay) {
+  char buf[6];
+  formatHHMM(buf, IS_24HOUR ? hour24 : hour12, minute, /*blinkColon=*/true, isRefresh);
+  // Side rails
+  for (int y = 0; y < matrix.height() - 1; y++) {
+    matrix.drawPixel(0, y, HIGH);
+    matrix.drawPixel(matrix.width() - 1, y, HIGH);
+  }
+  // Bottom rail
+  for (int x = 0; x < matrix.width(); x++) matrix.drawPixel(x, 7, HIGH);
+  // Top corner pips so the frame visually closes
+  matrix.drawPixel(0, 0, HIGH);
+  matrix.drawPixel(matrix.width() - 1, 0, HIGH);
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+  renderClassicTime(buf, isRefresh);
+}
+
+
+// (Dotted's render function is defined further down once BIG_DIGITS is in
+// scope — it's just BIG_DIGITS with the same `(x*7 + y*13) % 5 == 0` halftone
+// mask applied per-pixel during draw.)
+
+
+// ── Bespoke 5x8 "Big" digit bitmaps for Mega, Italic, Inverse ──────────────
+//
+// Each digit fills the full 8-pixel matrix height (vs Classic's 7). Stored
+// row-major: 8 bytes per glyph, 5 bits used (high-5). Indexed by digit.
+
+const uint8_t BIG_DIGITS[10][8] PROGMEM = {
+  // 0: rounded oval that fills 8 rows
+  {0x70, 0x88, 0x88, 0x88, 0x88, 0x88, 0x88, 0x70},
+  // 1: thick stem with serif foot
+  {0x20, 0x60, 0xA0, 0x20, 0x20, 0x20, 0x20, 0xF8},
+  // 2: classic 8-tall 2 with curved top and flat bottom
+  {0x70, 0x88, 0x08, 0x10, 0x20, 0x40, 0x80, 0xF8},
+  // 3: 8-tall S-bend
+  {0x70, 0x88, 0x08, 0x30, 0x08, 0x08, 0x88, 0x70},
+  // 4: open-top 4 with full crossbar
+  {0x10, 0x30, 0x50, 0x90, 0xF8, 0x10, 0x10, 0x10},
+  // 5: standard 5
+  {0xF8, 0x80, 0x80, 0xF0, 0x08, 0x08, 0x88, 0x70},
+  // 6: closed-bottom 6
+  {0x70, 0x80, 0x80, 0xF0, 0x88, 0x88, 0x88, 0x70},
+  // 7: triangular 7 with slight curve
+  {0xF8, 0x08, 0x08, 0x10, 0x10, 0x20, 0x20, 0x40},
+  // 8: 8-tall figure-8 (no overlap rows)
+  {0x70, 0x88, 0x88, 0x70, 0x88, 0x88, 0x88, 0x70},
+  // 9: open-top 9 with descender into row 7
+  {0x70, 0x88, 0x88, 0x88, 0x78, 0x08, 0x10, 0xE0},
+};
+
+// "Mega" colon: vertically-stacked 1-px dots, full 8 rows tall
+const uint8_t BIG_COLON[8] PROGMEM = {
+  0x00, 0x00, 0x80, 0x00, 0x80, 0x00, 0x00, 0x00,
+};
+
+// Helper: blit a bitmap glyph (5 cols, 8 rows) at (x, y). Width is 5,
+// rendering using the high 5 bits of each row byte. `inverted` flips the
+// pixel polarity for the Inverse style.
+inline void drawBigGlyph(int x, int y, const uint8_t *glyph, bool inverted) {
+  for (int row = 0; row < 8; row++) {
+    uint8_t bits = pgm_read_byte(&glyph[row]);
+    for (int col = 0; col < 5; col++) {
+      bool on = (bits & (0x80 >> col)) != 0;
+      if (inverted) on = !on;
+      if (on) matrix.drawPixel(x + col, y + row, HIGH);
+    }
+  }
+}
+
+
+// ── Style 1: Mega12h ────────────────────────────────────────────────────────
+//
+// "1:23" or "12:45" rendered with the BIG_DIGITS set. 5-col digits + 1-col
+// gap + 1-col colon + 1-col gap = 13 cols for a 4-char render ("1:23") or
+// 19 cols for "12:45". Centered in the 32-wide display.
+
+inline int megaRenderWidth(uint8_t hour) {
+  // hour digit count (1-9 single-digit, 10-12 double-digit) plus 5 for ":MM"
+  int hourCols = (hour >= 10 ? 11 : 5);  // 5 + 1 + 5 OR 5
+  return hourCols + /*colon*/ 1 + /*gap*/ 1 + /*MM*/ 5 + 5 + 1 /*gap between MM digits*/;
+}
+
+inline void renderMega12h(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                          bool isPM, bool isRefresh, bool eventDay) {
+  (void)hour24;
+  // Layout: each glyph is 5 wide; gap of 1 between digits; colon is its own
+  // 1-col cell. Build a list of cells, then center the whole string.
+  uint8_t cells[5];
+  uint8_t cellCount = 0;
+  if (hour12 >= 10) {
+    cells[cellCount++] = 1;  // digit "1" (always 1 for 12h hours 10-12)
+    cells[cellCount++] = hour12 - 10;
+  } else {
+    cells[cellCount++] = hour12;
+  }
+  cells[cellCount++] = 0xFF;  // sentinel for colon
+  cells[cellCount++] = minute / 10;
+  cells[cellCount++] = minute % 10;
+
+  // Total width: 5 per digit cell, 1 per colon cell, 1-pixel gap between
+  // each. We compute it on the fly to support 1- vs 2-digit hour widths.
+  int totalCols = 0;
+  for (uint8_t i = 0; i < cellCount; i++) {
+    totalCols += (cells[i] == 0xFF) ? 1 : 5;
+    if (i + 1 < cellCount) totalCols += 1;  // gap
+  }
+  int x = (matrix.width() - totalCols) / 2;
+
+  bool colonOn = isRefresh || ((second() % 2) != 0);
+  for (uint8_t i = 0; i < cellCount; i++) {
+    if (cells[i] == 0xFF) {
+      if (colonOn) {
+        matrix.drawPixel(x, 2, HIGH);
+        matrix.drawPixel(x, 5, HIGH);
+      }
+      x += 1 + 1;
+    } else {
+      drawBigGlyph(x, 0, BIG_DIGITS[cells[i]], /*inverted=*/false);
+      x += 5 + 1;
+    }
+  }
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+}
+
+
+// ── Style 7: Inverse12h ─────────────────────────────────────────────────────
+//
+// Fill the entire 32x8 (rows 0..6 — leave row 7 free as a separator from the
+// PM dot), then carve out the time digits as OFF pixels using BIG_DIGITS
+// inverted. Looks like cut-out kerning on a solid plate.
+
+inline void renderInverse12h(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                             bool isPM, bool isRefresh, bool eventDay) {
+  (void)hour24;
+  matrix.fillRect(0, 0, matrix.width(), 7, HIGH);
+
+  // Same layout machinery as Mega — single source of truth would be nice
+  // but the 5-col branch makes a generic helper noisy.
+  uint8_t cells[5];
+  uint8_t cellCount = 0;
+  if (hour12 >= 10) {
+    cells[cellCount++] = 1;
+    cells[cellCount++] = hour12 - 10;
+  } else {
+    cells[cellCount++] = hour12;
+  }
+  cells[cellCount++] = 0xFF;
+  cells[cellCount++] = minute / 10;
+  cells[cellCount++] = minute % 10;
+
+  int totalCols = 0;
+  for (uint8_t i = 0; i < cellCount; i++) {
+    totalCols += (cells[i] == 0xFF) ? 1 : 5;
+    if (i + 1 < cellCount) totalCols += 1;
+  }
+  int x = (matrix.width() - totalCols) / 2;
+
+  bool colonOn = isRefresh || ((second() % 2) != 0);
+  for (uint8_t i = 0; i < cellCount; i++) {
+    if (cells[i] == 0xFF) {
+      // Carve out the colon: turn off the two dots in the otherwise solid plate
+      if (colonOn) {
+        matrix.drawPixel(x, 2, LOW);
+        matrix.drawPixel(x, 5, LOW);
+      }
+      x += 1 + 1;
+    } else {
+      // Draw the digit's ON pixels as OFF on the solid plate. drawBigGlyph
+      // with inverted=true does that; but we also need to LEAVE the off
+      // pixels as ON. Since the plate is already filled, we simply draw the
+      // original glyph as OFF pixels.
+      const uint8_t *g = BIG_DIGITS[cells[i]];
+      for (int row = 0; row < 8; row++) {
+        uint8_t bits = pgm_read_byte(&g[row]);
+        for (int col = 0; col < 5; col++) {
+          if (bits & (0x80 >> col)) matrix.drawPixel(x + col, row, LOW);
+        }
+      }
+      x += 5 + 1;
+    }
+  }
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+}
+
+
+// ── Style 9: Italic12h ──────────────────────────────────────────────────────
+//
+// BIG_DIGITS + a per-row right-shift: rows 0..3 shift by 1, rows 4..7 stay
+// in place. Same trick the marquee Italic font uses, applied to the 5x8
+// digits instead of letters. Reads as a leaning clock.
+
+inline void drawItalicGlyph(int x, int y, const uint8_t *glyph) {
+  for (int row = 0; row < 8; row++) {
+    uint8_t bits = pgm_read_byte(&glyph[row]);
+    int shift = (row < 4) ? 1 : 0;
+    for (int col = 0; col < 5; col++) {
+      if (bits & (0x80 >> col)) {
+        int nx = x + col + shift;
+        if (nx < x + 6) matrix.drawPixel(nx, y + row, HIGH);
+      }
+    }
+  }
+}
+
+inline void renderItalic12h(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                            bool isPM, bool isRefresh, bool eventDay) {
+  (void)hour24;
+  uint8_t cells[5];
+  uint8_t cellCount = 0;
+  if (hour12 >= 10) {
+    cells[cellCount++] = 1;
+    cells[cellCount++] = hour12 - 10;
+  } else {
+    cells[cellCount++] = hour12;
+  }
+  cells[cellCount++] = 0xFF;
+  cells[cellCount++] = minute / 10;
+  cells[cellCount++] = minute % 10;
+
+  // Italic widens each glyph cell to 6 cols (5 + 1 for the slant overhang).
+  int totalCols = 0;
+  for (uint8_t i = 0; i < cellCount; i++) {
+    totalCols += (cells[i] == 0xFF) ? 1 : 6;
+    if (i + 1 < cellCount) totalCols += 1;
+  }
+  int x = (matrix.width() - totalCols) / 2;
+
+  bool colonOn = isRefresh || ((second() % 2) != 0);
+  for (uint8_t i = 0; i < cellCount; i++) {
+    if (cells[i] == 0xFF) {
+      // Italic-y colon: top dot shifted right, bottom dot in place
+      if (colonOn) {
+        matrix.drawPixel(x + 1, 2, HIGH);
+        matrix.drawPixel(x, 5, HIGH);
+      }
+      x += 1 + 1;
+    } else {
+      drawItalicGlyph(x, 0, BIG_DIGITS[cells[i]]);
+      x += 6 + 1;
+    }
+  }
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+}
+
+
+// ── Style 8: Stencil (12h + 24h) ────────────────────────────────────────────
+//
+// BIG_DIGITS rendered with stencil "bridge" cuts: at row 4 of every digit,
+// turn off any column whose original cell is between two ON neighbors (i.e.
+// long-vertical-stem detection lite). Reads as cardboard-stencil letters.
+
+inline void drawStencilGlyph(int x, int y, const uint8_t *glyph) {
+  // Pre-decode all 8 rows so we can run a midline cut after drawing.
+  uint8_t rows[8];
+  for (int i = 0; i < 8; i++) rows[i] = pgm_read_byte(&glyph[i]);
+  for (int row = 0; row < 8; row++) {
+    for (int col = 0; col < 5; col++) {
+      bool on = (rows[row] & (0x80 >> col)) != 0;
+      // Cut: if this is the middle row of a 3+ run in this column, drop it.
+      // Check by looking at the rows directly above and below.
+      if (on && row >= 1 && row <= 6) {
+        bool above = (rows[row - 1] & (0x80 >> col)) != 0;
+        bool below = (rows[row + 1] & (0x80 >> col)) != 0;
+        if (above && below && row == 4) on = false;  // single midline cut
+      }
+      if (on) matrix.drawPixel(x + col, y + row, HIGH);
+    }
+  }
+}
+
+inline void renderStencil(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                          bool isPM, bool isRefresh, bool eventDay) {
+  uint8_t hour = IS_24HOUR ? hour24 : hour12;
+  // Always two-character hour for 24h, but 12h has the same "short hours"
+  // optimization as Mega so "1:23" doesn't waste an extra digit cell.
+  uint8_t cells[5];
+  uint8_t cellCount = 0;
+  if (IS_24HOUR || hour >= 10) {
+    cells[cellCount++] = hour / 10;
+    cells[cellCount++] = hour % 10;
+  } else {
+    cells[cellCount++] = hour;
+  }
+  cells[cellCount++] = 0xFF;
+  cells[cellCount++] = minute / 10;
+  cells[cellCount++] = minute % 10;
+
+  int totalCols = 0;
+  for (uint8_t i = 0; i < cellCount; i++) {
+    totalCols += (cells[i] == 0xFF) ? 1 : 5;
+    if (i + 1 < cellCount) totalCols += 1;
+  }
+  int x = (matrix.width() - totalCols) / 2;
+
+  bool colonOn = isRefresh || ((second() % 2) != 0);
+  for (uint8_t i = 0; i < cellCount; i++) {
+    if (cells[i] == 0xFF) {
+      if (colonOn) {
+        matrix.drawPixel(x, 2, HIGH);
+        matrix.drawPixel(x, 5, HIGH);
+      }
+      x += 1 + 1;
+    } else {
+      drawStencilGlyph(x, 0, BIG_DIGITS[cells[i]]);
+      x += 5 + 1;
+    }
+  }
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+}
+
+
+// ── Style 10: Dotted (12h + 24h) ────────────────────────────────────────────
+//
+// BIG_DIGITS with a deterministic halftone speckle: for every ON pixel that
+// also satisfies `(x*7 + y*13) % 5 == 0` we skip the draw. ~20% of pixels
+// drop, leaving the silhouette dense enough to read as a digit but visibly
+// stippled. Same mask as the marquee Pixel font.
+
+inline void drawDottedGlyph(int x, int y, const uint8_t *glyph) {
+  for (int row = 0; row < 8; row++) {
+    uint8_t bits = pgm_read_byte(&glyph[row]);
+    for (int col = 0; col < 5; col++) {
+      bool on = (bits & (0x80 >> col)) != 0;
+      if (!on) continue;
+      int px = x + col;
+      int py = y + row;
+      if (((px * 7 + py * 13) % 5) == 0) continue;
+      matrix.drawPixel(px, py, HIGH);
+    }
+  }
+}
+
+inline void renderDotted(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                         bool isPM, bool isRefresh, bool eventDay) {
+  uint8_t hour = IS_24HOUR ? hour24 : hour12;
+  uint8_t cells[5];
+  uint8_t cellCount = 0;
+  if (IS_24HOUR || hour >= 10) {
+    cells[cellCount++] = hour / 10;
+    cells[cellCount++] = hour % 10;
+  } else {
+    cells[cellCount++] = hour;
+  }
+  cells[cellCount++] = 0xFF;
+  cells[cellCount++] = minute / 10;
+  cells[cellCount++] = minute % 10;
+
+  int totalCols = 0;
+  for (uint8_t i = 0; i < cellCount; i++) {
+    totalCols += (cells[i] == 0xFF) ? 1 : 5;
+    if (i + 1 < cellCount) totalCols += 1;
+  }
+  int x = (matrix.width() - totalCols) / 2;
+
+  bool colonOn = isRefresh || ((second() % 2) != 0);
+  for (uint8_t i = 0; i < cellCount; i++) {
+    if (cells[i] == 0xFF) {
+      if (colonOn) {
+        matrix.drawPixel(x, 2, HIGH);
+        matrix.drawPixel(x, 5, HIGH);
+      }
+      x += 1 + 1;
+    } else {
+      drawDottedGlyph(x, 0, BIG_DIGITS[cells[i]]);
+      x += 5 + 1;
+    }
+  }
+  if (eventDay) drawEventDayBorder();
+  drawPmDotIfNeeded(isPM);
+}
+
+
+// ── Style 4: Stack12h ───────────────────────────────────────────────────────
+//
+// Hour digit(s) in the top half (rows 0..3) and minute digits in the bottom
+// half (rows 4..7), each rendered with a custom 3x4 micro-digit set. A 2-digit
+// hour fits as "12" centered horizontally; "1" gets its own centered render.
+// A tiny PM arrow goes in the bottom-right corner. 12h-only because at 24h
+// the hour can be "23", and the layout means BOTH halves carry 2-digit pairs
+// — which still works, but loses the visual asymmetry that makes Stack feel
+// distinct from Classic.
+
+const uint8_t MINI_DIGITS[10][4] PROGMEM = {
+  // 3x4: each row's high 3 bits = cols 0..2
+  {0xE0, 0xA0, 0xA0, 0xE0},  // 0
+  {0x40, 0xC0, 0x40, 0xE0},  // 1
+  {0xE0, 0x20, 0x40, 0xE0},  // 2
+  {0xE0, 0x60, 0x20, 0xE0},  // 3
+  {0xA0, 0xA0, 0xE0, 0x20},  // 4
+  {0xE0, 0xC0, 0x20, 0xE0},  // 5
+  {0xE0, 0x80, 0xE0, 0xE0},  // 6
+  {0xE0, 0x20, 0x40, 0x40},  // 7
+  {0xE0, 0xE0, 0xA0, 0xE0},  // 8
+  {0xE0, 0xE0, 0x20, 0xE0},  // 9
+};
+
+inline void drawMiniGlyph(int x, int y, const uint8_t *glyph) {
+  for (int row = 0; row < 4; row++) {
+    uint8_t bits = pgm_read_byte(&glyph[row]);
+    for (int col = 0; col < 3; col++) {
+      if (bits & (0x80 >> col)) matrix.drawPixel(x + col, y + row, HIGH);
+    }
+  }
+}
+
+inline void renderStack12h(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                           bool isPM, bool isRefresh, bool eventDay) {
+  (void)hour24; (void)isRefresh;
+  // Top half: hour digits, centered. 1-digit hour = single 3x4 glyph; 2-digit
+  // hour ("10", "11", "12") = two 3x4 glyphs with a 1-col gap.
+  if (hour12 >= 10) {
+    int hourW = 3 + 1 + 3;
+    int hx = (matrix.width() - hourW) / 2;
+    drawMiniGlyph(hx, 0, MINI_DIGITS[hour12 / 10]);
+    drawMiniGlyph(hx + 4, 0, MINI_DIGITS[hour12 % 10]);
+  } else {
+    int hx = (matrix.width() - 3) / 2;
+    drawMiniGlyph(hx, 0, MINI_DIGITS[hour12]);
+  }
+
+  // Bottom half: minute (always 2-digit, zero-padded)
+  int minW = 3 + 1 + 3;
+  int mx = (matrix.width() - minW) / 2;
+  drawMiniGlyph(mx, 4, MINI_DIGITS[minute / 10]);
+  drawMiniGlyph(mx + 4, 4, MINI_DIGITS[minute % 10]);
+
+  // PM marker: tiny dot pair top-right when isPM
+  if (IS_PM && isPM) {
+    matrix.drawPixel(matrix.width() - 1, 0, HIGH);
+    matrix.drawPixel(matrix.width() - 1, 1, HIGH);
+  }
+  if (eventDay) drawEventDayBorder();
+}
+
+
+// ── Style 6: Suffix12h ──────────────────────────────────────────────────────
+//
+// Compact "H:MM AM/PM": Classic-tiny digits at left, 3-letter AM/PM at right
+// using the shipped TomThumb 3x5 font for the suffix. 12h-only — at 24h the
+// suffix is meaningless and we'd lose the room.
+
+inline void renderSuffix12h(uint8_t hour12, uint8_t hour24, uint8_t minute,
+                            bool isPM, bool isRefresh, bool eventDay) {
+  (void)hour24;
+  // Time string at the LEFT, fixed 4-wide ("H:MM" if hour <10, else 5-wide
+  // "HH:MM"). We always draw it at x=0 so the suffix has a known anchor.
+  char buf[6];
+  int px = 0;
+  if (hour12 >= 10) {
+    buf[0] = '0' + (hour12 / 10);
+    buf[1] = '0' + (hour12 % 10);
+    bool colonOn = isRefresh || ((second() % 2) != 0);
+    buf[2] = colonOn ? ':' : ' ';
+    buf[3] = '0' + (minute / 10);
+    buf[4] = '0' + (minute % 10);
+    buf[5] = '\0';
+    px = 0;
+  } else {
+    buf[0] = '0' + hour12;
+    bool colonOn = isRefresh || ((second() % 2) != 0);
+    buf[1] = colonOn ? ':' : ' ';
+    buf[2] = '0' + (minute / 10);
+    buf[3] = '0' + (minute % 10);
+    buf[4] = '\0';
+    px = 0;
+  }
+  matrix.setFont();
+  matrix.setCursor(px, 0);
+  matrix.print(buf);
+
+  // Suffix: render "AM" or "PM" using TomThumb (~3 wide × 5 tall). Let the
+  // GFX font path do the work — it lands the glyphs at baseline=5 nicely on
+  // the matrix.
+  extern const GFXfont TomThumb;
+  matrix.setFont(&TomThumb);
+  matrix.setCursor(matrix.width() - 8, 7);
+  matrix.print(isPM ? F("PM") : F("AM"));
+  matrix.setFont();
+
+  if (eventDay) drawEventDayBorder();
+}
+
+
+// ── Registry ────────────────────────────────────────────────────────────────
+
+static const ClockStyle CLOCK_STYLES[] = {
+  // id  name        12h    24h    render
+  {  "Classic",   true,  true,  renderClassic    },  // 0
+  {  "Mega",      true,  false, renderMega12h    },  // 1
+  {  "Banner",    true,  true,  renderBanner     },  // 2
+  {  "Pulse",     true,  true,  renderPulse      },  // 3
+  {  "Stack",     true,  false, renderStack12h   },  // 4
+  {  "Frame",     true,  true,  renderFrame      },  // 5
+  {  "Suffix",    true,  false, renderSuffix12h  },  // 6
+  {  "Inverse",   true,  false, renderInverse12h },  // 7
+  {  "Stencil",   true,  true,  renderStencil    },  // 8
+  {  "Italic",    true,  false, renderItalic12h  },  // 9
+  {  "Dotted",    true,  true,  renderDotted     },  // 10
+};
+static const int CLOCK_STYLE_COUNT =
+    sizeof(CLOCK_STYLES) / sizeof(CLOCK_STYLES[0]);

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -68,7 +68,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.3.0-wagfam"
+#define BASE_VERSION "4.4.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -35,6 +35,7 @@
 #include <Fonts/TomThumb.h>
 #include <Fonts/Org_01.h>
 #include "WagfamFont.h"
+#include "ClockStyles.h"
 
 // Scroller font registry (issue #106). Index 0 is the Adafruit_GFX builtin
 // 5x7 fixed-width font (passed as nullptr to setFont). Other entries are
@@ -112,6 +113,7 @@ void savePersistentConfig();
 void readPersistentConfig();
 void scrollMessageWait(const String &msg);
 void centerPrint(const String &msg, bool extraStuff = false);
+void renderClockFace(bool isRefresh = false);
 String EncodeUrlSpecialChars(const char *msg);
 void performAutoUpdate(const String &firmwareUrl);
 void checkOtaRollback();
@@ -144,6 +146,7 @@ int spacer = 1;  // dots between letters
 int width = 5 + spacer; // The font width is 5 pixels + spacer (Classic font path)
 bool displayDirty = true; // true = framebuffer needs redraw before next write
 int displayFont = 0;  // index into SCROLLER_FONTS; persisted as scrollFont in /conf.txt
+int displayClockStyle = 0;  // index into CLOCK_STYLES; persisted as clockStyle in /conf.txt
 
 // Matrix panel
 Max72xxPanel matrix = Max72xxPanel(pinCS, numberOfHorizontalDisplays, numberOfVerticalDisplays);
@@ -671,11 +674,17 @@ void loop() {
     processEveryMinute();
   }
 
-  // Only redraw when content has changed. The animated event-day border
-  // requires per-frame updates, so always redraw when it is active.
-  if (displayDirty || WAGFAM_EVENT_TODAY) {
+  // Only redraw when content has changed. The animated event-day border, the
+  // animated colon, and animated clock styles (Pulse) all need per-frame
+  // updates, so always redraw when those are active.
+  bool needsAnimatedFrame = WAGFAM_EVENT_TODAY;
+  if (displayClockStyle > 0 && displayClockStyle < CLOCK_STYLE_COUNT) {
+    needsAnimatedFrame = true;  // bespoke styles repaint every frame
+  }
+  if (displayDirty || needsAnimatedFrame) {
     matrix.fillScreen(LOW);
-    centerPrint(displayTime, true);
+    renderClockFace(/*isRefresh=*/false);
+    matrix.write();
     displayDirty = false;
   }
 
@@ -1124,7 +1133,7 @@ void getWeatherData() //client function to send/receive GET request data.
 
   // pull the weather data
   if (firstTimeSync != 0) {
-    centerPrint(displayTime, true);
+    renderClockFace(/*isRefresh=*/true);
   } else {
     centerPrint("...");
   }
@@ -1506,6 +1515,7 @@ void savePersistentConfig() {
     f.println("ledIntensity=" + String(displayIntensity));
     f.println("scrollSpeed=" + String(displayScrollSpeed));
     f.println("scrollFont=" + String(displayFont));
+    f.println("clockStyle=" + String(displayClockStyle));
     f.println("is24hour=" + String(IS_24HOUR));
     f.println("isPM=" + String(IS_PM));
     f.println("isMetric=" + String(IS_METRIC));
@@ -1592,6 +1602,11 @@ void readPersistentConfig() {
       if (v < 0 || v >= SCROLLER_FONT_COUNT) v = 0;
       displayFont = v;
       Serial.println("displayFont=" + String(displayFont));
+    } else if (key == "clockStyle") {
+      int v = value.toInt();
+      if (v < 0 || v >= CLOCK_STYLE_COUNT) v = 0;
+      displayClockStyle = v;
+      Serial.println("displayClockStyle=" + String(displayClockStyle));
     } else if (key == "SHOW_CITY") {
       SHOW_CITY = value.toInt();
       Serial.println("SHOW_CITY=" + String(SHOW_CITY));
@@ -1693,6 +1708,21 @@ void scrollMessageWait(const String &msg) {
     delay(displayScrollSpeed);
   }
   matrix.setCursor(0, 0);
+}
+
+// Dispatch a single clock-face frame through the active style in CLOCK_STYLES.
+// Falls back to Classic when the selected style doesn't declare support for
+// the current 12h/24h mode. The caller is responsible for fillScreen/write
+// — we just paint into the buffer so the boot path can layer extras (the
+// data-refresh dot indicator) on top.
+void renderClockFace(bool isRefresh) {
+  const ClockStyle &style = CLOCK_STYLES[
+      (displayClockStyle >= 0 && displayClockStyle < CLOCK_STYLE_COUNT)
+      ? displayClockStyle : 0];
+  bool ok = IS_24HOUR ? style.supports24h : style.supports12h;
+  const ClockStyle &active = ok ? style : CLOCK_STYLES[0];
+  active.render(hourFormat12(), hour(), minute(), isPM(),
+                isRefresh, WAGFAM_EVENT_TODAY);
 }
 
 void centerPrint(const String &msg, boolean extraStuff) {
@@ -1827,6 +1857,7 @@ void handleApiConfigGet(AsyncWebServerRequest *request) {
   doc["display_intensity"] = displayIntensity;
   doc["display_scroll_speed"] = displayScrollSpeed;
   doc["display_font"] = displayFont;
+  doc["display_clock_style"] = displayClockStyle;
   doc["minutes_between_data_refresh"] = minutesBetweenDataRefresh;
   doc["minutes_between_scrolling"] = minutesBetweenScrolling;
   doc["show_date"] = SHOW_DATE;
@@ -1863,6 +1894,7 @@ static void applyConfigJson(JsonObject json) {
   if (json["display_intensity"].is<int>()) displayIntensity = constrain(json["display_intensity"].as<int>(), 0, 15);
   if (json["display_scroll_speed"].is<int>()) displayScrollSpeed = max(1, json["display_scroll_speed"].as<int>());
   if (json["display_font"].is<int>()) displayFont = constrain(json["display_font"].as<int>(), 0, SCROLLER_FONT_COUNT - 1);
+  if (json["display_clock_style"].is<int>()) displayClockStyle = constrain(json["display_clock_style"].as<int>(), 0, CLOCK_STYLE_COUNT - 1);
   if (json["minutes_between_data_refresh"].is<int>()) minutesBetweenDataRefresh = max(1, json["minutes_between_data_refresh"].as<int>());
   if (json["minutes_between_scrolling"].is<int>()) minutesBetweenScrolling = max(1, json["minutes_between_scrolling"].as<int>());
   if (json["show_date"].is<bool>()) SHOW_DATE = json["show_date"].as<bool>();

--- a/webui/src/pages/SettingsPage.tsx
+++ b/webui/src/pages/SettingsPage.tsx
@@ -37,6 +37,7 @@ const DEFAULTS: ConfigData = {
   display_intensity: 4,
   display_scroll_speed: 25,
   display_font: 0,
+  display_clock_style: 0,
   minutes_between_data_refresh: 15,
   minutes_between_scrolling: 1,
   show_date: false,
@@ -206,6 +207,41 @@ export function SettingsPage() {
               <option value="13">Inverse (5x8 negative)</option>
               <option value="14">Stencil (5x8 cut)</option>
             </select>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <label class="form-label" for="clock-style">
+            Clock face
+          </label>
+          <div class="text-group">
+            <select
+              id="clock-style"
+              value={String(cfg.display_clock_style)}
+              onChange={(e) =>
+                setVal(
+                  "display_clock_style",
+                  +(e.target as HTMLSelectElement).value,
+                )
+              }
+            >
+              <option value="0">Classic (5x7 — both)</option>
+              <option value="1">Mega (5x8 huge — 12h only)</option>
+              <option value="2">Banner (Classic + bars — both)</option>
+              <option value="3">Pulse (animated colon — both)</option>
+              <option value="4">Stack (hour over minute — 12h only)</option>
+              <option value="5">Frame (bordered — both)</option>
+              <option value="6">Suffix (with AM/PM — 12h only)</option>
+              <option value="7">Inverse (negative space — 12h only)</option>
+              <option value="8">Stencil (bridge cuts — both)</option>
+              <option value="9">Italic (leaned — 12h only)</option>
+              <option value="10">Dotted (halftone — both)</option>
+            </select>
+            {cfg.is_24hour && [1, 4, 6, 7, 9].includes(cfg.display_clock_style) && (
+              <span class="form-note">
+                12h-only style — falls back to Classic in 24-hour mode
+              </span>
+            )}
           </div>
         </div>
 

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -94,6 +94,7 @@ export interface ConfigData {
   display_intensity: number;
   display_scroll_speed: number;
   display_font: number;
+  display_clock_style: number;
   minutes_between_data_refresh: number;
   minutes_between_scrolling: number;
   show_date: boolean;


### PR DESCRIPTION
## Summary

The clock display now has its own selectable rendering, separate from the marquee scroller font. Knowing the alphabet is just **digits + colon** (and AM/PM in 12-hour mode) lets each style optimize layout in ways a general scrolling font can't.

New file `marquee/ClockStyles.h` holds the registry. Each entry declares 12h/24h compatibility — styles flagged 12h-only fall back to **Classic** at render time when the device is in 24-hour mode.

## Styles (id 0 is the existing default)

| ID | Name | 12h | 24h | Notes |
| --- | --- | --- | --- | --- |
| 0 | Classic | ✓ | ✓ | default Adafruit 5x7, blinking colon, PM dot |
| 1 | Mega | ✓ | ✗ | bespoke 5x8 digits filling the full matrix height |
| 2 | Banner | ✓ | ✓ | Classic + bottom rule + corner notches up top |
| 3 | Pulse | ✓ | ✓ | Classic + animated heartbeat colon (500 ms blink) |
| 4 | Stack | ✓ | ✗ | hour digits in top half, minute in bottom (3x4 micro) |
| 5 | Frame | ✓ | ✓ | Classic inside a 1-pixel rectangular border |
| 6 | Suffix | ✓ | ✗ | Classic + AM/PM rendered with TomThumb at right |
| 7 | Inverse | ✓ | ✗ | solid plate with digits carved as negative space |
| 8 | Stencil | ✓ | ✓ | bespoke 5x8 digits with bridge cuts at the midline |
| 9 | Italic | ✓ | ✗ | bespoke 5x8 digits with upper-half right shift |
| 10 | Dotted | ✓ | ✓ | bespoke 5x8 digits with `(x*7+y*13)%5==0` halftone speckle |

## Plumbing

- Persisted as `clockStyle=` in `/conf.txt`, exposed as `display_clock_style` on `/api/config` (GET + POST, bounds-checked to `[0, CLOCK_STYLE_COUNT-1]`).
- New `renderClockFace(isRefresh)` helper in `marquee.ino` centralizes dispatch — used by both the main loop and the data-refresh path in `getWeatherData()`.
- The loop's previously-conditional `displayDirty` short-circuit is widened to redraw every frame whenever a non-Classic style is selected, since several styles need per-frame animation.
- SPA Settings tab gets a "Clock face" dropdown that hints "12h-only style — falls back to Classic in 24-hour mode" when a 12h-only style is paired with `is_24hour=true`.

## Flash impact

- Sketch: **55.4% → 55.8%** (~3.5 KB of bitmaps + render code)
- RAM: 46.0% → 46.3%

## Test plan

- [x] PIO build succeeds, all sizes within budget
- [x] Verified live on device (`192.168.168.66`) — sketch + LittleFS flashed, config preserved (`display_font`, OWM key, calendar URL all intact); `display_clock_style` defaults to `0`
- [x] All 6 new style labels (Mega/Banner/Pulse/Stack/Frame/Suffix) verified present in the deployed SPA bundle
- [ ] Visual sanity-check of each style on the live device — leaving for the reviewer / next round

## Base

This branches off `font-selection-106` so the diff stays focused on clock-style work only. Once #107 merges to master this can be retargeted with a clean rebase.