### PR TITLE
Advertise device via mDNS + send LAN IP in heartbeat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ All firmware source lives in [marquee/](marquee/):
 | [OpenWeatherMapClient.h/.cpp](marquee/OpenWeatherMapClient.h) | Fetches weather from OpenWeatherMap API using ArduinoJson |
 | [WagFamBdayClient.h/.cpp](marquee/WagFamBdayClient.h) | Fetches family calendar JSON over HTTPS; parses messages and remote config |
 | [SecurityHelpers.h/.cpp](marquee/SecurityHelpers.h) | Firmware URL validation, path protection, domain extraction |
+| [MdnsHelpers.h/.cpp](marquee/MdnsHelpers.h) | DNS-safe hostname sanitization for mDNS bringup (extracted so it's testable under tests/native/) |
 | [timeNTP.h/.cpp](marquee/timeNTP.h) | NTP time sync; exposes `timeNTPsetup()`, `getNtpTime()`, and `set_timeZoneSec()` |
 | [timeStr.h/.cpp](marquee/timeStr.h) | Time formatting helpers (zero-pad, day/month names, etc.) |
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,30 @@ The calendar client fetches a JSON array from the configured URL (HTTPS supporte
 ### Device Heartbeat
 
 Each calendar fetch includes device telemetry as URL query parameters (`chip_id`, `version`,
-`uptime`, `heap`, `rssi`, and `utc_offset_sec`). The UTC offset in seconds is derived
-automatically from the OpenWeatherMap response — no extra configuration needed. A backend
-can use these to identify and monitor all deployed clocks. Static JSON hosts ignore the query
-params.
+`uptime`, `heap`, `rssi`, `utc_offset_sec`, `lan_ip`, and `mdns_name`). The UTC offset in
+seconds is derived automatically from the OpenWeatherMap response. `lan_ip` is the device's
+private LAN IP (e.g. `192.168.1.42`) — distinct from the household NAT public IP that a
+backend would otherwise see in `X-Forwarded-For`. `mdns_name` is the sanitized Bonjour
+hostname (see below). A backend uses these to power a directory page that one-click jumps the
+user to `http://<mdns_name>.local/spa/` when they're on the same LAN. Static JSON hosts
+ignore the query params.
+
+### Local discovery (mDNS / Bonjour)
+
+The device advertises itself on the local network via mDNS so users don't have to look up
+its IP. After WiFi connects, the device publishes:
+
+- An `A` record at `<sanitized-name>.local` — open `http://<sanitized-name>.local/spa/` from
+  any device on the same LAN. The name is derived from the server-set `device_name` (e.g.
+  "Kitchen Clock" → `kitchen-clock.local`); when no name is set yet the fallback is
+  `wagfam-<chip-id>.local` so every clock has a stable label even before naming.
+- An `_http._tcp` service record (port 80) so generic HTTP browsers see the device.
+- A `_wagfam._tcp` service record with `chip` and `version` TXT entries — intended for a
+  future native app that enumerates every clock on the LAN with one Bonjour query.
+
+The current `mdns_name` is also exposed in `GET /api/status` for debugging. mDNS works
+reliably on iOS Safari, macOS, and Linux; Android Chrome support is patchy and may need a
+fallback to the LAN IP.
 
 ### Geo Location
 

--- a/marquee/MdnsHelpers.cpp
+++ b/marquee/MdnsHelpers.cpp
@@ -1,0 +1,32 @@
+#include "MdnsHelpers.h"
+
+String mdnsLabelFor(const String &source, const String &chipId) {
+  String out;
+  out.reserve(source.length());
+  bool prevHyphen = true;  // leading hyphen guard
+  for (size_t i = 0; i < source.length(); i++) {
+    char c = source[i];
+    if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+    bool ok = (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9');
+    if (ok) {
+      out += c;
+      prevHyphen = false;
+    } else if (!prevHyphen) {
+      out += '-';
+      prevHyphen = true;
+    }
+  }
+  while (out.length() > 0 && out[out.length() - 1] == '-') {
+    out = out.substring(0, out.length() - 1);
+  }
+  if (out.length() == 0) {
+    out = "wagfam-" + chipId;
+  }
+  if (out.length() > 63) {
+    out = out.substring(0, 63);
+    while (out.length() > 0 && out[out.length() - 1] == '-') {
+      out = out.substring(0, out.length() - 1);
+    }
+  }
+  return out;
+}

--- a/marquee/MdnsHelpers.h
+++ b/marquee/MdnsHelpers.h
@@ -1,0 +1,21 @@
+// mDNS hostname sanitization. Pulled out of marquee.ino so it can be unit-
+// tested under tests/native/ without dragging in the entire ESP8266mDNS
+// stack. Pure String-in / String-out — no globals, no hardware dependencies.
+#pragma once
+
+#include <Arduino.h>
+
+// Convert a free-form label (typically the user-set DEVICE_NAME) into a
+// DNS-safe mDNS hostname conforming to RFC 1035 + Apple's Bonjour rules:
+//
+//  - lowercase only
+//  - characters limited to [a-z0-9-]
+//  - no leading or trailing hyphen
+//  - max 63 characters (DNS label limit)
+//
+// Runs of non-alphanumeric characters collapse to a single hyphen so
+// multi-word names (e.g. "Kitchen Clock") become "kitchen-clock". When the
+// sanitized result is empty (input was nothing but punctuation, or empty),
+// we fall back to "wagfam-<chipId>" so every device still gets a stable,
+// non-colliding label.
+String mdnsLabelFor(const String &source, const String &chipId);

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -36,6 +36,7 @@ SOFTWARE.
  ******************************************************************************/
 
 #include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
 #include <ESPAsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <AsyncJson.h>

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -65,6 +65,14 @@ WagFamBdayClient::configValues WagFamBdayClient::updateData(const DeviceInfo& de
   url += String(device.rssi);
   url += "&utc_offset_sec=";
   url += String(device.utcOffsetSec);
+  if (device.lanIp.length() > 0) {
+    url += "&lan_ip=";
+    url += device.lanIp;
+  }
+  if (device.mdnsName.length() > 0) {
+    url += "&mdns_name=";
+    url += device.mdnsName;
+  }
 
   Serial.println("Getting Birthdays Data");
   Serial.println(F("[calendar URL redacted]"));

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -35,6 +35,14 @@ struct DeviceInfo {
     uint32_t freeHeap;
     int32_t rssi;
     int32_t utcOffsetSec; // UTC offset in seconds from OWM (e.g. -21600 for UTC-6)
+    String lanIp;         // Device's LAN IP (e.g. "192.168.1.42") — server uses
+                          // this to redirect a directory click to the device.
+                          // Differs from server-side X-Forwarded-For, which
+                          // captures only the household NAT public IP.
+    String mdnsName;      // Sanitized mDNS hostname (e.g. "kitchen-clock"),
+                          // suffixed `.local` by the resolver. Stable across
+                          // DHCP reassignments — preferred over lanIp by the
+                          // directory page's redirect target.
 };
 
 class WagFamBdayClient: public JsonListener {

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -27,6 +27,7 @@
 
 #include "Settings.h"
 #include "SecurityHelpers.h"
+#include "MdnsHelpers.h"
 #include "ConfigUpdateVerify.h"
 #include "HwVerifyTest.h"
 
@@ -54,6 +55,7 @@ void redirectToSpa(AsyncWebServerRequest *request);
 void handleNotFound(AsyncWebServerRequest *request);
 void configModeCallback (AsyncWiFiManager *myWiFiManager);
 void flashLED(int number, int delayTime);
+void startMdns();
 String getTempSymbol(bool forWeb = false);
 String getSpeedSymbol();
 String getPressureSymbol();
@@ -111,6 +113,10 @@ WagFamBdayClient bdayClient(WAGFAM_API_KEY, WAGFAM_DATA_URL);
 int bdayMessageIndex = 0;
 WagFamBdayClient::configValues serverConfig = {};
 String DEVICE_NAME = "";     // Human-friendly name assigned by server (not user-editable)
+String mdnsHostname = "";    // DNS-safe label registered with ESP8266mDNS (e.g.
+                             // "kitchen-clock"); resolves as "<name>.local" on
+                             // any mDNS-capable client. Recomputed in startMdns()
+                             // and again whenever DEVICE_NAME changes.
 String SPA_VERSION = "unknown"; // Read from /spa/version.json at boot; "unknown" if absent
 bool spaUpdateAvailable = false;
 String pendingSpaFsUrl = "";
@@ -567,6 +573,12 @@ void setup() {
   Serial.println("Use this URL : " + webAddress);
   scrollMessageWait(" v" + String(VERSION) + "  IP: " + WiFi.localIP().toString() + "  ");
 
+  // mDNS bringup — advertises the device under <mdnsHostname>.local so users
+  // (and a future native discovery app) can reach it without knowing the LAN
+  // IP. Also publishes a `_wagfam._tcp.local.` service record so a discovery
+  // pass on the LAN can enumerate every clock with one mDNS query.
+  startMdns();
+
   // Start NTP , although it can't do anything while in config mode or when no WiFi AP connected
   timeNTPsetup();
 
@@ -577,6 +589,10 @@ void setup() {
 // Main Loop
 //************************************************************
 void loop() {
+
+  // Pump the mDNS responder. The sync ESP8266mDNS variant needs this every
+  // loop iteration; the wrapper is cheap when no queries are pending.
+  MDNS.update();
 
   if (lastSecond != second()) {
     lastSecond = second();
@@ -1099,6 +1115,8 @@ void getWeatherData() //client function to send/receive GET request data.
   devInfo.freeHeap = ESP.getFreeHeap();
   devInfo.rssi = WiFi.RSSI();
   devInfo.utcOffsetSec = weatherClient.getTimeZoneSeconds();
+  devInfo.lanIp = WiFi.localIP().toString();
+  devInfo.mdnsName = mdnsHostname;
   serverConfig = bdayClient.updateData(devInfo);
   bool needToSave = false;
   // SEC-12: Validate server-pushed dataSourceUrl must use HTTPS
@@ -1123,6 +1141,9 @@ void getWeatherData() //client function to send/receive GET request data.
   if (serverConfig.deviceNameValid) {
     DEVICE_NAME = serverConfig.deviceName;
     needToSave = true;
+    // Re-derive and re-announce mDNS so `<name>.local` follows renames
+    // without waiting for a reboot.
+    startMdns();
   }
   if (needToSave) {
     Serial.println("Saving new config received from server");
@@ -1321,6 +1342,34 @@ void configModeCallback (AsyncWiFiManager *myWiFiManager) {
   Serial.println("To setup Wifi Configuration");
   scrollMessageWait("Please Connect to AP: " + String(myWiFiManager->getConfigPortalSSID()));
   centerPrint("wifi");
+}
+
+// Bring up mDNS responder + advertise the HTTP server at port 80 and a
+// `_wagfam._tcp` service record so a future native discovery app can
+// enumerate every clock with a single Bonjour query. Safe to call again
+// after DEVICE_NAME changes; we tear down and rebuild the responder so the
+// announced name actually updates (just calling MDNS.setHostname would
+// silently keep the old name on some Espressif builds).
+void startMdns() {
+  String chipId = String(ESP.getChipId(), HEX);
+  String label = mdnsLabelFor(DEVICE_NAME, chipId);
+  if (label == mdnsHostname && mdnsHostname.length() > 0) {
+    return;  // already running with the correct label
+  }
+  if (mdnsHostname.length() > 0) {
+    MDNS.end();
+  }
+  mdnsHostname = label;
+  if (!MDNS.begin(mdnsHostname.c_str())) {
+    Serial.println(F("[mDNS] begin() failed"));
+    mdnsHostname = "";
+    return;
+  }
+  MDNS.addService("http", "tcp", 80);
+  MDNS.addService("wagfam", "tcp", 80);
+  MDNS.addServiceTxt("wagfam", "tcp", "chip", chipId);
+  MDNS.addServiceTxt("wagfam", "tcp", "version", VERSION);
+  Serial.printf_P(PSTR("[mDNS] http://%s.local/\n"), mdnsHostname.c_str());
 }
 
 void flashLED(int number, int delayTime) {
@@ -1592,6 +1641,8 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   doc["heap_fragmentation"] = ESP.getHeapFragmentation();
   doc["chip_id"] = String(ESP.getChipId(), HEX);
   doc["device_name"] = DEVICE_NAME;
+  doc["mdns_name"] = mdnsHostname;
+  doc["lan_ip"] = WiFi.localIP().toString();
   doc["flash_size"] = ESP.getFlashChipRealSize();
   doc["sketch_size"] = ESP.getSketchSize();
   doc["free_sketch_space"] = ESP.getFreeSketchSpace();

--- a/tests/native/test_mdns_helpers/test_mdns_helpers.cpp
+++ b/tests/native/test_mdns_helpers/test_mdns_helpers.cpp
@@ -1,0 +1,124 @@
+#include <unity.h>
+#include "Arduino.h"
+
+#include "MdnsHelpers.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+// ── Happy path ──────────────────────────────────────────────────────────────
+
+void test_simple_lowercase_passes_through() {
+    TEST_ASSERT_EQUAL_STRING("kitchen", mdnsLabelFor("kitchen", "5fc8ad").c_str());
+}
+
+void test_uppercase_lowercased() {
+    TEST_ASSERT_EQUAL_STRING("kitchen", mdnsLabelFor("KITCHEN", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("kitchen", mdnsLabelFor("Kitchen", "5fc8ad").c_str());
+}
+
+void test_spaces_become_hyphens() {
+    TEST_ASSERT_EQUAL_STRING("kitchen-clock",
+                             mdnsLabelFor("Kitchen Clock", "5fc8ad").c_str());
+}
+
+void test_multiple_spaces_collapse_to_single_hyphen() {
+    TEST_ASSERT_EQUAL_STRING("kitchen-clock",
+                             mdnsLabelFor("Kitchen   Clock", "5fc8ad").c_str());
+}
+
+void test_punctuation_collapses_to_single_hyphen() {
+    // Each run of non-alphanumeric collapses to ONE hyphen — punctuation
+    // touching alphanumerics on both sides splits the word. This is
+    // documented behavior; users who want no hyphen mid-word should rename.
+    TEST_ASSERT_EQUAL_STRING("dallan-s-clock",
+                             mdnsLabelFor("Dallan's Clock!", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("foo-bar",
+                             mdnsLabelFor("foo___bar", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("foo-bar",
+                             mdnsLabelFor("foo.bar", "5fc8ad").c_str());
+}
+
+void test_digits_preserved() {
+    TEST_ASSERT_EQUAL_STRING("clock2", mdnsLabelFor("Clock2", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("clock-2", mdnsLabelFor("Clock 2", "5fc8ad").c_str());
+}
+
+
+// ── Edge cases ──────────────────────────────────────────────────────────────
+
+void test_leading_punctuation_does_not_produce_leading_hyphen() {
+    TEST_ASSERT_EQUAL_STRING("clock", mdnsLabelFor("!!!Clock", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("clock", mdnsLabelFor("   Clock", "5fc8ad").c_str());
+}
+
+void test_trailing_punctuation_does_not_produce_trailing_hyphen() {
+    TEST_ASSERT_EQUAL_STRING("clock", mdnsLabelFor("Clock!!!", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("clock", mdnsLabelFor("Clock   ", "5fc8ad").c_str());
+}
+
+void test_empty_input_falls_back_to_chip_id() {
+    TEST_ASSERT_EQUAL_STRING("wagfam-5fc8ad",
+                             mdnsLabelFor("", "5fc8ad").c_str());
+}
+
+void test_punctuation_only_input_falls_back_to_chip_id() {
+    TEST_ASSERT_EQUAL_STRING("wagfam-5fc8ad",
+                             mdnsLabelFor("!!!", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("wagfam-5fc8ad",
+                             mdnsLabelFor("   ", "5fc8ad").c_str());
+}
+
+void test_long_input_truncated_to_63_chars() {
+    String long_input = "";
+    for (int i = 0; i < 80; i++) long_input += "a";
+    String result = mdnsLabelFor(long_input, "5fc8ad");
+    TEST_ASSERT_TRUE(result.length() <= 63);
+    TEST_ASSERT_EQUAL_INT(63, result.length());
+}
+
+void test_truncation_does_not_leave_trailing_hyphen() {
+    // 62 chars of 'a', then a space, then more text. Truncating at 63 would
+    // land on the hyphen produced by the space — strip it.
+    String src = "";
+    for (int i = 0; i < 62; i++) src += "a";
+    src += " bbb";
+    String result = mdnsLabelFor(src, "5fc8ad");
+    TEST_ASSERT_NOT_EQUAL('-', result[result.length() - 1]);
+}
+
+
+// ── Real-world device names ─────────────────────────────────────────────────
+
+void test_realistic_device_names() {
+    TEST_ASSERT_EQUAL_STRING("dallan-clock",
+                             mdnsLabelFor("dallan-clock", "5fc8ad").c_str());
+    TEST_ASSERT_EQUAL_STRING("grandma-s-kitchen",
+                             mdnsLabelFor("Grandma's Kitchen", "abc123").c_str());
+    TEST_ASSERT_EQUAL_STRING("front-door",
+                             mdnsLabelFor("Front-Door", "abc123").c_str());
+    TEST_ASSERT_EQUAL_STRING("clock-3",
+                             mdnsLabelFor("Clock #3", "abc123").c_str());
+}
+
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_simple_lowercase_passes_through);
+    RUN_TEST(test_uppercase_lowercased);
+    RUN_TEST(test_spaces_become_hyphens);
+    RUN_TEST(test_multiple_spaces_collapse_to_single_hyphen);
+    RUN_TEST(test_punctuation_collapses_to_single_hyphen);
+    RUN_TEST(test_digits_preserved);
+
+    RUN_TEST(test_leading_punctuation_does_not_produce_leading_hyphen);
+    RUN_TEST(test_trailing_punctuation_does_not_produce_trailing_hyphen);
+    RUN_TEST(test_empty_input_falls_back_to_chip_id);
+    RUN_TEST(test_punctuation_only_input_falls_back_to_chip_id);
+    RUN_TEST(test_long_input_truncated_to_63_chars);
+    RUN_TEST(test_truncation_does_not_leave_trailing_hyphen);
+
+    RUN_TEST(test_realistic_device_names);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Two coordinated firmware changes that pave the way for a cloud-hosted directory page (Path A) and a future native discovery app (Path C) without committing to either yet.

**Local discovery (Path D — \`<name>.local\`):**
- Each clock now advertises itself on its LAN via mDNS. Open \`http://kitchen-clock.local/spa/\` from any device on the same WiFi — no more "what's my clock's IP?".
- Hostname is sanitized from the server-set \`device_name\` per RFC 1035 + Bonjour rules: lowercase, \`[a-z0-9-]\` only, no leading/trailing hyphen, max 63 chars. Empty/punctuation-only names fall back to \`wagfam-<chip-id>\` so every clock has a stable label.
- Three service records published:
  - \`_http._tcp\` port 80 — generic HTTP browsers see the device
  - \`_wagfam._tcp\` port 80 with \`chip\` + \`version\` TXT — intended for a future native enumeration app
- Renames via the calendar push update mDNS without a reboot.

**Heartbeat additions (Path A prerequisite):**
- The calendar GET URL now appends \`lan_ip=...\` and \`mdns_name=...\`. The server-side X-Forwarded-For only captures the household NAT public IP; \`lan_ip\` is what a directory page needs to redirect a click to the device.
- Both fields are also exposed in \`/api/status\` for debugging.
- Server-side capture is additive — older servers silently ignore the new params.

## Tests

- 13 new native unit tests on \`mdnsLabelFor()\` covering: simple lowercasing, multi-word hyphenation, punctuation collapse, leading/trailing hyphen stripping, empty input falling back to \`wagfam-<chip-id>\`, 63-char truncation that doesn't leave a trailing hyphen, real-world names like \`Grandma's Kitchen\` → \`grandma-s-kitchen\`.
- All 120 native tests pass (\`pio test -e native_test\`).

## Flash impact

- Sketch: **53.5% → 55.8%** (~2.3 KB for the ESP8266mDNS responder + helpers + service registrations)
- RAM: 46.0% (no change)

## Test plan

- [x] PIO build succeeds, all sizes within budget
- [x] Native test suite passes (\`pio test -e native_test\`)
- [x] Verified live on \`192.168.168.66\`:
  - \`GET /api/status\` returns \`"mdns_name":"dallan-clock"\` and \`"lan_ip":"192.168.168.66"\`
  - \`ping dallan-clock.local\` resolves from macOS to 192.168.168.66
  - 64 bytes from 192.168.168.66: icmp_seq=0 ttl=255 time=110 ms
- [ ] Server-side capture of \`lan_ip\` and \`mdns_name\` (next PR on wagfam-server)

## Next

Server-side PR on jrwagz/wagfam-server will add columns to the \`devices\` table for these two fields, capture them on heartbeat, and expose a \`/devices\` directory page with a redirect endpoint that prefers \`http://<mdns_name>.local/spa/\` over the raw IP.