### PR TITLE
Bump minor version to 4.3.0-wagfam

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -32,7 +32,7 @@
 #include "CorsSupport.h"
 #include "HwVerifyTest.h"
 
-#define BASE_VERSION "4.2.0-wagfam"
+#define BASE_VERSION "4.3.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else


### PR DESCRIPTION
Routine minor version bump: `4.2.0-wagfam` → `4.3.0-wagfam`.

Touches `BASE_VERSION` in `marquee/marquee.ino`. No behavior changes.