### PR TITLE
/update + /updatefs: return 400 on zero-byte uploads

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -264,6 +264,17 @@ static const char MINIMAL_PAGE_CLOSE[] PROGMEM =
 extern "C" uint32_t _FS_start;
 extern "C" uint32_t _FS_end;
 
+// Did the most recent /update or /updatefs request actually receive upload
+// bytes? AsyncWebServer fires the completion handler whether or not the
+// upload callback ever ran — so a POST with an empty/missing multipart body
+// (e.g. a cross-origin browser request killed by mixed-content blocking)
+// would otherwise reach `!Update.hasError()` and reboot the device without
+// having written any flash. The completion handler checks these flags and
+// returns 400 instead, so callers see a real failure. ESP8266 is
+// effectively single-threaded so file-scope flags are safe here.
+bool sketchUploadStarted = false;
+bool fsUploadStarted = false;
+
 // OTA auto-update state
 String OTA_SAFE_URL = "";       // URL of last confirmed firmware; rollback target for next update
 uint32_t otaConfirmAt = 0;      // non-zero: millis() target after which the pending update is confirmed
@@ -496,6 +507,22 @@ void setup() {
   // Update.runAsync(true) lets the flash routine cooperate with the async event loop.
   server.on("/update", HTTP_POST,
     [](AsyncWebServerRequest *request) {
+      // No upload bytes ever arrived — almost always a cross-origin browser
+      // block (HTTPS page POSTing to HTTP clock IP is mixed-content; the
+      // browser kills the request before any bytes leave). Without this
+      // guard the device would reboot regardless and the caller would
+      // assume the flash succeeded.
+      if (!sketchUploadStarted) {
+        Serial.println(F("[OTA] /update POST received no upload bytes — likely cross-origin browser block"));
+        AsyncWebServerResponse *response = request->beginResponse(400, F("text/plain"),
+          F("FAIL: no upload bytes received. If this came from a cross-origin browser request "
+            "(e.g. an HTTPS admin page POSTing to this http:// clock), mixed-content protection "
+            "likely killed it silently. Try uploading directly from http://<clock-ip>/update."));
+        response->addHeader(F("Connection"), F("close"));
+        request->send(response);
+        return;
+      }
+      sketchUploadStarted = false; // reset for the next request
       bool ok = !Update.hasError();
       AsyncWebServerResponse *response = request->beginResponse(200, F("text/plain"), ok ? F("OK") : F("FAIL"));
       response->addHeader(F("Connection"), F("close"));
@@ -509,6 +536,7 @@ void setup() {
     },
     [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
       if (index == 0) {
+        sketchUploadStarted = true;
         Serial.printf_P(PSTR("[OTA] Upload start: %s\n"), filename.c_str());
         Update.runAsync(true);
         uint32_t maxSketchSpace = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;
@@ -558,6 +586,22 @@ void setup() {
   // called to remount the (still-old) FS so the device stays usable.
   server.on("/updatefs", HTTP_POST,
     [](AsyncWebServerRequest *request) {
+      // No upload bytes ever arrived — almost always cross-origin mixed-content
+      // blocking from an HTTPS admin page (e.g. wagfam-server's /lan/ tool).
+      // The upload callback never fired, so /conf.txt was NOT backed up and
+      // LittleFS was NOT unmounted — the old FS is still intact. Return 400
+      // so the caller surfaces a real error instead of "success → reboot".
+      if (!fsUploadStarted) {
+        Serial.println(F("[OTAFS] /updatefs POST received no upload bytes — likely cross-origin browser block"));
+        AsyncWebServerResponse *response = request->beginResponse(400, F("text/plain"),
+          F("FAIL: no upload bytes received. If this came from a cross-origin browser request "
+            "(e.g. an HTTPS admin page POSTing to this http:// clock), mixed-content protection "
+            "likely killed it silently. Try uploading directly from http://<clock-ip>/updatefs."));
+        response->addHeader(F("Connection"), F("close"));
+        request->send(response);
+        return;
+      }
+      fsUploadStarted = false; // reset for the next request
       bool ok = !Update.hasError();
       AsyncWebServerResponse *response = request->beginResponse(200, F("text/plain"),
         ok ? F("OK — device will reboot to mount the new FS") : F("FAIL — see serial log"));
@@ -589,6 +633,7 @@ void setup() {
     },
     [](AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
       if (index == 0) {
+        fsUploadStarted = true;
         Serial.printf_P(PSTR("[OTAFS] Upload start: %s\n"), filename.c_str());
         // Save /conf.txt before unmounting so it survives the FS wipe.
         fsUpdateConfBackup = "";


### PR DESCRIPTION
## What this fixes

A 0-byte POST to either `/update` or `/updatefs` would cause the device to reboot **without writing any flash** while the caller saw `200 OK — device will reboot to mount the new FS`. The completion handler fires regardless of whether the multipart upload callback ever ran, and the previous code only checked `!Update.hasError()` — which is `true` when `Update.begin()` was never called, so the device cheerfully claimed success and rebooted.

This hit dallan-clock today: wagfam-server's `/lan/` admin tool tried to push a SPA bundle from an HTTPS page to the `http://` clock IP on iOS Safari. Mixed-content blocking silently killed the upload before any bytes left the page. The clock's completion handler fired anyway, returned "OK", rebooted. `/lan/` polled `GET /` (which `waitForRebootBack` does), got a response, displayed "Clock back online. Proceed to step 5." LittleFS was empty. `/spa/` returned 404. `/api/status` reported `spa_version: "unknown"`.

## Fix

Two file-scope booleans (`sketchUploadStarted`, `fsUploadStarted`) get set in the respective upload callbacks at `index == 0`. The completion handlers check the flag first — if `false`, return `400` with an error body that names the most likely cause (cross-origin mixed-content block) and suggests the same-origin recovery path (`http://<clock-ip>/updatefs` directly).

ESP8266 is effectively single-threaded so file-scope flags are safe here. The flags reset to `false` after each completion-handler check so the next request starts clean.

The error body explicitly mentions mixed-content blocking because it's the dominant failure mode for this 0-byte case in practice — any HTTPS admin page targeting a plain-HTTP clock will see this on modern browsers.

## Verification on real hardware (chip `5fc8ad`)

```text
$ curl -i -X POST http://192.168.168.66/updatefs
HTTP/1.1 400 Bad Request
Content-Length: 246
Content-Type: text/plain
Connection: close

FAIL: no upload bytes received. If this came from a cross-origin browser request
(e.g. an HTTPS admin page POSTing to this http:// clock), mixed-content protection
likely killed it silently. Try uploading directly from http://<clock-ip>/updatefs.

$ curl -i -X POST http://192.168.168.66/update
HTTP/1.1 400 Bad Request
FAIL: no upload bytes received. ...
```

Uptime climbed from `35s` to `56s` across both 400 responses — clock did **not** reboot from invalid POSTs.

Happy path still works:

```text
$ curl -F "update=@v441-littlefs.bin" http://192.168.168.66/updatefs
OK — device will reboot to mount the new FS
```

Followed by the expected reboot and `spa_version` transition.

## Companion fix

Even with this firmware fix, the `/lan/` JS still treats `xhr.onerror` and `xhr.status === 0` as success in `pushBinaryToClock`. A separate PR on wagfam-server will add a post-reboot `/api/status` poll to verify `version` / `spa_version` actually changed to the expected value and surface a real error otherwise — so admins on older firmware (that doesn't return 400) still get feedback.

## Test plan

- [x] `pio run -e default` — clean build, 16.68s
- [x] `make test-native` — 138 / 138 pass
- [x] Empty POST `/updatefs` → 400, no reboot, helpful body
- [x] Empty POST `/update` → 400, no reboot, helpful body
- [x] Real `/updatefs` upload of `littlefs.bin` → 200 OK, reboot, SPA boots
- [x] Real `/update` upload via `curl -F update=@firmware.bin` → 200 OK, reboot, new version boots
- [ ] After this lands and is released, re-run the `/lan/` upgrade flow from iOS Safari and confirm the clock now returns a real error on the failed-upload case instead of silently rebooting.