### PR TITLE
Bump patch version to 4.4.2-wagfam

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -69,7 +69,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.4.1-wagfam"
+#define BASE_VERSION "4.4.2-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else


### PR DESCRIPTION
Routine patch version bump: `4.4.1-wagfam` → `4.4.2-wagfam`.

Touches `BASE_VERSION` in `marquee/marquee.ino`. No behavior changes.