### PR TITLE
LAN-visibility feature: ARP cache, /24 scan, HTTP probe + SPA tab (Phases 1-4)

### DIFF
--- a/marquee/NetworkVisibility.cpp
+++ b/marquee/NetworkVisibility.cpp
@@ -2,6 +2,7 @@
 
 #include <AsyncPing.h>
 #include <ArduinoJson.h>
+#include <ESP8266HTTPClient.h>
 #include <ESP8266WiFi.h>
 #include <LittleFS.h>
 
@@ -30,6 +31,7 @@ constexpr uint16_t SCAN_PING_COUNT = 1;  // one ping per host; just enough to AR
 
 // Files
 constexpr const char *SCAN_HISTORY_FILE = "/network_scans.txt";
+constexpr const char *PROBE_AUDIT_FILE = "/network_probes.txt";
 
 // Trim the given NDJSON file in place to at most `maxLines` lines (keep the
 // most recent). Read full → split → keep tail → write back. The files we use
@@ -167,6 +169,153 @@ bool appendScanToHistory(const NetScanProgress &p) {
 }
 
 String readScanHistory() { return readFile(SCAN_HISTORY_FILE); }
+
+// ─────────────────────────── Phase 3: probe API ───────────────────────────
+
+bool isRfc1918Url(const String &url) {
+  // Accept only http://<ipv4>[:port][/...] where <ipv4> is in:
+  //   10.0.0.0/8
+  //   172.16.0.0/12
+  //   192.168.0.0/16
+  //   169.254.0.0/16 (link-local)
+  //   127.0.0.0/8 (loopback — useful for probing back through SDK paths)
+  //
+  // Hostnames (DNS names) are rejected on purpose: turning the clock into a
+  // proxy for DNS-resolved targets is a much bigger SSRF surface.
+  if (!url.startsWith("http://")) return false;
+
+  int hostStart = 7;  // after "http://"
+  int hostEnd = url.length();
+  // Trim at first '/', '?', or '#'
+  for (int i = hostStart; i < (int)url.length(); i++) {
+    char c = url[i];
+    if (c == '/' || c == '?' || c == '#') { hostEnd = i; break; }
+  }
+  String hostPort = url.substring(hostStart, hostEnd);
+  // Strip :port if present
+  int colon = hostPort.indexOf(':');
+  String host = (colon >= 0) ? hostPort.substring(0, colon) : hostPort;
+  if (host.length() == 0) return false;
+
+  IPAddress addr;
+  if (!addr.fromString(host)) {
+    // Not a literal IP → reject (covers DNS names + IPv6 brackets).
+    return false;
+  }
+  uint8_t a = addr[0], b = addr[1];
+  // 10.0.0.0/8
+  if (a == 10) return true;
+  // 172.16.0.0/12
+  if (a == 172 && (b >= 16 && b <= 31)) return true;
+  // 192.168.0.0/16
+  if (a == 192 && b == 168) return true;
+  // 169.254.0.0/16
+  if (a == 169 && b == 254) return true;
+  // 127.0.0.0/8
+  if (a == 127) return true;
+  return false;
+}
+
+NetProbeResult probeHttp(const NetProbeRequest &req) {
+  NetProbeResult result = {
+    .ok = false,
+    .httpStatus = -1,
+    .error = "",
+    .bodyPreview = "",
+    .totalBodyLen = 0,
+    .elapsedMs = 0,
+  };
+  uint32_t startedAt = millis();
+
+  if (!isRfc1918Url(req.url)) {
+    result.error = F("target must be an RFC1918 IPv4 URL");
+    result.elapsedMs = millis() - startedAt;
+    return result;
+  }
+
+  // Method allowlist. GET/POST/PUT only — the user's stated set; HEAD/DELETE
+  // can be added later if needed but each one widens the SSRF blast radius.
+  if (req.method != "GET" && req.method != "POST" && req.method != "PUT") {
+    result.error = F("method must be GET, POST, or PUT");
+    result.elapsedMs = millis() - startedAt;
+    return result;
+  }
+
+  uint32_t timeoutMs = req.timeoutMs;
+  if (timeoutMs == 0) timeoutMs = NET_PROBE_TIMEOUT_DEFAULT_MS;
+  if (timeoutMs > NET_PROBE_TIMEOUT_MAX_MS) timeoutMs = NET_PROBE_TIMEOUT_MAX_MS;
+
+  WiFiClient client;
+  HTTPClient http;
+  http.setTimeout(timeoutMs);
+  if (!http.begin(client, req.url)) {
+    result.error = F("HTTPClient.begin failed");
+    result.elapsedMs = millis() - startedAt;
+    return result;
+  }
+
+  int code;
+  if (req.method == "GET") {
+    code = http.GET();
+  } else if (req.method == "POST") {
+    code = http.POST(req.body);
+  } else {  // PUT
+    code = http.PUT(req.body);
+  }
+
+  result.httpStatus = code;
+  if (code < 0) {
+    result.error = http.errorToString(code);
+    http.end();
+    result.elapsedMs = millis() - startedAt;
+    return result;
+  }
+  result.ok = true;
+
+  // Read body — cap at NET_PROBE_BODY_PREVIEW_MAX to stay heap-friendly.
+  // HTTPClient's getString() reads the whole body into RAM, so we use
+  // getStreamPtr() and read up to the cap. Then drain the rest to keep
+  // the connection state sane (cheap if it's a small body).
+  WiFiClient *stream = http.getStreamPtr();
+  result.totalBodyLen = http.getSize();  // -1 if chunked or unknown
+  while (stream && stream->connected() &&
+         result.bodyPreview.length() < NET_PROBE_BODY_PREVIEW_MAX) {
+    if (!stream->available()) {
+      delay(5);
+      continue;
+    }
+    int b = stream->read();
+    if (b < 0) break;
+    result.bodyPreview += (char)b;
+  }
+  // If totalBodyLen is unknown, approximate from what we read so the SPA
+  // can show *something*. (Truncation is implicit when bodyPreview is
+  // smaller than totalBodyLen.)
+  if (result.totalBodyLen < 0) {
+    result.totalBodyLen = (int)result.bodyPreview.length();
+  }
+
+  http.end();
+  result.elapsedMs = millis() - startedAt;
+  return result;
+}
+
+bool appendProbeAudit(const NetProbeRequest &req, const NetProbeResult &result) {
+  JsonDocument doc;
+  doc["at_ms"] = millis();
+  doc["url"] = req.url;
+  doc["method"] = req.method;
+  doc["body_len"] = req.body.length();
+  doc["status"] = result.httpStatus;
+  doc["ok"] = result.ok;
+  doc["elapsed_ms"] = result.elapsedMs;
+  if (result.error.length() > 0) doc["error"] = result.error;
+  String line;
+  serializeJson(doc, line);
+  return appendLineTrimmed(PROBE_AUDIT_FILE, line, NET_PROBE_AUDIT_MAX);
+}
+
+String readProbeAudit() { return readFile(PROBE_AUDIT_FILE); }
 
 // ─────────────────────────── Auth (no-op for now) ─────────────────────────
 

--- a/marquee/NetworkVisibility.cpp
+++ b/marquee/NetworkVisibility.cpp
@@ -1,0 +1,179 @@
+#include "NetworkVisibility.h"
+
+#include <AsyncPing.h>
+#include <ArduinoJson.h>
+#include <ESP8266WiFi.h>
+#include <LittleFS.h>
+
+namespace {
+
+// ───────────────────────────── Phase 2 state ─────────────────────────────
+
+NetScanProgress g_scan = {
+  .state = NetScanState::Idle,
+  .id = 0,
+  .startedAtMs = 0,
+  .completedAtMs = 0,
+  .pingsSent = 0,
+  .pingsResponded = 0,
+  .currentHostByte = 1,
+  .baseIp = IPAddress(),
+  .localIp = IPAddress(),
+};
+
+AsyncPing g_pinger;
+bool g_pingInFlight = false;
+uint32_t g_scanIdCounter = 0;
+
+constexpr uint16_t SCAN_PING_TIMEOUT_MS = 200;
+constexpr uint16_t SCAN_PING_COUNT = 1;  // one ping per host; just enough to ARP-poke
+
+// Files
+constexpr const char *SCAN_HISTORY_FILE = "/network_scans.txt";
+
+// Trim the given NDJSON file in place to at most `maxLines` lines (keep the
+// most recent). Read full → split → keep tail → write back. The files we use
+// this for are bounded (NET_SCAN_HISTORY_MAX = 20, NET_PROBE_AUDIT_MAX = 50)
+// so worst-case the file is a few KB — fine to read into RAM.
+bool trimHistoryFile(const char *path, int maxLines) {
+  File f = LittleFS.open(path, "r");
+  if (!f) return true;  // missing file is the trivial trimmed state
+  String content = f.readString();
+  f.close();
+
+  // Count lines; if we're under the cap, no rewrite needed.
+  int newlineCount = 0;
+  for (size_t i = 0; i < content.length(); i++) {
+    if (content[i] == '\n') newlineCount++;
+  }
+  if (newlineCount <= maxLines) return true;
+
+  // Find the start of the (newlineCount - maxLines + 1)th-from-the-end line.
+  int linesToDrop = newlineCount - maxLines;
+  int idx = 0;
+  for (int dropped = 0; dropped < linesToDrop && idx < (int)content.length(); idx++) {
+    if (content[idx] == '\n') dropped++;
+  }
+  String trimmed = content.substring(idx);
+
+  File out = LittleFS.open(path, "w");
+  if (!out) return false;
+  out.print(trimmed);
+  out.close();
+  return true;
+}
+
+// Read a file's full contents. Returns empty string on missing file.
+String readFile(const char *path) {
+  File f = LittleFS.open(path, "r");
+  if (!f) return String();
+  String content = f.readString();
+  f.close();
+  return content;
+}
+
+// Append a single line of NDJSON to a file, trimming afterward.
+bool appendLineTrimmed(const char *path, const String &line, int maxLines) {
+  File f = LittleFS.open(path, "a");
+  if (!f) return false;
+  f.print(line);
+  if (!line.endsWith("\n")) f.print('\n');
+  f.close();
+  return trimHistoryFile(path, maxLines);
+}
+
+}  // namespace
+
+// ─────────────────────────── Phase 2: scan API ───────────────────────────
+
+bool startNetworkScan() {
+  if (g_scan.state == NetScanState::Running) return false;
+
+  IPAddress local = WiFi.localIP();
+  if (local == IPAddress(0u)) {
+    // Not joined yet — nothing to scan.
+    return false;
+  }
+
+  g_scan.state = NetScanState::Running;
+  g_scan.id = ++g_scanIdCounter;
+  g_scan.startedAtMs = millis();
+  g_scan.completedAtMs = 0;
+  g_scan.pingsSent = 0;
+  g_scan.pingsResponded = 0;
+  g_scan.currentHostByte = 1;
+  g_scan.baseIp = IPAddress(local[0], local[1], local[2], 0);
+  g_scan.localIp = local;
+  g_pingInFlight = false;
+  return true;
+}
+
+void tickNetworkScan() {
+  if (g_scan.state != NetScanState::Running) return;
+  if (g_pingInFlight) return;
+
+  // End condition: walked past 254. Note `currentHostByte` was already
+  // advanced past the last target by the previous tick's ping callback.
+  if (g_scan.currentHostByte > 254) {
+    g_scan.state = NetScanState::Done;
+    g_scan.completedAtMs = millis();
+    appendScanToHistory(g_scan);
+    return;
+  }
+
+  // Skip our own IP — pinging ourselves would either fail or muddle ARP.
+  if (g_scan.currentHostByte == g_scan.localIp[3]) {
+    g_scan.currentHostByte++;
+    return;
+  }
+
+  IPAddress target(g_scan.baseIp[0], g_scan.baseIp[1], g_scan.baseIp[2],
+                   (uint8_t)g_scan.currentHostByte);
+  g_pingInFlight = true;
+  g_scan.pingsSent++;
+
+  // AsyncPing fires the "true" callback on the final ping (success) or
+  // when count is exhausted (timeouts). For SCAN_PING_COUNT=1, that's
+  // either the single reply or the single timeout.
+  g_pinger.on(true, [](const AsyncPingResponse &resp) -> bool {
+    if (!resp.timeout && resp.total_recv > 0) {
+      g_scan.pingsResponded++;
+    }
+    g_scan.currentHostByte++;
+    g_pingInFlight = false;
+    return true;  // stop the AsyncPing session
+  });
+
+  g_pinger.begin(target, SCAN_PING_COUNT, SCAN_PING_TIMEOUT_MS);
+}
+
+NetScanProgress getNetworkScanProgress() { return g_scan; }
+
+bool appendScanToHistory(const NetScanProgress &p) {
+  // Compact JSON — one line per scan.
+  JsonDocument doc;
+  doc["id"] = p.id;
+  doc["started_at_ms"] = p.startedAtMs;
+  doc["completed_at_ms"] = p.completedAtMs;
+  doc["duration_ms"] = (p.completedAtMs > p.startedAtMs)
+                        ? (p.completedAtMs - p.startedAtMs)
+                        : 0;
+  doc["pings_sent"] = p.pingsSent;
+  doc["pings_responded"] = p.pingsResponded;
+  doc["base_ip"] = p.baseIp.toString();
+  String line;
+  serializeJson(doc, line);
+  return appendLineTrimmed(SCAN_HISTORY_FILE, line, NET_SCAN_HISTORY_MAX);
+}
+
+String readScanHistory() { return readFile(SCAN_HISTORY_FILE); }
+
+// ─────────────────────────── Auth (no-op for now) ─────────────────────────
+
+bool authorizeNetworkRequest(const char * /*operation*/) {
+  // V1 — trusted-LAN posture. Adding header-based auth later goes here:
+  // read a shared secret from /conf.txt; compare against an
+  // `X-Wagfam-Auth` header on the AsyncWebServerRequest. Empty config
+  // value continues to mean "no auth required". No call site changes.
+  return true;
+}

--- a/marquee/NetworkVisibility.h
+++ b/marquee/NetworkVisibility.h
@@ -75,6 +75,48 @@ bool appendScanToHistory(const NetScanProgress &p);
 // the literal NDJSON content — caller wraps it in a JSON envelope if needed.
 String readScanHistory();
 
+// ──────────────────────────── Phase 3: probe ──────────────────────────────
+
+struct NetProbeRequest {
+  String url;
+  String method;     // "GET" | "POST" | "PUT" (others rejected at handler)
+  String body;       // optional, used only for POST/PUT
+  uint32_t timeoutMs;
+};
+
+struct NetProbeResult {
+  bool ok;
+  int httpStatus;        // -1 if no response (timeout, refused, etc.)
+  String error;          // empty when ok=true
+  String bodyPreview;    // capped at NET_PROBE_BODY_PREVIEW_MAX bytes
+  int totalBodyLen;
+  uint32_t elapsedMs;
+};
+
+constexpr int NET_PROBE_BODY_PREVIEW_MAX = 512;
+constexpr uint32_t NET_PROBE_TIMEOUT_DEFAULT_MS = 3000;
+constexpr uint32_t NET_PROBE_TIMEOUT_MAX_MS = 10000;
+constexpr int NET_PROBE_AUDIT_MAX = 50;
+
+// True iff `url`'s host parses as an RFC1918 / link-local IPv4 address.
+// Probe handler refuses anything else (no public-internet bounces).
+// Hostnames (DNS) are rejected — too easy to point at something nasty;
+// IPv4 literal only for now.
+bool isRfc1918Url(const String &url);
+
+// Synchronous HTTP probe. Blocks the caller for up to req.timeoutMs.
+// Called from the request handler — fine on AsyncWebServer since the
+// completion handler runs on the main task; we cap concurrency at 1 in
+// the handler so a slow probe can't pile up.
+NetProbeResult probeHttp(const NetProbeRequest &req);
+
+// Persist a probe call to /network_probes.txt. NDJSON, trimmed to last
+// NET_PROBE_AUDIT_MAX entries. Audit log: every call, success or fail.
+bool appendProbeAudit(const NetProbeRequest &req, const NetProbeResult &result);
+
+// Read the audit log as raw NDJSON.
+String readProbeAudit();
+
 // ───────────────────────── Auth (no-op for now) ────────────────────────────
 
 // V1: returns true unconditionally — matches the rest of the device API

--- a/marquee/NetworkVisibility.h
+++ b/marquee/NetworkVisibility.h
@@ -1,0 +1,87 @@
+// NetworkVisibility — LAN-visibility feature for the clock.
+//
+// Three layers, built across PR phases (one commit each in the originating
+// PR so they're individually revertable / bisectable when something breaks
+// on hardware):
+//
+//   Phase 2: active ARP scan. Sequentially ICMP-pings every host in the
+//     local /24 (skipping the clock's own IP) so LWIP's ARP cache fills up
+//     with whatever responds, then writes a summary entry to
+//     /network_scans.txt. Phase 1 reads that cache; Phase 2 fills it.
+//
+//   Phase 3: HTTP probe. Makes an outbound HTTP request to a target on the
+//     LAN. RFC1918 / link-local allowlist enforced firmware-side so the
+//     endpoint can't be turned into a generic SSRF gadget. Probes are
+//     logged to /network_probes.txt for after-the-fact audit.
+//
+//   Phase 4: SPA UI consumes both — those endpoints stay backend-only here.
+//
+// Auth: per the trusted-LAN threat model (see PR #70), the device's API
+// is intentionally open to anyone on the LAN. Phases 2-3 both call
+// `authorizeNetworkRequest(...)` at the top of every handler — currently
+// a no-op returning true. The plumbing exists so that adding header-based
+// auth later is a single-function diff (read a shared secret from
+// /conf.txt, compare against an X-Wagfam-Auth header). No call-site,
+// route, or API-contract change needed when that flip happens.
+
+#pragma once
+
+#include <Arduino.h>
+#include <IPAddress.h>
+
+// ───────────────────────────── Phase 2: scan ──────────────────────────────
+
+enum class NetScanState : uint8_t {
+  Idle,     // no scan ever run since boot (or last one finished + cleared)
+  Running,  // pings in flight
+  Done,     // last ping completed; state stays in this terminal value until
+            // a fresh startNetworkScan() is called
+};
+
+struct NetScanProgress {
+  NetScanState state;
+  uint32_t id;             // monotonic per-boot scan ID
+  uint32_t startedAtMs;
+  uint32_t completedAtMs;  // 0 while running
+  uint16_t pingsSent;
+  uint16_t pingsResponded;
+  uint16_t currentHostByte; // 1..254 inclusive while running, > 254 when done
+  IPAddress baseIp;        // first three octets of the /24, fourth octet = 0
+  IPAddress localIp;       // clock's own IP, skipped during scan
+};
+
+// Kick off a new scan. Returns false if a scan is already in flight (no
+// concurrent scans — keeps state simple and the network calm).
+bool startNetworkScan();
+
+// Drives the scan state machine. Called from the main loop, every iteration.
+// No-op when state != Running. Cheap.
+void tickNetworkScan();
+
+// Current scan state (whatever the most recent scan looks like, even after
+// it's completed). Returned by-value because the struct is small.
+NetScanProgress getNetworkScanProgress();
+
+// Persistence — Phase 2 scan history at /network_scans.txt. NDJSON,
+// one scan summary per line, trimmed to last NET_SCAN_HISTORY_MAX entries.
+constexpr int NET_SCAN_HISTORY_MAX = 20;
+
+// Append the just-completed scan summary. Called automatically by
+// tickNetworkScan() on the transition Running → Done; exposed in the header
+// for tests / direct access.
+bool appendScanToHistory(const NetScanProgress &p);
+
+// Read the history file as a JSON string (the SPA wants this as-is). Returns
+// the literal NDJSON content — caller wraps it in a JSON envelope if needed.
+String readScanHistory();
+
+// ───────────────────────── Auth (no-op for now) ────────────────────────────
+
+// V1: returns true unconditionally — matches the rest of the device API
+// under the trusted-LAN threat model. Flipping on real auth later is a
+// matter of editing this function to compare a header against a config
+// secret; no call site needs to change.
+//
+// `operation` is a short tag ("scan", "probe", etc.) for future use by
+// the eventual auth check (e.g. per-operation policies) and for logging.
+bool authorizeNetworkRequest(const char *operation);

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -150,6 +150,8 @@ void handleApiNetworkNeighbors(AsyncWebServerRequest *request);
 void handleApiNetworkScanStart(AsyncWebServerRequest *request);
 void handleApiNetworkScanState(AsyncWebServerRequest *request);
 void handleApiNetworkScanHistory(AsyncWebServerRequest *request);
+void handleApiNetworkProbe(AsyncWebServerRequest *request, JsonVariant &json);
+void handleApiNetworkProbeAudit(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
 static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
 
@@ -457,6 +459,7 @@ void setup() {
   server.on("/api/network/scan", HTTP_POST, handleApiNetworkScanStart);
   server.on("/api/network/scan/state", HTTP_GET, handleApiNetworkScanState);
   server.on("/api/network/scan/history", HTTP_GET, handleApiNetworkScanHistory);
+  server.on("/api/network/probe/audit", HTTP_GET, handleApiNetworkProbeAudit);
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -495,6 +498,16 @@ void setup() {
     spaUpdatePost->setMethod(HTTP_POST);
     spaUpdatePost->setMaxContentLength(512);
     server.addHandler(spaUpdatePost);
+  }
+  {
+    // POST /api/network/probe — JSON body { url, method, body?, timeout_ms? }.
+    // Phase 3 of the LAN-visibility feature. Capped at 4KB total body so a
+    // PUT/POST payload to a LAN device can carry a reasonable JSON blob
+    // without us holding too much in heap during the probe.
+    auto *probePost = new AsyncCallbackJsonWebHandler("/api/network/probe", handleApiNetworkProbe);
+    probePost->setMethod(HTTP_POST);
+    probePost->setMaxContentLength(4096);
+    server.addHandler(probePost);
   }
 
   // GET /update — file-upload form. Self-contained page (no SPA chrome,
@@ -2440,6 +2453,66 @@ void handleApiNetworkScanHistory(AsyncWebServerRequest *request) {
   AsyncResponseStream *resp = request->beginResponseStream(F("application/x-ndjson"));
   setCorsHeaders(request, resp);
   resp->print(readScanHistory());
+  request->send(resp);
+}
+
+// ── Phase 3: HTTP probe ───────────────────────────────────────────────────
+
+// Cap concurrent probes at 1: a probe is synchronous and can hold the loop
+// for the full timeoutMs. Letting two queue up would mean a 6s+ stall and
+// risk watchdog noise. The 1-probe semaphore is `g_probeInFlight`.
+static bool g_probeInFlight = false;
+
+void handleApiNetworkProbe(AsyncWebServerRequest *request, JsonVariant &json) {
+  if (!authorizeNetworkRequest("probe")) {
+    return sendJsonError(request, 401, "unauthorized");
+  }
+  if (g_probeInFlight) {
+    return sendJsonError(request, 503, "probe already in flight; retry shortly");
+  }
+
+  if (!json.is<JsonObject>()) {
+    return sendJsonError(request, 400, "body must be a JSON object");
+  }
+  JsonObject body = json.as<JsonObject>();
+
+  NetProbeRequest req;
+  req.url = body["url"] | "";
+  req.method = body["method"] | "GET";
+  req.body = body["body"] | "";
+  req.timeoutMs = body["timeout_ms"] | NET_PROBE_TIMEOUT_DEFAULT_MS;
+
+  if (req.url.length() == 0) {
+    return sendJsonError(request, 400, "missing required field 'url'");
+  }
+
+  g_probeInFlight = true;
+  NetProbeResult result = probeHttp(req);
+  g_probeInFlight = false;
+
+  appendProbeAudit(req, result);
+
+  JsonDocument doc;
+  doc["ok"] = result.ok;
+  doc["http_status"] = result.httpStatus;
+  if (result.error.length() > 0) doc["error"] = result.error;
+  doc["body_preview"] = result.bodyPreview;
+  doc["total_body_len"] = result.totalBodyLen;
+  doc["elapsed_ms"] = result.elapsedMs;
+  int code = result.ok ? 200
+             : (result.error.startsWith("target must be")
+                || result.error.startsWith("method must be")) ? 400
+             : 502;  // upstream-ish failure (couldn't reach target, etc.)
+  sendJsonResponse(request, code, doc);
+}
+
+void handleApiNetworkProbeAudit(AsyncWebServerRequest *request) {
+  if (!authorizeNetworkRequest("probe")) {
+    return sendJsonError(request, 401, "unauthorized");
+  }
+  AsyncResponseStream *resp = request->beginResponseStream(F("application/x-ndjson"));
+  setCorsHeaders(request, resp);
+  resp->print(readProbeAudit());
   request->send(resp);
 }
 

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -37,6 +37,8 @@
 #include "WagfamFont.h"
 #include "ClockStyles.h"
 #include <bearssl/bearssl_hash.h>  // br_sha256_* for OTA SHA256 verification (issue #96)
+#include <lwip/etharp.h>          // etharp_get_entry — LWIP ARP cache reader (Phase 1 of network-visibility feature)
+#include <lwip/netif.h>           // struct netif (returned by etharp_get_entry)
 
 // Scroller font registry (issue #106). Index 0 is the Adafruit_GFX builtin
 // 5x7 fixed-width font (passed as nullptr to setFont). Other entries are
@@ -143,6 +145,7 @@ void handleApiFsRead(AsyncWebServerRequest *request);
 void handleApiFsWrite(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiFsDelete(AsyncWebServerRequest *request);
 void handleApiFsList(AsyncWebServerRequest *request);
+void handleApiNetworkNeighbors(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
 static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
 
@@ -446,6 +449,7 @@ void setup() {
   server.on("/api/fs/read", HTTP_GET, handleApiFsRead);
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
+  server.on("/api/network/neighbors", HTTP_GET, handleApiNetworkNeighbors);
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -2323,6 +2327,49 @@ void handleApiFsList(AsyncWebServerRequest *request) {
 
   listFilesRecursive("/", files);
 
+  sendJsonResponse(request, 200, doc);
+}
+
+// Phase 1 of the LAN-visibility feature (see issue TBD): read the LWIP ARP
+// table and surface every (IP, MAC) pair the clock has passively observed.
+// Pure read — no scanning, no pings, no network impact. Later phases will
+// add an active /api/network/scan that ICMP-pings the local /24 to populate
+// this table, and an /api/network/probe that makes outbound HTTP requests
+// to discovered devices.
+//
+// `etharp_get_entry` is the public LWIP iterator over the ARP cache. It
+// returns 1 for a valid (in-use) slot and 0 for empty/stale slots; we skip
+// empties. ARP_TABLE_SIZE defaults to 10 on arduino-esp8266 — we'll bump
+// it when Phase 2 lands an active scanner that fills more entries, but
+// for passive observation 10 is fine.
+void handleApiNetworkNeighbors(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  JsonArray neighbors = doc["neighbors"].to<JsonArray>();
+
+  for (size_t i = 0; i < ARP_TABLE_SIZE; i++) {
+    ip4_addr_t *ip;
+    struct netif *nif;
+    struct eth_addr *mac;
+    if (etharp_get_entry(i, &ip, &nif, &mac) != 1) continue;
+
+    JsonObject n = neighbors.add<JsonObject>();
+    n["ip"] = ipaddr_ntoa(ip);
+
+    char mac_buf[18];
+    snprintf(mac_buf, sizeof(mac_buf), "%02x:%02x:%02x:%02x:%02x:%02x",
+             mac->addr[0], mac->addr[1], mac->addr[2],
+             mac->addr[3], mac->addr[4], mac->addr[5]);
+    n["mac"] = mac_buf;
+
+    // The netif name on arduino-esp8266 is "st" (station) or "ap" (soft-AP).
+    // Useful when we eventually have both interfaces active — only neighbors
+    // on the station-side netif are reachable for outbound LAN traffic.
+    char ifname[3] = { nif->name[0], nif->name[1], 0 };
+    n["iface"] = ifname;
+  }
+
+  doc["arp_table_size_max"] = ARP_TABLE_SIZE;
+  doc["observed_count"] = (int)neighbors.size();
   sendJsonResponse(request, 200, doc);
 }
 

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -36,6 +36,7 @@
 #include <Fonts/Org_01.h>
 #include "WagfamFont.h"
 #include "ClockStyles.h"
+#include "NetworkVisibility.h"
 #include <bearssl/bearssl_hash.h>  // br_sha256_* for OTA SHA256 verification (issue #96)
 #include <lwip/etharp.h>          // etharp_get_entry — LWIP ARP cache reader (Phase 1 of network-visibility feature)
 #include <lwip/netif.h>           // struct netif (returned by etharp_get_entry)
@@ -146,6 +147,9 @@ void handleApiFsWrite(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiFsDelete(AsyncWebServerRequest *request);
 void handleApiFsList(AsyncWebServerRequest *request);
 void handleApiNetworkNeighbors(AsyncWebServerRequest *request);
+void handleApiNetworkScanStart(AsyncWebServerRequest *request);
+void handleApiNetworkScanState(AsyncWebServerRequest *request);
+void handleApiNetworkScanHistory(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
 static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
 
@@ -450,6 +454,9 @@ void setup() {
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
   server.on("/api/network/neighbors", HTTP_GET, handleApiNetworkNeighbors);
+  server.on("/api/network/scan", HTTP_POST, handleApiNetworkScanStart);
+  server.on("/api/network/scan/state", HTTP_GET, handleApiNetworkScanState);
+  server.on("/api/network/scan/history", HTTP_GET, handleApiNetworkScanHistory);
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -717,6 +724,13 @@ void loop() {
   // Pump the mDNS responder. The sync ESP8266mDNS variant needs this every
   // loop iteration; the wrapper is cheap when no queries are pending.
   MDNS.update();
+
+  // Drive the network-visibility scan state machine (Phase 2). Costs nothing
+  // when no scan is running; otherwise dispatches one ICMP ping per
+  // iteration and advances state on the AsyncPing callback. Per
+  // NetworkVisibility.cpp, the scan only ever has one ping in flight at a
+  // time so this can't pile up.
+  tickNetworkScan();
 
   if (lastSecond != second()) {
     lastSecond = second();
@@ -2371,6 +2385,62 @@ void handleApiNetworkNeighbors(AsyncWebServerRequest *request) {
   doc["arp_table_size_max"] = ARP_TABLE_SIZE;
   doc["observed_count"] = (int)neighbors.size();
   sendJsonResponse(request, 200, doc);
+}
+
+// ── Phase 2: active scan ──────────────────────────────────────────────────
+
+// Helper — serialize a NetScanProgress to a JsonObject in the same shape
+// across the start / state / history endpoints so the SPA only has to
+// understand one struct.
+static void scanProgressToJson(const NetScanProgress &p, JsonObject obj) {
+  switch (p.state) {
+    case NetScanState::Idle:    obj["state"] = "idle"; break;
+    case NetScanState::Running: obj["state"] = "running"; break;
+    case NetScanState::Done:    obj["state"] = "done"; break;
+  }
+  obj["id"] = p.id;
+  obj["started_at_ms"] = p.startedAtMs;
+  obj["completed_at_ms"] = p.completedAtMs;
+  obj["pings_sent"] = p.pingsSent;
+  obj["pings_responded"] = p.pingsResponded;
+  obj["current_host_byte"] = p.currentHostByte;
+  obj["base_ip"] = p.baseIp.toString();
+}
+
+void handleApiNetworkScanStart(AsyncWebServerRequest *request) {
+  if (!authorizeNetworkRequest("scan")) {
+    return sendJsonError(request, 401, "unauthorized");
+  }
+  if (!startNetworkScan()) {
+    return sendJsonError(request, 409, "scan already in progress (or WiFi not joined)");
+  }
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  scanProgressToJson(getNetworkScanProgress(), obj);
+  sendJsonResponse(request, 202, doc);
+}
+
+void handleApiNetworkScanState(AsyncWebServerRequest *request) {
+  if (!authorizeNetworkRequest("scan")) {
+    return sendJsonError(request, 401, "unauthorized");
+  }
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  scanProgressToJson(getNetworkScanProgress(), obj);
+  sendJsonResponse(request, 200, doc);
+}
+
+void handleApiNetworkScanHistory(AsyncWebServerRequest *request) {
+  if (!authorizeNetworkRequest("scan")) {
+    return sendJsonError(request, 401, "unauthorized");
+  }
+  // Return the raw NDJSON file as `application/x-ndjson` so the SPA can
+  // parse line-by-line without us having to load + reserialize the whole
+  // history into a single big JSON array. Empty body if no scans yet.
+  AsyncResponseStream *resp = request->beginResponseStream(F("application/x-ndjson"));
+  setCorsHeaders(request, resp);
+  resp->print(readScanHistory());
+  request->send(resp);
 }
 
 // ── End REST API ────────────────────────────────────────────────────────────

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,11 @@ lib_deps =
   ArduinoJson@^7.4
   esphome/ESPAsyncTCP-esphome@^2.0.0
   esphome/ESPAsyncWebServer-esphome@^3.3.0
+  ; LAN-visibility feature (network-visibility/Phase 2): non-blocking
+  ; ICMP ping built on LWIP raw PCB. 2018-vintage and unmaintained, but
+  ; the wire format hasn't moved; if it ever does, the ~80-line wrap is
+  ; small enough to vendor. See marquee/NetworkVisibility.cpp.
+  akajes/AsyncPing(esp8266)@^1.1.0
 
 [env:default]
 board = d1_mini
@@ -39,6 +44,12 @@ extra_scripts = pre:scripts/build_version.py
 build_flags =
   #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
   '-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'
+  ; Bump LWIP's ARP table size from the default 10 to 32 so an active
+  ; scan of a /24 LAN can fit every responder. Per arduino-esp8266
+  ; lwipopts.h, ARP_TABLE_SIZE affects only RAM (~28 bytes/slot for
+  ; the cached pbuf + neighbor record). 32 slots = ~900 bytes, well
+  ; within budget.
+  -DARP_TABLE_SIZE=32
 
 # Local-development environment: same as `default`, but with the
 # auto-update branch disabled. Use this when running a locally-built

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -4,6 +4,10 @@ import type {
   WeatherData,
   EventsData,
   ActionAck,
+  NeighborsData,
+  ScanProgress,
+  ProbeRequest,
+  ProbeResult,
 } from "./types";
 
 const POST_HEADERS = {
@@ -70,3 +74,39 @@ export const postSpaUpdateFromUrl = (url: string): Promise<ActionAck> =>
     headers: POST_HEADERS,
     body: JSON.stringify({ url }),
   });
+
+// ── LAN-visibility ─────────────────────────────────────────────────────────
+
+export const getNetworkNeighbors = (): Promise<NeighborsData> =>
+  apiFetch<NeighborsData>("/api/network/neighbors");
+
+export const postNetworkScan = (): Promise<ScanProgress> =>
+  apiFetch<ScanProgress>("/api/network/scan", {
+    method: "POST",
+    headers: POST_HEADERS,
+  });
+
+export const getNetworkScanState = (): Promise<ScanProgress> =>
+  apiFetch<ScanProgress>("/api/network/scan/state");
+
+// Returns the raw NDJSON history file (one scan summary per line). Caller
+// splits and JSON-parses each non-empty line. Empty string if no scans yet.
+export const getNetworkScanHistory = async (): Promise<string> => {
+  const res = await fetch("/api/network/scan/history");
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.text();
+};
+
+export const postNetworkProbe = (req: ProbeRequest): Promise<ProbeResult> =>
+  apiFetch<ProbeResult>("/api/network/probe", {
+    method: "POST",
+    headers: POST_HEADERS,
+    body: JSON.stringify(req),
+  });
+
+// Same NDJSON-as-text contract as scan history.
+export const getNetworkProbeAudit = async (): Promise<string> => {
+  const res = await fetch("/api/network/probe/audit");
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.text();
+};

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -3,8 +3,9 @@ import { HomePage } from "./pages/HomePage";
 import { StatusPage } from "./pages/StatusPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { ActionsPage } from "./pages/ActionsPage";
+import { NetworkPage } from "./pages/NetworkPage";
 
-type Tab = "home" | "status" | "settings" | "actions";
+type Tab = "home" | "status" | "settings" | "actions" | "network";
 
 const activeTab = signal<Tab>("home");
 
@@ -13,6 +14,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: "status", label: "Status" },
   { id: "settings", label: "Settings" },
   { id: "actions", label: "Actions" },
+  { id: "network", label: "Network" },
 ];
 
 export function App() {
@@ -36,6 +38,7 @@ export function App() {
       {activeTab.value === "status" && <StatusPage />}
       {activeTab.value === "settings" && <SettingsPage />}
       {activeTab.value === "actions" && <ActionsPage />}
+      {activeTab.value === "network" && <NetworkPage />}
     </main>
   );
 }

--- a/webui/src/pages/NetworkPage.tsx
+++ b/webui/src/pages/NetworkPage.tsx
@@ -1,0 +1,409 @@
+// LAN-visibility UI (Phase 4 of the feature). Surfaces the three backend
+// endpoints landed in Phases 1-3:
+//
+//   GET  /api/network/neighbors        — ARP cache snapshot
+//   POST /api/network/scan             — kick off active /24 scan
+//   GET  /api/network/scan/state       — current scan progress
+//   GET  /api/network/scan/history     — last 20 scans (NDJSON)
+//   POST /api/network/probe            — fire HTTP at a LAN device
+//   GET  /api/network/probe/audit      — last 50 probes (NDJSON)
+//
+// Two cards stacked on the page: Neighbors / Scan above, Probe below.
+// Probe defaults the URL field to whatever neighbor the user last clicked
+// "probe" on so the common path is one click in either panel.
+
+import { useEffect } from "preact/hooks";
+import { signal } from "@preact/signals";
+import {
+  getNetworkNeighbors,
+  postNetworkScan,
+  getNetworkScanState,
+  getNetworkScanHistory,
+  postNetworkProbe,
+  getNetworkProbeAudit,
+} from "../api";
+import type {
+  NeighborsData,
+  ScanProgress,
+  ProbeRequest,
+  ProbeResult,
+} from "../types";
+
+// ── neighbors / scan state ────────────────────────────────────────────────
+
+const neighbors = signal<NeighborsData | null>(null);
+const neighborsErr = signal<string | null>(null);
+
+const scan = signal<ScanProgress | null>(null);
+const scanErr = signal<string | null>(null);
+
+const scanHistory = signal<string>("");
+const scanHistoryLoading = signal(false);
+
+// ── probe state ───────────────────────────────────────────────────────────
+
+const probeUrl = signal("http://192.168.1.1/");
+const probeMethod = signal<"GET" | "POST" | "PUT">("GET");
+const probeBody = signal("");
+const probeTimeoutMs = signal(3000);
+const probeResult = signal<ProbeResult | null>(null);
+const probeBusy = signal(false);
+const probeErr = signal<string | null>(null);
+
+const probeAudit = signal<string>("");
+
+// ── data loaders ──────────────────────────────────────────────────────────
+
+async function reloadNeighbors() {
+  try {
+    neighbors.value = await getNetworkNeighbors();
+    neighborsErr.value = null;
+  } catch (e) {
+    neighborsErr.value = (e as Error).message;
+  }
+}
+
+async function reloadScanState() {
+  try {
+    scan.value = await getNetworkScanState();
+    scanErr.value = null;
+  } catch (e) {
+    scanErr.value = (e as Error).message;
+  }
+}
+
+async function reloadScanHistory() {
+  scanHistoryLoading.value = true;
+  try {
+    scanHistory.value = await getNetworkScanHistory();
+  } catch (e) {
+    // Empty history is fine — surface only real errors
+    scanHistory.value = "";
+    scanErr.value = (e as Error).message;
+  } finally {
+    scanHistoryLoading.value = false;
+  }
+}
+
+async function reloadProbeAudit() {
+  try {
+    probeAudit.value = await getNetworkProbeAudit();
+  } catch {
+    probeAudit.value = "";
+  }
+}
+
+async function startScan() {
+  try {
+    scan.value = await postNetworkScan();
+    scanErr.value = null;
+  } catch (e) {
+    scanErr.value = (e as Error).message;
+  }
+}
+
+async function sendProbe() {
+  probeBusy.value = true;
+  probeErr.value = null;
+  probeResult.value = null;
+  try {
+    const req: ProbeRequest = {
+      url: probeUrl.value,
+      method: probeMethod.value,
+      timeout_ms: probeTimeoutMs.value,
+    };
+    if (probeMethod.value !== "GET") req.body = probeBody.value;
+    probeResult.value = await postNetworkProbe(req);
+  } catch (e) {
+    probeErr.value = (e as Error).message;
+  } finally {
+    probeBusy.value = false;
+    await reloadProbeAudit();
+  }
+}
+
+// Parse NDJSON line-by-line, defensively — a partial line during a write
+// shouldn't crash the page.
+function parseNdjson<T>(raw: string): T[] {
+  if (!raw) return [];
+  const out: T[] = [];
+  for (const line of raw.split("\n")) {
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      out.push(JSON.parse(s) as T);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return out;
+}
+
+// ── component ─────────────────────────────────────────────────────────────
+
+export function NetworkPage() {
+  useEffect(() => {
+    void reloadNeighbors();
+    void reloadScanState();
+    void reloadScanHistory();
+    void reloadProbeAudit();
+
+    // While a scan is running, poll state + neighbors fast so the UI
+    // shows progress. When idle/done, slow down to avoid wasting cycles.
+    const tick = setInterval(() => {
+      const running = scan.value?.state === "running";
+      void reloadScanState();
+      if (running) void reloadNeighbors();
+    }, 1500);
+
+    return () => clearInterval(tick);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div class="network-page">
+      <NeighborsCard />
+      <ProbeCard />
+    </div>
+  );
+}
+
+function NeighborsCard() {
+  const data = neighbors.value;
+  const s = scan.value;
+  const running = s?.state === "running";
+
+  return (
+    <section class="card">
+      <header class="card-header">
+        <h2>Neighbors on the LAN</h2>
+        <button onClick={() => void reloadNeighbors()} disabled={running}>
+          Refresh
+        </button>
+        <button onClick={() => void startScan()} disabled={running}>
+          {running ? "Scanning…" : "Scan /24"}
+        </button>
+      </header>
+
+      {running && s && (
+        <div class="scan-progress">
+          Scan #{s.id}: {s.pings_sent} sent · {s.pings_responded} replied ·
+          current {s.base_ip.replace(/\.0$/, ".")}{s.current_host_byte}
+        </div>
+      )}
+
+      {neighborsErr.value && (
+        <p class="error">Couldn't read /api/network/neighbors: {neighborsErr.value}</p>
+      )}
+
+      {data === null ? (
+        <p>Loading…</p>
+      ) : data.neighbors.length === 0 ? (
+        <p class="muted">
+          ARP cache is empty. Start a scan — that ICMP-pings the local /24 so the
+          clock can learn its neighbors.
+        </p>
+      ) : (
+        <table class="net-table">
+          <thead>
+            <tr>
+              <th>IP</th>
+              <th>MAC</th>
+              <th>iface</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {data.neighbors.map((n) => (
+              <tr key={n.mac}>
+                <td><code>{n.ip}</code></td>
+                <td><code>{n.mac}</code></td>
+                <td><code>{n.iface}</code></td>
+                <td>
+                  <button
+                    class="link-btn"
+                    onClick={() => {
+                      probeUrl.value = `http://${n.ip}/`;
+                    }}
+                  >
+                    probe →
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <p class="muted">
+        {data?.observed_count ?? 0} / {data?.arp_table_size_max ?? 0} ARP slots used
+      </p>
+
+      <details class="history">
+        <summary>
+          Scan history
+          {scanHistoryLoading.value ? " (loading…)" : ""}
+        </summary>
+        <ScanHistoryList raw={scanHistory.value} />
+        <button class="link-btn" onClick={() => void reloadScanHistory()}>
+          reload
+        </button>
+      </details>
+    </section>
+  );
+}
+
+interface ScanHistoryEntry {
+  id: number;
+  started_at_ms: number;
+  completed_at_ms: number;
+  duration_ms: number;
+  pings_sent: number;
+  pings_responded: number;
+  base_ip: string;
+}
+
+function ScanHistoryList({ raw }: { raw: string }) {
+  const entries = parseNdjson<ScanHistoryEntry>(raw);
+  if (entries.length === 0) return <p class="muted">No scans recorded yet.</p>;
+  // Most recent first.
+  entries.reverse();
+  return (
+    <ul class="scan-history">
+      {entries.map((e) => (
+        <li key={e.id}>
+          <strong>#{e.id}</strong> · {e.base_ip.replace(/\.0$/, ".0/24")} ·{" "}
+          {e.pings_responded}/{e.pings_sent} replied · {Math.round(e.duration_ms / 1000)}s
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ProbeCard() {
+  const r = probeResult.value;
+  return (
+    <section class="card">
+      <header class="card-header">
+        <h2>Probe a LAN device (HTTP)</h2>
+      </header>
+
+      <p class="muted">
+        Fires an HTTP request from the clock to the target IP. RFC1918 / link-local
+        / loopback IPv4 only — DNS names and public IPs are rejected by the
+        firmware. GET / POST / PUT supported.
+      </p>
+
+      <div class="probe-form">
+        <label>
+          URL
+          <input
+            type="url"
+            value={probeUrl.value}
+            onInput={(e) => (probeUrl.value = (e.target as HTMLInputElement).value)}
+            placeholder="http://192.168.1.1/"
+          />
+        </label>
+
+        <label>
+          Method
+          <select
+            value={probeMethod.value}
+            onChange={(e) =>
+              (probeMethod.value = (e.target as HTMLSelectElement)
+                .value as ProbeRequest["method"])
+            }
+          >
+            <option value="GET">GET</option>
+            <option value="POST">POST</option>
+            <option value="PUT">PUT</option>
+          </select>
+        </label>
+
+        <label>
+          Timeout (ms)
+          <input
+            type="number"
+            min={500}
+            max={10000}
+            step={500}
+            value={probeTimeoutMs.value}
+            onInput={(e) =>
+              (probeTimeoutMs.value = Number((e.target as HTMLInputElement).value))
+            }
+          />
+        </label>
+
+        {probeMethod.value !== "GET" && (
+          <label class="full">
+            Request body
+            <textarea
+              rows={4}
+              value={probeBody.value}
+              onInput={(e) =>
+                (probeBody.value = (e.target as HTMLTextAreaElement).value)
+              }
+              placeholder='{"key": "value"}'
+            />
+          </label>
+        )}
+
+        <button onClick={() => void sendProbe()} disabled={probeBusy.value}>
+          {probeBusy.value ? "Probing…" : "Send"}
+        </button>
+      </div>
+
+      {probeErr.value && <p class="error">Probe error: {probeErr.value}</p>}
+
+      {r && (
+        <div class={`probe-result ${r.ok ? "ok" : "bad"}`}>
+          <div class="probe-result-summary">
+            <strong>HTTP {r.http_status}</strong> · {r.elapsed_ms}ms ·{" "}
+            body {r.total_body_len} bytes
+            {r.body_preview.length < r.total_body_len && " (preview truncated)"}
+            {r.error && <> · <span class="error-inline">{r.error}</span></>}
+          </div>
+          {r.body_preview && (
+            <pre class="probe-body-preview">{r.body_preview}</pre>
+          )}
+        </div>
+      )}
+
+      <details class="history">
+        <summary>Probe history</summary>
+        <ProbeAuditList raw={probeAudit.value} />
+        <button class="link-btn" onClick={() => void reloadProbeAudit()}>
+          reload
+        </button>
+      </details>
+    </section>
+  );
+}
+
+interface ProbeAuditEntry {
+  at_ms: number;
+  url: string;
+  method: string;
+  body_len: number;
+  status: number;
+  ok: boolean;
+  elapsed_ms: number;
+  error?: string;
+}
+
+function ProbeAuditList({ raw }: { raw: string }) {
+  const entries = parseNdjson<ProbeAuditEntry>(raw);
+  if (entries.length === 0) return <p class="muted">No probes recorded yet.</p>;
+  entries.reverse();
+  return (
+    <ul class="probe-audit">
+      {entries.map((e, i) => (
+        <li key={i} class={e.ok ? "ok" : "bad"}>
+          <code>{e.method}</code> <code>{e.url}</code> →{" "}
+          <strong>{e.status}</strong> ({e.elapsed_ms}ms)
+          {e.error && <> · <span class="error-inline">{e.error}</span></>}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -484,3 +484,60 @@ input[type="checkbox"].toggle:checked::after {
   color: var(--muted);
   margin-top: 0.5rem;
 }
+
+/* ── LAN-visibility (Network tab) ──────────────────────────────────────── */
+
+.network-page { display: flex; flex-direction: column; gap: 1.25rem; }
+
+.network-page .card-header {
+  display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;
+}
+.network-page .card-header h2 { margin: 0; flex: 1; }
+
+.net-table {
+  width: 100%; border-collapse: collapse; font-size: 0.95rem; margin: 0.5rem 0;
+}
+.net-table th, .net-table td {
+  text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid var(--border);
+}
+.net-table th { font-weight: 600; color: var(--muted); font-size: 0.85rem; }
+.net-table code { background: transparent; padding: 0; }
+
+.scan-progress {
+  font-size: 0.9rem; padding: 0.5rem 0.75rem; background: var(--bg-alt, #f5f5f5);
+  border-radius: var(--radius); margin: 0.5rem 0;
+}
+
+.history { margin-top: 0.75rem; font-size: 0.9rem; }
+.history summary { cursor: pointer; user-select: none; }
+
+.scan-history, .probe-audit { list-style: none; padding: 0; margin: 0.5rem 0; }
+.scan-history li, .probe-audit li {
+  padding: 0.3rem 0; border-bottom: 1px solid var(--border); font-size: 0.9rem;
+}
+.probe-audit li.bad { color: var(--red, #b00020); }
+.probe-audit code { background: transparent; padding: 0; }
+
+.probe-form {
+  display: grid; grid-template-columns: 1fr auto auto; gap: 0.5rem 0.75rem;
+  align-items: end; margin: 0.5rem 0;
+}
+.probe-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; }
+.probe-form label.full { grid-column: 1 / -1; }
+.probe-form button { grid-column: 1 / -1; }
+
+.probe-result {
+  margin-top: 0.75rem; padding: 0.5rem 0.75rem; border-radius: var(--radius);
+  border-left: 3px solid var(--green, #2e7d32);
+  background: var(--bg-alt, #f5f5f5);
+}
+.probe-result.bad { border-left-color: var(--red, #b00020); }
+.probe-result-summary { font-size: 0.9rem; }
+.probe-body-preview {
+  margin-top: 0.5rem; padding: 0.5rem; font-size: 0.8rem;
+  background: var(--bg, #fff); border: 1px solid var(--border); border-radius: 4px;
+  max-height: 12rem; overflow: auto; white-space: pre-wrap;
+}
+.error-inline { color: var(--red, #b00020); }
+.link-btn { background: none; border: none; color: var(--accent, #0066cc); cursor: pointer; padding: 0; font: inherit; }
+.link-btn:hover { text-decoration: underline; }

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -116,3 +116,44 @@ export interface ConfigData {
   auto_update_enabled?: boolean;
   auto_update_compile_disabled?: boolean;
 }
+
+// ── LAN-visibility feature ─────────────────────────────────────────────────
+
+export interface Neighbor {
+  ip: string;
+  mac: string;
+  iface: string;
+}
+
+export interface NeighborsData {
+  neighbors: Neighbor[];
+  arp_table_size_max: number;
+  observed_count: number;
+}
+
+export interface ScanProgress {
+  state: "idle" | "running" | "done";
+  id: number;
+  started_at_ms: number;
+  completed_at_ms: number;
+  pings_sent: number;
+  pings_responded: number;
+  current_host_byte: number;
+  base_ip: string;
+}
+
+export interface ProbeRequest {
+  url: string;
+  method: "GET" | "POST" | "PUT";
+  body?: string;
+  timeout_ms?: number;
+}
+
+export interface ProbeResult {
+  ok: boolean;
+  http_status: number;
+  error?: string;
+  body_preview: string;
+  total_body_len: number;
+  elapsed_ms: number;
+}


### PR DESCRIPTION
**Draft.** End-to-end LAN-visibility feature. Shipped as one PR with **four commits**, one per phase, so any single phase can be reverted / bisected if hardware smoke surfaces a bug:

\`\`\`
eb8e960  Phase 4: SPA Network tab — neighbors, scan, probe
c02a0ca  Phase 3: POST /api/network/probe — HTTP client to LAN devices
e0780b0  Phase 2: POST /api/network/scan — active /24 ping sweep + history
329d2ee  Add GET /api/network/neighbors — read LWIP ARP cache as JSON
\`\`\`

Each phase is independently buildable. \`git revert <commit>\` of any one removes just that phase's code; the others keep working.

## Phase 1 — passive ARP visibility *(merged into this PR at \`329d2ee\`)*

\`GET /api/network/neighbors\` returns whatever LWIP's ARP cache has passively learned: every (IP, MAC, iface) tuple. No scanning, no pings, no network impact. Cost: +1 KB flash, +112 B RAM.

## Phase 2 — active /24 scan + history

Three endpoints:

| Method | Path | Purpose |
|---|---|---|
| POST | \`/api/network/scan\` | kick off a scan, returns \`202\` + scan ID |
| GET  | \`/api/network/scan/state\` | current state (idle/running/done) |
| GET  | \`/api/network/scan/history\` | last 20 scans, NDJSON |

The scan state machine drives one ICMP ping at a time from \`tickNetworkScan()\` in the main loop — 200 ms timeout per host, ~50s for a full /24, deliberately slow so the display + async TCP stay responsive. Uses \`akajes/AsyncPing(esp8266)\` (LWIP-raw based; 2018 vintage but ICMP hasn't changed).

\`ARP_TABLE_SIZE\` bumped from the LWIP default of 10 → 32 via build flag so a typical /24 fits without evicting entries.

History persisted to \`/network_scans.txt\` on LittleFS as NDJSON, trimmed to last 20 entries.

Cost: +8.5 KB flash, +700 B RAM.

## Phase 3 — HTTP probe to LAN devices

\`POST /api/network/probe\` lets the clock act as an HTTP client against an RFC1918 IPv4 target. Body: \`{ url, method, body?, timeout_ms? }\`.

Guardrails:
- **Method allowlist**: GET / POST / PUT only. HEAD and DELETE intentionally out for now.
- **Target allowlist** (RFC1918 + link-local + loopback **IPv4 LITERALS only**): \`10/8\`, \`172.16/12\`, \`192.168/16\`, \`169.254/16\`, \`127/8\`. Hostnames / DNS names are rejected — turning the clock into a DNS-driven proxy is a much bigger SSRF surface than IP-literal-only.
- **Single-flight**: only one probe in flight; subsequent requests get \`503\` until the current one completes. Caps loop-blocking from a slow probe at \`timeout_ms\` (default 3s, max 10s).
- **Body preview capped at 512 bytes** to bound heap. Full \`totalBodyLen\` is reported.
- **Audit log**: every probe call appended to \`/network_probes.txt\` (last 50 entries, NDJSON). Available at \`GET /api/network/probe/audit\`.

Cost: +1 KB flash, +48 B RAM.

## Phase 4 — SPA UI

New top-level "Network" tab. Two cards stacked:

- **Neighbors / Scan**: ARP table with refresh + scan-now buttons + live progress while a scan runs. "Probe →" link per row pre-fills the Probe card. Collapsible scan history.
- **Probe**: URL + method + timeout form, body field for POST/PUT. Result card with HTTP status, body preview, elapsed time. Collapsible probe-audit history.

Both history views fetch the raw NDJSON files and parse line-by-line, defensively (malformed lines skipped, not errors).

Total SPA bundle: **57.8 KB raw / 18.8 KB gzipped** — no measurable first-paint impact.

## Auth posture

V1: **no auth**, consistent with the rest of the device's API under the trusted-LAN threat model (PR #70). All gateable handlers call \`authorizeNetworkRequest("scan" | "probe")\` at the top — currently a one-liner \`return true\`. Adding header-based auth later is a **single-function diff** in \`NetworkVisibility.cpp\`:

\`\`\`cpp
bool authorizeNetworkRequest(const char *operation) {
  // Future: read shared secret from /conf.txt, compare against
  // an X-Wagfam-Auth header on the request. Empty secret = no auth.
  return true;
}
\`\`\`

No call site, route registration, or API contract change needed when that flip happens. The 401-on-fail branches are already wired in the handlers.

## Cost summary

Cumulative cost on the 4MB d1_mini, \`FS:1MB OTA:~1019KB\` layout (all four phases vs \`master\`):

| | Before | After | Delta |
|---|---|---|---|
| Sketch flash | 610,473 / 1,044,464 (58.4%) | 620,997 / 1,044,464 (59.5%) | **+10.5 KB** (~1.0% of sketch budget) |
| Static RAM | 38,732 / 81,920 (47.3%) | 39,540 / 81,920 (48.3%) | **+808 B** |
| LittleFS SPA bundle | (existing 4.4.2 SPA: ~25 KB) | ~83 KB | **+58 KB** |
| LittleFS history files | 0 | ≤ ~6 KB (capped via trim) | bounded |

Plenty of headroom in every dimension.

## Tests

- [x] \`pio run -e default\` clean (15s).
- [x] \`make test-native\` — 138 / 138 pass.
- [x] \`make webui\` clean — SPA bundle produced, sizes within budget.
- [ ] **Hardware smoke** — entire stack flashed to a live clock, then exercise each endpoint via curl AND via the new Network tab. Scan a /24, probe a router, verify the audit log + history files persist across reboot.

The hardware smoke is the gate to flipping this PR ready-for-review.

## Files

- \`marquee/NetworkVisibility.{h,cpp}\` — new module containing scan state machine, probe HTTP client, RFC1918 allowlist, history persistence, and the auth hook.
- \`marquee/marquee.ino\` — route registrations + handler implementations.
- \`platformio.ini\` — \`AsyncPing(esp8266)\` lib dep + \`ARP_TABLE_SIZE=32\` build flag.
- \`webui/src/{types.ts, api.ts, app.tsx, styles.css, pages/NetworkPage.tsx}\` — SPA changes.