### PR TITLE
Tasmota scheduler — cron-driven LAN switch control + auto-discovery

### DIFF
--- a/makefile
+++ b/makefile
@@ -278,6 +278,12 @@ webui/node_modules/.installed: webui/package.json
 
 .PHONY: webui
 webui: .passwd webui/node_modules/.installed
+	# Stamp the JS bundle with its version. write_spa_version.py writes
+	# data/spa/version.json; vite.config.ts reads it and injects the value
+	# as __SPA_VERSION__ into the bundle. The Footer in app.tsx compares
+	# this baked-in value against /api/status.spa_version so a stale
+	# browser cache is visible at a glance.
+	python3 scripts/write_spa_version.py
 	docker run \
 		--rm $(DOCKER_TTY_ARGS) \
 		-v ${PWD}:${PWD} \
@@ -288,6 +294,10 @@ webui: .passwd webui/node_modules/.installed
 		-e npm_config_cache=${PWD}/webui/.npm-cache \
 		$(NODE_IMAGE) \
 		npm run build
+	# vite's emptyOutDir wiped data/spa/version.json — restore it so the
+	# device's boot-time read_spa_version() and /api/status both report
+	# the same string baked into the bundle above.
+	python3 scripts/write_spa_version.py
 	@echo ""
 	@echo "SPA bundle written to data/spa/. Sizes:"
 	@cd data/spa && find . -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' \) -exec ls -l {} \; | awk '{printf "  %8d  %s\n", $$5, $$NF}'

--- a/marquee/TasmotaDiscovery.cpp
+++ b/marquee/TasmotaDiscovery.cpp
@@ -1,0 +1,237 @@
+#include "TasmotaDiscovery.h"
+
+#include <AsyncPing.h>
+#include <ArduinoJson.h>
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266mDNS.h>
+
+namespace TasmotaDiscovery {
+
+namespace {
+
+DiscoveryProgress g_progress = {
+  .state = DiscoveryState::Idle,
+  .id = 0,
+  .startedAtMs = 0,
+  .completedAtMs = 0,
+  .pingsSent = 0,
+  .pingsResponded = 0,
+  .httpProbed = 0,
+  .tasmotaFound = 0,
+  .currentHostByte = 1,
+  .baseIp = IPAddress(),
+};
+
+DiscoveredDevice g_results[MAX_RESULTS];
+int g_resultCount = 0;
+uint32_t g_idCounter = 0;
+
+AsyncPing g_pinger;
+bool g_pingInFlight = false;
+// When a ping completes successfully, we stash the IP here so the next
+// tick fires an HTTP probe. Keeps the AsyncPing callback short.
+IPAddress g_pendingProbeIp = IPAddress(0u);
+bool g_hasPendingProbe = false;
+
+constexpr uint16_t PING_TIMEOUT_MS = 200;
+constexpr uint16_t HTTP_PROBE_TIMEOUT_MS = 500;
+
+// ── HTTP probe ────────────────────────────────────────────────────────────
+//
+// Issues GET /cm?cmnd=Status%200 (the "everything" status). On a Tasmota
+// device this returns a big JSON with both Status (DeviceName /
+// FriendlyName) and StatusNET (Hostname). On a non-Tasmota device it
+// returns whatever — most likely 404 or HTML, both of which fail the
+// JSON parse and the "Status.DeviceName present" check.
+
+bool probeTasmota(const char *ip, DiscoveredDevice *out) {
+  WiFiClient client;
+  HTTPClient http;
+  http.setTimeout(HTTP_PROBE_TIMEOUT_MS);
+  String url = String("http://") + ip + "/cm?cmnd=Status%200";
+  if (!http.begin(client, url)) return false;
+  int code = http.GET();
+  if (code != 200) {
+    http.end();
+    return false;
+  }
+  String body = http.getString();
+  http.end();
+
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) return false;
+
+  // Tasmota Status 0 response wraps everything in top-level keys.
+  // Required: Status.DeviceName (or FriendlyName). Helpful: StatusNET.Hostname.
+  JsonVariant status = doc["Status"];
+  if (status.isNull()) return false;
+  String name;
+  if (status["DeviceName"].is<const char *>()) {
+    name = status["DeviceName"].as<String>();
+  }
+  if (name.length() == 0 && status["FriendlyName"].is<JsonArray>()) {
+    JsonArray fn = status["FriendlyName"].as<JsonArray>();
+    if (fn.size() > 0) name = fn[0].as<String>();
+  }
+  if (name.length() == 0) return false;
+
+  strlcpy(out->ip, ip, IP_STR_MAX);
+  strlcpy(out->name, name.c_str(), NAME_STR_MAX);
+
+  String hostname;
+  JsonVariant net = doc["StatusNET"];
+  if (!net.isNull() && net["Hostname"].is<const char *>()) {
+    hostname = net["Hostname"].as<String>();
+  }
+  strlcpy(out->hostname, hostname.c_str(), HOST_STR_MAX);
+  return true;
+}
+
+bool addResultIfNew(const DiscoveredDevice &d) {
+  for (int i = 0; i < g_resultCount; i++) {
+    if (strcmp(g_results[i].ip, d.ip) == 0) {
+      // Already have this IP — update name/hostname in case mDNS got us
+      // a partial entry that scan now fills in.
+      if (d.name[0]) strlcpy(g_results[i].name, d.name, NAME_STR_MAX);
+      if (d.hostname[0]) strlcpy(g_results[i].hostname, d.hostname, HOST_STR_MAX);
+      return false;
+    }
+  }
+  if (g_resultCount >= MAX_RESULTS) return false;
+  g_results[g_resultCount++] = d;
+  return true;
+}
+
+// ── mDNS path ─────────────────────────────────────────────────────────────
+
+// Synchronous mDNS query — blocks ~3s. Called once at the start of a
+// discovery run. Each hit is added immediately to results; the friendly
+// name + hostname come from the mDNS record so no HTTP probe needed for
+// these (we could probe to enrich, but ESP8266mDNS doesn't always give
+// us enough info to know if it's worth it; keep it simple).
+void runMdnsQuery() {
+  int n = MDNS.queryService("tasmota", "tcp");
+  for (int i = 0; i < n && g_resultCount < MAX_RESULTS; i++) {
+    IPAddress ip = MDNS.IP(i);
+    String host = MDNS.hostname(i);
+    DiscoveredDevice d = {};
+    strlcpy(d.ip, ip.toString().c_str(), IP_STR_MAX);
+    strlcpy(d.hostname, host.c_str(), HOST_STR_MAX);
+    d.source = "mdns";
+    // FriendlyName isn't in the mDNS record; HTTP-probe to fill it in.
+    // This adds ~300ms per mDNS hit but enriches the entry meaningfully.
+    DiscoveredDevice enriched = d;
+    if (probeTasmota(d.ip, &enriched)) {
+      enriched.source = "mdns";
+      addResultIfNew(enriched);
+      g_progress.httpProbed++;
+      g_progress.tasmotaFound++;
+    } else {
+      // mDNS said it's there but HTTP probe failed — still add it so the
+      // user sees something. They can edit the name manually.
+      addResultIfNew(d);
+      g_progress.tasmotaFound++;
+    }
+  }
+}
+
+}  // namespace
+
+bool start() {
+  if (g_progress.state != DiscoveryState::Idle &&
+      g_progress.state != DiscoveryState::Done) {
+    return false;
+  }
+  IPAddress local = WiFi.localIP();
+  if (local == IPAddress(0u)) return false;
+
+  g_resultCount = 0;
+  g_progress.state = DiscoveryState::MdnsQuery;
+  g_progress.id = ++g_idCounter;
+  g_progress.startedAtMs = millis();
+  g_progress.completedAtMs = 0;
+  g_progress.pingsSent = 0;
+  g_progress.pingsResponded = 0;
+  g_progress.httpProbed = 0;
+  g_progress.tasmotaFound = 0;
+  g_progress.currentHostByte = 1;
+  g_progress.baseIp = IPAddress(local[0], local[1], local[2], 0);
+  g_pingInFlight = false;
+  g_hasPendingProbe = false;
+  return true;
+}
+
+void tick() {
+  // mDNS phase is synchronous — collapse it into one tick. (Blocks ~3s
+  // once per run; not worth state-machine-ifying further.)
+  if (g_progress.state == DiscoveryState::MdnsQuery) {
+    runMdnsQuery();
+    g_progress.state = DiscoveryState::PingSweep;
+    return;
+  }
+
+  if (g_progress.state != DiscoveryState::PingSweep) return;
+
+  // Deferred HTTP probe from the previous ping reply.
+  if (g_hasPendingProbe) {
+    g_hasPendingProbe = false;
+    char ipStr[IP_STR_MAX];
+    g_pendingProbeIp.toString().toCharArray(ipStr, IP_STR_MAX);
+    DiscoveredDevice d = {};
+    g_progress.httpProbed++;
+    if (probeTasmota(ipStr, &d)) {
+      d.source = "scan";
+      if (addResultIfNew(d)) g_progress.tasmotaFound++;
+    }
+    return;
+  }
+
+  if (g_pingInFlight) return;
+
+  if (g_progress.currentHostByte > 254) {
+    g_progress.state = DiscoveryState::Done;
+    g_progress.completedAtMs = millis();
+    Serial.printf_P(PSTR("[discover] done — %d Tasmota(s) on %d responders\n"),
+                    (int)g_progress.tasmotaFound, (int)g_progress.pingsResponded);
+    return;
+  }
+
+  IPAddress local = WiFi.localIP();
+  if (g_progress.currentHostByte == local[3]) {
+    g_progress.currentHostByte++;
+    return;
+  }
+
+  IPAddress target(g_progress.baseIp[0], g_progress.baseIp[1],
+                   g_progress.baseIp[2], (uint8_t)g_progress.currentHostByte);
+  g_pingInFlight = true;
+  g_progress.pingsSent++;
+
+  g_pinger.on(true, [target](const AsyncPingResponse &resp) -> bool {
+    if (!resp.timeout && resp.total_recv > 0) {
+      g_progress.pingsResponded++;
+      g_pendingProbeIp = target;
+      g_hasPendingProbe = true;
+    }
+    g_progress.currentHostByte++;
+    g_pingInFlight = false;
+    return true;
+  });
+
+  g_pinger.begin(target, 1, PING_TIMEOUT_MS);
+}
+
+DiscoveryProgress getProgress() { return g_progress; }
+int resultCount() { return g_resultCount; }
+const DiscoveredDevice &getResult(int i) { return g_results[i]; }
+
+bool probeOne(const char *ip, DiscoveredDevice *out) {
+  DiscoveredDevice d = {};
+  if (!probeTasmota(ip, &d)) return false;
+  d.source = "manual";
+  *out = d;
+  return true;
+}
+
+}  // namespace TasmotaDiscovery

--- a/marquee/TasmotaDiscovery.cpp
+++ b/marquee/TasmotaDiscovery.cpp
@@ -36,8 +36,12 @@ bool g_pingInFlight = false;
 IPAddress g_pendingProbeIp = IPAddress(0u);
 bool g_hasPendingProbe = false;
 
-constexpr uint16_t PING_TIMEOUT_MS = 200;
-constexpr uint16_t HTTP_PROBE_TIMEOUT_MS = 500;
+// Originally 200ms — empirically that was too aggressive over WiFi; pings
+// to known-alive hosts (gateway, Tasmota at .241, Mac at .198) all reported
+// as timeouts. Bumping to 500ms catches typical LAN reply latency
+// (~5-50ms) plus the ESP8266 WiFi-stack queue delay.
+constexpr uint16_t PING_TIMEOUT_MS = 500;
+constexpr uint16_t HTTP_PROBE_TIMEOUT_MS = 1000;
 
 // ── HTTP probe ────────────────────────────────────────────────────────────
 //
@@ -241,7 +245,11 @@ void tick() {
   g_progress.pingsSent++;
 
   g_pinger.on(true, [target](const AsyncPingResponse &resp) -> bool {
-    if (!resp.timeout && resp.total_recv > 0) {
+    // resp.answer is the "got a reply this round" boolean. resp.timeout is
+    // the configured timeout in ms (poorly named in the library — it is
+    // *not* a "did we time out" flag), so checking it was a no-op bug that
+    // made every ping look like a failure.
+    if (resp.answer) {
       g_progress.pingsResponded++;
       g_pendingProbeIp = target;
       g_hasPendingProbe = true;

--- a/marquee/TasmotaDiscovery.cpp
+++ b/marquee/TasmotaDiscovery.cpp
@@ -5,6 +5,8 @@
 #include <ESP8266HTTPClient.h>
 #include <ESP8266WiFi.h>
 #include <ESP8266mDNS.h>
+#include <LittleFS.h>
+#include <TimeLib.h>
 
 namespace TasmotaDiscovery {
 
@@ -194,6 +196,36 @@ void tick() {
     g_progress.completedAtMs = millis();
     Serial.printf_P(PSTR("[discover] done — %d Tasmota(s) on %d responders\n"),
                     (int)g_progress.tasmotaFound, (int)g_progress.pingsResponded);
+
+    // Persist results to LittleFS. Source of truth for the planned
+    // upload-to-server feature: the server periodically fetches this
+    // file, snapshots it per-clock, and on a replacement clock pushes
+    // it back down via a future config-block field so the user's
+    // inventory survives a flash wipe / hardware swap.
+    File f = LittleFS.open(DISCOVERED_FILE, "w");
+    if (f) {
+      JsonDocument doc;
+      doc["scan_id"] = g_progress.id;
+      doc["completed_at_unix"] = (uint32_t)now();
+      doc["completed_at_ms"] = g_progress.completedAtMs;
+      doc["pings_sent"] = g_progress.pingsSent;
+      doc["pings_responded"] = g_progress.pingsResponded;
+      JsonArray arr = doc["results"].to<JsonArray>();
+      for (int i = 0; i < g_resultCount; i++) {
+        const auto &d = g_results[i];
+        JsonObject o = arr.add<JsonObject>();
+        o["ip"] = d.ip;
+        o["name"] = d.name;
+        o["hostname"] = d.hostname;
+        o["source"] = d.source ? d.source : "scan";
+      }
+      serializeJson(doc, f);
+      f.close();
+      Serial.printf_P(PSTR("[discover] wrote %d device(s) to %s\n"),
+                      g_resultCount, DISCOVERED_FILE);
+    } else {
+      Serial.println(F("[discover] FAILED to open discovered file for write"));
+    }
     return;
   }
 
@@ -232,6 +264,14 @@ bool probeOne(const char *ip, DiscoveredDevice *out) {
   d.source = "manual";
   *out = d;
   return true;
+}
+
+String readPersistedResults() {
+  File f = LittleFS.open(DISCOVERED_FILE, "r");
+  if (!f) return String();
+  String s = f.readString();
+  f.close();
+  return s;
 }
 
 }  // namespace TasmotaDiscovery

--- a/marquee/TasmotaDiscovery.h
+++ b/marquee/TasmotaDiscovery.h
@@ -32,7 +32,7 @@
 
 namespace TasmotaDiscovery {
 
-constexpr int MAX_RESULTS = 32;
+constexpr int MAX_RESULTS = 16;
 constexpr int NAME_STR_MAX = 32;
 constexpr int IP_STR_MAX = 16;
 constexpr int HOST_STR_MAX = 32;

--- a/marquee/TasmotaDiscovery.h
+++ b/marquee/TasmotaDiscovery.h
@@ -1,0 +1,91 @@
+// TasmotaDiscovery — auto-detect Tasmota switches on the LAN.
+//
+// Strategy is "all of the above" so we catch devices regardless of their
+// configuration:
+//
+//   1. mDNS query for _tasmota._tcp. Tasmota only registers this when
+//      SetOption55 is on (off by default), so this finds the opted-in
+//      subset — but for those, it's instantaneous.
+//
+//   2. Ping sweep of the local /24. AsyncPing one host at a time so the
+//      loop stays responsive; takes ~50s for a full /24. Populates LWIP's
+//      ARP cache as a side effect.
+//
+//   3. HTTP probe of every IP that responded to ping. GET /cm?cmnd=Status
+//      with a short timeout; if the response parses as Tasmota JSON
+//      (presence of "Status.DeviceName"), record the device with its
+//      friendly name + hostname (via Status 5 / StatusNET).
+//
+// Steps 2 and 3 are interleaved: each ping that responds immediately
+// kicks off an HTTP probe for that IP before moving to the next ping.
+// Total time for a /24 with 20 devices alive: ~57s (254 × 200ms ICMP +
+// 20 × 300ms HTTP).
+//
+// Output: an in-RAM array of DiscoveredDevice — read by the SPA's
+// "Auto-detect" button on the Devices card.
+
+#pragma once
+
+#include <Arduino.h>
+#include <stdint.h>
+#include <IPAddress.h>
+
+namespace TasmotaDiscovery {
+
+constexpr int MAX_RESULTS = 32;
+constexpr int NAME_STR_MAX = 32;
+constexpr int IP_STR_MAX = 16;
+constexpr int HOST_STR_MAX = 32;
+
+struct DiscoveredDevice {
+  char ip[IP_STR_MAX];
+  char name[NAME_STR_MAX];       // FriendlyName / DeviceName from Status
+  char hostname[HOST_STR_MAX];   // network hostname from Status 5 (e.g.
+                                 // "office-light-6908"), helpful when
+                                 // DeviceName is the default "Tasmota"
+  const char *source;            // "mdns" or "scan" — caller may want to
+                                 // distinguish; points to a static literal
+};
+
+enum class DiscoveryState : uint8_t {
+  Idle,
+  MdnsQuery,   // running the mDNS lookup
+  PingSweep,   // ICMP-pinging the /24 (interleaved with HTTP probes)
+  Done,
+};
+
+struct DiscoveryProgress {
+  DiscoveryState state;
+  uint32_t id;             // monotonic per-boot
+  uint32_t startedAtMs;
+  uint32_t completedAtMs;
+  uint16_t pingsSent;      // 0..254
+  uint16_t pingsResponded;
+  uint16_t httpProbed;
+  uint16_t tasmotaFound;
+  uint16_t currentHostByte;
+  IPAddress baseIp;
+};
+
+// Kick off a discovery run. Returns false if one is already in flight or
+// WiFi isn't joined.
+bool start();
+
+// Drive the state machine. Called from main loop every iteration.
+void tick();
+
+// Current state — safe to read at any time.
+DiscoveryProgress getProgress();
+
+// Read results. Stable after state == Done; partial results during
+// PingSweep are visible too.
+int resultCount();
+const DiscoveredDevice &getResult(int i);
+
+// One-shot synchronous probe of a known IP. Used by the "test a specific
+// IP" button in the UI when the user wants to verify a manually-entered
+// address looks Tasmota-shaped without running the full discovery. Returns
+// true and populates *out on success.
+bool probeOne(const char *ip, DiscoveredDevice *out);
+
+}  // namespace TasmotaDiscovery

--- a/marquee/TasmotaDiscovery.h
+++ b/marquee/TasmotaDiscovery.h
@@ -88,4 +88,17 @@ const DiscoveredDevice &getResult(int i);
 // true and populates *out on success.
 bool probeOne(const char *ip, DiscoveredDevice *out);
 
+// Persistence — last completed scan is written to LittleFS at
+// /tasmota_discovered.json when the state machine transitions
+// PingSweep → Done. The file format is a JSON object with `scan_id`,
+// `completed_at_unix`, and `results` (array of {ip, name, hostname,
+// source}). This is the source of truth for the planned upload-to-server
+// feature: the server fetches it, persists per-clock, and pushes it back
+// down on a hardware replacement so the user doesn't lose their inventory.
+constexpr const char *DISCOVERED_FILE = "/tasmota_discovered.json";
+
+// Read the persisted scan results (raw JSON). Returns empty string if no
+// scan has been written yet. Caller passes to the SPA as-is.
+String readPersistedResults();
+
 }  // namespace TasmotaDiscovery

--- a/marquee/TasmotaScheduler.cpp
+++ b/marquee/TasmotaScheduler.cpp
@@ -297,6 +297,45 @@ void drainPendingProbe() {
 const ProbeCache &getProbeCache() { return g_probe; }
 
 namespace {
+String g_pendingSetPowerIp;
+String g_pendingSetPowerAction;
+}  // namespace
+
+bool queueSetPower(const char *ip, const char *action) {
+  if (!ip || !*ip || !action || !*action) return false;
+  if (strcasecmp(action, "ON") && strcasecmp(action, "OFF") &&
+      strcasecmp(action, "TOGGLE")) {
+    return false;
+  }
+  if (g_pendingSetPowerIp.length() > 0) return false;
+  g_pendingSetPowerIp = ip;
+  g_pendingSetPowerAction = action;
+  // Show "pending" on the same IP so the SPA's existing /api/tasmota/power
+  // polling reflects the in-flight action.
+  g_probe.ip = g_pendingSetPowerIp;
+  g_probe.pending = true;
+  return true;
+}
+
+void drainPendingSetPower() {
+  if (g_pendingSetPowerIp.length() == 0) return;
+  String ip = g_pendingSetPowerIp;
+  String action = g_pendingSetPowerAction;
+  g_pendingSetPowerIp = String();
+  g_pendingSetPowerAction = String();
+
+  String state = setTasmotaPower(ip.c_str(), action.c_str());
+  g_probe.ip = ip;
+  g_probe.power = state;
+  g_probe.reachable = state.length() > 0;
+  g_probe.pending = false;
+  g_probe.lastUpdatedMs = millis();
+  Serial.printf_P(PSTR("[tasmota] handler-deferred Power %s → %s = %s\n"),
+                  action.c_str(), ip.c_str(),
+                  state.length() ? state.c_str() : "(unreachable)");
+}
+
+namespace {
 uint32_t g_pendingActionScheduleId = 0;  // 0 = none queued
 }  // namespace
 

--- a/marquee/TasmotaScheduler.cpp
+++ b/marquee/TasmotaScheduler.cpp
@@ -1,0 +1,455 @@
+#include "TasmotaScheduler.h"
+
+#include <ArduinoJson.h>
+#include <ESP8266HTTPClient.h>
+#include <ESP8266WiFi.h>
+#include <LittleFS.h>
+#include <TimeLib.h>
+
+namespace TasmotaScheduler {
+
+namespace {
+
+// ── in-memory state ───────────────────────────────────────────────────────
+
+TasmotaDevice g_devices[MAX_DEVICES];
+int g_deviceCount = 0;
+
+Schedule g_schedules[MAX_SCHEDULES];
+int g_scheduleCount = 0;
+uint32_t g_nextScheduleId = 1;
+
+constexpr const char *DEVICES_FILE = "/tasmota_devices.json";
+constexpr const char *SCHEDULES_FILE = "/tasmota_schedules.json";
+
+// ── cron-field parsing ────────────────────────────────────────────────────
+//
+// Each field accepts: '*'  |  N  |  N-M  |  N,M,K (lists)  |  N-M/S (steps)
+//                     |  */S (step from minVal to maxVal)
+// Range checking is done against [minVal, maxVal]; the resulting bitmask
+// has bit N set iff value N is allowed. uint64_t comfortably holds minute
+// (0-59 = 60 bits), so all five fields share the same return type.
+
+bool parseCronField(const char *spec, uint64_t *out, int minVal, int maxVal) {
+  *out = 0;
+  if (!spec || !*spec) return false;
+  String s(spec);
+  s.trim();
+
+  // Split on commas — each piece is a "term".
+  int from = 0;
+  while (from <= (int)s.length()) {
+    int comma = s.indexOf(',', from);
+    String term = (comma < 0) ? s.substring(from) : s.substring(from, comma);
+    term.trim();
+    if (term.length() == 0) return false;
+
+    int rangeStart = minVal;
+    int rangeEnd = maxVal;
+    int step = 1;
+
+    // Split off "/step" suffix if present.
+    int slash = term.indexOf('/');
+    String stepStr;
+    if (slash >= 0) {
+      stepStr = term.substring(slash + 1);
+      term = term.substring(0, slash);
+      stepStr.trim();
+      term.trim();
+      step = stepStr.toInt();
+      if (step <= 0) return false;
+    }
+
+    if (term == "*") {
+      rangeStart = minVal;
+      rangeEnd = maxVal;
+    } else {
+      int dash = term.indexOf('-');
+      if (dash >= 0) {
+        String a = term.substring(0, dash);
+        String b = term.substring(dash + 1);
+        a.trim(); b.trim();
+        if (a.length() == 0 || b.length() == 0) return false;
+        rangeStart = a.toInt();
+        rangeEnd = b.toInt();
+      } else {
+        // Bare number.
+        // String::toInt returns 0 on parse failure — distinguish "0" from
+        // "garbage" by checking digit-ness.
+        for (size_t i = 0; i < term.length(); i++) {
+          if (!isDigit(term[i])) return false;
+        }
+        int n = term.toInt();
+        rangeStart = n;
+        rangeEnd = n;
+      }
+    }
+
+    if (rangeStart < minVal || rangeEnd > maxVal || rangeStart > rangeEnd) {
+      return false;
+    }
+    for (int v = rangeStart; v <= rangeEnd; v += step) {
+      *out |= (uint64_t)1 << v;
+    }
+
+    if (comma < 0) break;
+    from = comma + 1;
+  }
+
+  return true;
+}
+
+}  // namespace
+
+bool parseCron(const char *cronStr, CronMask *out) {
+  out->valid = false;
+  if (!cronStr) return false;
+
+  // Tokenize on whitespace into exactly 5 fields.
+  String s(cronStr);
+  s.trim();
+  String fields[5];
+  int fi = 0;
+  int from = 0;
+  while (from < (int)s.length() && fi < 5) {
+    while (from < (int)s.length() && isSpace(s[from])) from++;
+    int end = from;
+    while (end < (int)s.length() && !isSpace(s[end])) end++;
+    if (end > from) {
+      fields[fi++] = s.substring(from, end);
+    }
+    from = end;
+  }
+  if (fi != 5) return false;
+
+  // Skip any leftover trailing tokens? No — we want exactly 5.
+  while (from < (int)s.length() && isSpace(s[from])) from++;
+  if (from < (int)s.length()) return false;
+
+  uint64_t m = 0, h = 0, dom = 0, mon = 0, dow = 0;
+  if (!parseCronField(fields[0].c_str(), &m, 0, 59)) return false;
+  if (!parseCronField(fields[1].c_str(), &h, 0, 23)) return false;
+  if (!parseCronField(fields[2].c_str(), &dom, 1, 31)) return false;
+  if (!parseCronField(fields[3].c_str(), &mon, 1, 12)) return false;
+  // DoW: accept 0-7; fold "7" → "0" (Sunday) per POSIX cron convention.
+  if (!parseCronField(fields[4].c_str(), &dow, 0, 7)) return false;
+  if (dow & (1ULL << 7)) { dow |= 1ULL; dow &= ~(1ULL << 7); }
+
+  out->minute = m;
+  out->hour = (uint32_t)h;
+  out->dom = (uint32_t)dom;
+  out->month = (uint16_t)mon;
+  out->dow = (uint8_t)(dow & 0x7F);
+  out->valid = true;
+  return true;
+}
+
+bool cronMatches(const CronMask &m, int minute, int hour, int dom, int mon,
+                 int dowSunZero) {
+  if (!m.valid) return false;
+  if (!((m.minute >> minute) & 1ULL)) return false;
+  if (!((m.hour >> hour) & 1U)) return false;
+  if (!((m.dom >> dom) & 1U)) return false;
+  if (!((m.month >> mon) & 1U)) return false;
+  if (!((m.dow >> dowSunZero) & 1U)) return false;
+  return true;
+}
+
+bool runCronSelfTest() {
+  struct Case {
+    const char *cron;
+    bool shouldParse;
+    int min, hour, dom, mon, dow;
+    bool shouldMatch;
+  };
+  // Each row: parse the cron, then check against (min, hour, dom, mon, dow).
+  const Case cases[] = {
+    {"* * * * *",       true,  0, 0, 1, 1, 0, true},
+    {"0 22 * * *",      true,  0, 22, 5, 6, 3, true},   // 10pm any day
+    {"0 22 * * *",      true,  1, 22, 5, 6, 3, false},  // 10:01pm — no
+    {"*/15 * * * *",    true,  15, 9, 1, 1, 0, true},   // every 15 min
+    {"*/15 * * * *",    true,  16, 9, 1, 1, 0, false},
+    {"0 6 * * 1-5",     true,  0, 6, 15, 5, 1, true},   // weekday 6am
+    {"0 6 * * 1-5",     true,  0, 6, 15, 5, 0, false},  // Sunday — no
+    {"0 6 * * 7",       true,  0, 6, 15, 5, 0, true},   // 7 == Sunday
+    {"30 8,12,17 * * *", true, 30, 12, 1, 1, 0, true},
+    {"30 8,12,17 * * *", true, 30, 13, 1, 1, 0, false},
+    // Syntax errors:
+    {"* * * *",         false, 0,0,0,0,0, false},        // 4 fields
+    {"60 * * * *",      false, 0,0,0,0,0, false},        // minute out of range
+    {"* * * 13 *",      false, 0,0,0,0,0, false},        // month out of range
+    {"* * 0 * *",       false, 0,0,0,0,0, false},        // dom must be >= 1
+  };
+  bool allOk = true;
+  for (const auto &c : cases) {
+    CronMask m;
+    bool parsed = parseCron(c.cron, &m);
+    if (parsed != c.shouldParse) {
+      Serial.printf_P(PSTR("[cron-selftest] parse(%s) expected %d got %d\n"),
+                      c.cron, (int)c.shouldParse, (int)parsed);
+      allOk = false;
+      continue;
+    }
+    if (!parsed) continue;  // syntax-error cases don't have a match expectation
+    bool matched = cronMatches(m, c.min, c.hour, c.dom, c.mon, c.dow);
+    if (matched != c.shouldMatch) {
+      Serial.printf_P(PSTR("[cron-selftest] match(%s, m=%d h=%d dom=%d mon=%d dow=%d) "
+                            "expected %d got %d\n"),
+                      c.cron, c.min, c.hour, c.dom, c.mon, c.dow,
+                      (int)c.shouldMatch, (int)matched);
+      allOk = false;
+    }
+  }
+  return allOk;
+}
+
+// ── action ↔ string ───────────────────────────────────────────────────────
+
+static const char *actionToCmd(TasmotaAction a) {
+  switch (a) {
+    case TasmotaAction::On:     return "ON";
+    case TasmotaAction::Off:    return "OFF";
+    case TasmotaAction::Toggle: return "TOGGLE";
+  }
+  return "OFF";
+}
+
+static TasmotaAction actionFromStr(const char *s) {
+  if (!s) return TasmotaAction::Off;
+  if (!strcasecmp(s, "ON")) return TasmotaAction::On;
+  if (!strcasecmp(s, "TOGGLE")) return TasmotaAction::Toggle;
+  return TasmotaAction::Off;
+}
+
+// ── HTTP — talks to Tasmota /cm endpoint ──────────────────────────────────
+
+static String tasmotaCmd(const char *ip, const String &cmnd) {
+  WiFiClient client;
+  HTTPClient http;
+  http.setTimeout(3000);
+  String url = String("http://") + ip + "/cm?cmnd=" + cmnd;
+  if (!http.begin(client, url)) return String();
+  int code = http.GET();
+  String body;
+  if (code == 200) {
+    body = http.getString();
+  }
+  http.end();
+  if (code != 200) {
+    Serial.printf_P(PSTR("[tasmota] %s → HTTP %d\n"), ip, code);
+    return String();
+  }
+  return body;
+}
+
+String setTasmotaPower(const char *ip, const char *action) {
+  String body = tasmotaCmd(ip, String("Power%20") + action);
+  if (body.length() == 0) return String();
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) return String();
+  return doc["POWER"].as<String>();
+}
+
+String readTasmotaPower(const char *ip) {
+  String body = tasmotaCmd(ip, "Power");
+  if (body.length() == 0) return String();
+  JsonDocument doc;
+  if (deserializeJson(doc, body)) return String();
+  return doc["POWER"].as<String>();
+}
+
+// ── persistence ───────────────────────────────────────────────────────────
+
+void loadFromDisk() {
+  // Devices
+  g_deviceCount = 0;
+  {
+    File f = LittleFS.open(DEVICES_FILE, "r");
+    if (f) {
+      JsonDocument doc;
+      if (!deserializeJson(doc, f) && doc.is<JsonArray>()) {
+        for (JsonObject obj : doc.as<JsonArray>()) {
+          if (g_deviceCount >= MAX_DEVICES) break;
+          strlcpy(g_devices[g_deviceCount].ip, obj["ip"] | "", IP_STR_MAX);
+          strlcpy(g_devices[g_deviceCount].name, obj["name"] | "", NAME_STR_MAX);
+          if (g_devices[g_deviceCount].ip[0]) g_deviceCount++;
+        }
+      }
+      f.close();
+    }
+  }
+
+  // Schedules
+  g_scheduleCount = 0;
+  g_nextScheduleId = 1;
+  {
+    File f = LittleFS.open(SCHEDULES_FILE, "r");
+    if (f) {
+      JsonDocument doc;
+      if (!deserializeJson(doc, f) && doc.is<JsonArray>()) {
+        for (JsonObject obj : doc.as<JsonArray>()) {
+          if (g_scheduleCount >= MAX_SCHEDULES) break;
+          Schedule &s = g_schedules[g_scheduleCount];
+          s.id = obj["id"] | 0;
+          strlcpy(s.ip, obj["ip"] | "", IP_STR_MAX);
+          strlcpy(s.cronStr, obj["cron"] | "", CRON_STR_MAX);
+          strlcpy(s.name, obj["name"] | "", NAME_STR_MAX);
+          s.action = actionFromStr(obj["action"] | "OFF");
+          s.enabled = obj["enabled"] | true;
+          s.lastFiredEpoch = 0;
+          parseCron(s.cronStr, &s.mask);  // mark invalid if it fails
+          if (s.id == 0 || !s.ip[0]) continue;
+          if (s.id >= g_nextScheduleId) g_nextScheduleId = s.id + 1;
+          g_scheduleCount++;
+        }
+      }
+      f.close();
+    }
+  }
+}
+
+bool saveToDisk() {
+  // Devices
+  {
+    File f = LittleFS.open(DEVICES_FILE, "w");
+    if (!f) return false;
+    JsonDocument doc;
+    JsonArray arr = doc.to<JsonArray>();
+    for (int i = 0; i < g_deviceCount; i++) {
+      JsonObject o = arr.add<JsonObject>();
+      o["ip"] = g_devices[i].ip;
+      o["name"] = g_devices[i].name;
+    }
+    serializeJson(doc, f);
+    f.close();
+  }
+  // Schedules
+  {
+    File f = LittleFS.open(SCHEDULES_FILE, "w");
+    if (!f) return false;
+    JsonDocument doc;
+    JsonArray arr = doc.to<JsonArray>();
+    for (int i = 0; i < g_scheduleCount; i++) {
+      const Schedule &s = g_schedules[i];
+      JsonObject o = arr.add<JsonObject>();
+      o["id"] = s.id;
+      o["ip"] = s.ip;
+      o["cron"] = s.cronStr;
+      o["action"] = actionToCmd(s.action);
+      o["enabled"] = s.enabled;
+      o["name"] = s.name;
+    }
+    serializeJson(doc, f);
+    f.close();
+  }
+  return true;
+}
+
+// ── tick ──────────────────────────────────────────────────────────────────
+
+void tickMinute(time_t nowLocal) {
+  int m = ::minute(nowLocal);
+  int h = ::hour(nowLocal);
+  int dom = ::day(nowLocal);
+  int mon = ::month(nowLocal);
+  int dow = ::weekday(nowLocal) - 1;  // Time lib: Sun=1..Sat=7; cron wants 0..6
+
+  // De-dup key: epoch minute. If a schedule already fired this minute,
+  // skip — even if the loop ticks twice (clock correction, etc.).
+  uint32_t epochMinute = (uint32_t)(nowLocal / 60);
+
+  for (int i = 0; i < g_scheduleCount; i++) {
+    Schedule &s = g_schedules[i];
+    if (!s.enabled || !s.mask.valid) continue;
+    if (!cronMatches(s.mask, m, h, dom, mon, dow)) continue;
+    if (s.lastFiredEpoch == epochMinute) continue;
+
+    s.lastFiredEpoch = epochMinute;
+    Serial.printf_P(PSTR("[tasmota] firing schedule #%u: %s %s → %s\n"),
+                    (unsigned)s.id, s.ip, s.cronStr, actionToCmd(s.action));
+    String result = setTasmotaPower(s.ip, actionToCmd(s.action));
+    if (result.length() == 0) {
+      Serial.printf_P(PSTR("[tasmota] schedule #%u FAILED\n"), (unsigned)s.id);
+    } else {
+      Serial.printf_P(PSTR("[tasmota] schedule #%u ok, state=%s\n"),
+                      (unsigned)s.id, result.c_str());
+    }
+  }
+}
+
+// ── device CRUD ───────────────────────────────────────────────────────────
+
+int deviceCount() { return g_deviceCount; }
+const TasmotaDevice &getDevice(int i) { return g_devices[i]; }
+
+bool replaceDevices(const TasmotaDevice *devices, int count) {
+  if (count < 0) return false;
+  if (count > MAX_DEVICES) count = MAX_DEVICES;
+  for (int i = 0; i < count; i++) {
+    strlcpy(g_devices[i].ip, devices[i].ip, IP_STR_MAX);
+    strlcpy(g_devices[i].name, devices[i].name, NAME_STR_MAX);
+  }
+  g_deviceCount = count;
+  return saveToDisk();
+}
+
+// ── schedule CRUD ─────────────────────────────────────────────────────────
+
+int scheduleCount() { return g_scheduleCount; }
+const Schedule &getSchedule(int i) { return g_schedules[i]; }
+
+static int findScheduleIndexById(uint32_t id) {
+  for (int i = 0; i < g_scheduleCount; i++) {
+    if (g_schedules[i].id == id) return i;
+  }
+  return -1;
+}
+
+uint32_t createSchedule(const Schedule &s) {
+  if (g_scheduleCount >= MAX_SCHEDULES) return 0;
+  Schedule &dst = g_schedules[g_scheduleCount];
+  dst.id = g_nextScheduleId++;
+  strlcpy(dst.ip, s.ip, IP_STR_MAX);
+  strlcpy(dst.cronStr, s.cronStr, CRON_STR_MAX);
+  strlcpy(dst.name, s.name, NAME_STR_MAX);
+  dst.action = s.action;
+  dst.enabled = s.enabled;
+  dst.lastFiredEpoch = 0;
+  if (!parseCron(dst.cronStr, &dst.mask)) return 0;
+  g_scheduleCount++;
+  if (!saveToDisk()) return 0;
+  return dst.id;
+}
+
+bool updateSchedule(uint32_t id, const Schedule &s) {
+  int idx = findScheduleIndexById(id);
+  if (idx < 0) return false;
+  Schedule &dst = g_schedules[idx];
+  strlcpy(dst.ip, s.ip, IP_STR_MAX);
+  strlcpy(dst.cronStr, s.cronStr, CRON_STR_MAX);
+  strlcpy(dst.name, s.name, NAME_STR_MAX);
+  dst.action = s.action;
+  dst.enabled = s.enabled;
+  if (!parseCron(dst.cronStr, &dst.mask)) return false;
+  return saveToDisk();
+}
+
+bool deleteSchedule(uint32_t id) {
+  int idx = findScheduleIndexById(id);
+  if (idx < 0) return false;
+  for (int i = idx; i < g_scheduleCount - 1; i++) {
+    g_schedules[i] = g_schedules[i + 1];
+  }
+  g_scheduleCount--;
+  return saveToDisk();
+}
+
+int runScheduleNow(uint32_t id) {
+  int idx = findScheduleIndexById(id);
+  if (idx < 0) return -1;
+  const Schedule &s = g_schedules[idx];
+  String result = setTasmotaPower(s.ip, actionToCmd(s.action));
+  return result.length() > 0 ? 200 : -1;
+}
+
+}  // namespace TasmotaScheduler

--- a/marquee/TasmotaScheduler.cpp
+++ b/marquee/TasmotaScheduler.cpp
@@ -258,6 +258,72 @@ String readTasmotaPower(const char *ip) {
   return doc["POWER"].as<String>();
 }
 
+// ── deferred probe ────────────────────────────────────────────────────────
+
+namespace {
+ProbeCache g_probe = { String(), String(), false, false, 0 };
+String g_pendingIp;
+bool g_pending = false;
+}  // namespace
+
+bool queueProbe(const char *ip) {
+  if (g_pending) {
+    // Already a different request in flight — refuse to clobber.
+    if (g_pendingIp != ip) return false;
+    return true;  // same IP, idempotent
+  }
+  g_pendingIp = ip;
+  g_pending = true;
+  g_probe.pending = true;
+  return true;
+}
+
+void drainPendingProbe() {
+  if (!g_pending) return;
+  // Snapshot the IP and clear the pending flag BEFORE the (~1s) HTTP call.
+  // If the call crashes / watchdogs anyway we don't want to come back and
+  // immediately retry the same probe on next boot.
+  String ip = g_pendingIp;
+  g_pending = false;
+
+  String state = readTasmotaPower(ip.c_str());
+  g_probe.ip = ip;
+  g_probe.power = state;
+  g_probe.reachable = state.length() > 0;
+  g_probe.pending = false;
+  g_probe.lastUpdatedMs = millis();
+}
+
+const ProbeCache &getProbeCache() { return g_probe; }
+
+namespace {
+uint32_t g_pendingActionScheduleId = 0;  // 0 = none queued
+}  // namespace
+
+bool queueRunSchedule(uint32_t id) {
+  if (g_pendingActionScheduleId != 0) return false;  // one in flight at a time
+  // Walk schedules inline rather than use the anonymous-namespace helper,
+  // which isn't reachable from this translation-unit-public function.
+  bool found = false;
+  for (int i = 0; i < g_scheduleCount; i++) {
+    if (g_schedules[i].id == id) { found = true; break; }
+  }
+  if (!found) return false;
+  g_pendingActionScheduleId = id;
+  return true;
+}
+
+void drainPendingAction() {
+  if (g_pendingActionScheduleId == 0) return;
+  uint32_t id = g_pendingActionScheduleId;
+  g_pendingActionScheduleId = 0;  // clear before HTTP so a crash doesn't loop
+  Serial.printf_P(PSTR("[tasmota] handler-deferred run for schedule #%u\n"),
+                  (unsigned)id);
+  runScheduleNow(id);  // result feeds into the schedule's own state +
+                       // serial log; the SPA can poll Power separately to
+                       // confirm the action took effect
+}
+
 // ── persistence ───────────────────────────────────────────────────────────
 
 void loadFromDisk() {

--- a/marquee/TasmotaScheduler.h
+++ b/marquee/TasmotaScheduler.h
@@ -65,8 +65,12 @@ bool runCronSelfTest();
 
 // ── schedule model ────────────────────────────────────────────────────────
 
-constexpr int MAX_DEVICES = 16;
-constexpr int MAX_SCHEDULES = 32;
+// Bound RAM aggressively: each entry is ~150 bytes for a schedule (with
+// CronMask + char buffers) and ~50 bytes for a device. Combined with the
+// discovery results array (TasmotaDiscovery::MAX_RESULTS) we want to stay
+// well under 5 KB total static — heap headroom is the squeeze point.
+constexpr int MAX_DEVICES = 8;
+constexpr int MAX_SCHEDULES = 8;
 constexpr int CRON_STR_MAX = 64;
 constexpr int IP_STR_MAX = 16;
 constexpr int NAME_STR_MAX = 32;
@@ -137,18 +141,57 @@ bool deleteSchedule(uint32_t id);
 
 // Fire a schedule's action immediately (for the SPA's "Test" button).
 // Returns the HTTP status code from the Tasmota, or -1 on transport error.
+// **Internal: blocks on HTTP. Safe from main loop only.** Handler context
+// should call queueRunSchedule() + drainPendingAction() instead.
 int runScheduleNow(uint32_t id);
 
+// Handler-safe variant: queues an immediate-fire request for `id`. Result
+// (last-action-result) lives in the same ProbeCache once the main loop
+// drainPendingAction() picks it up.
+bool queueRunSchedule(uint32_t id);
+void drainPendingAction();
+
 // ── direct HTTP probe (no schedule lookup) ────────────────────────────────
+//
+// These both block the caller for the full HTTP round-trip (~1s typical).
+// They are safe to call from the main loop (tickMinute, the deferred probe
+// drain — see below), but **NOT** from inside an AsyncWebServer handler,
+// where blocking causes watchdog resets / heap exhaustion. Use the
+// queueProbe / drainPendingProbe pair below for handler-context calls.
 
 // Issue a Power command to a Tasmota device. `action` accepts "ON", "OFF",
 // "TOGGLE". Returns the parsed POWER state from the response ("ON" / "OFF")
-// on success, empty string on failure. Used by both the schedule executor
-// and the SPA's "device state probe" button.
+// on success, empty string on failure.
 String setTasmotaPower(const char *ip, const char *action);
 
 // Read the current POWER state of a Tasmota at the given IP. Returns
 // "ON" / "OFF" on success, empty on failure. Wraps GET /cm?cmnd=Power.
 String readTasmotaPower(const char *ip);
+
+// ── deferred power-state probe (for HTTP handlers) ────────────────────────
+//
+// The /api/tasmota/power handler queues a probe via queueProbe(); the main
+// loop calls drainPendingProbe() each iteration to actually execute it.
+// The result is cached in lastProbe* and read back by the handler on a
+// subsequent poll. Polling cadence on the SPA side is typically 1-2s, so
+// the handler-context call returns "pending" once and the result on the
+// next poll. Same pattern the firmware uses for OTA-from-URL (see
+// pendingOtaUrl / otaFromUrlRequested in marquee.ino).
+//
+// Returns false if a different IP is currently pending (one in-flight at a
+// time keeps the loop blocking-budget bounded).
+bool queueProbe(const char *ip);
+void drainPendingProbe();  // call from main loop
+
+// Read the most recent probe result. ip will be empty until queueProbe()
+// has been called at least once and drained.
+struct ProbeCache {
+  String ip;
+  String power;        // "ON" | "OFF" | "" if unreachable
+  bool reachable;
+  bool pending;
+  uint32_t lastUpdatedMs;
+};
+const ProbeCache &getProbeCache();
 
 }  // namespace TasmotaScheduler

--- a/marquee/TasmotaScheduler.h
+++ b/marquee/TasmotaScheduler.h
@@ -183,6 +183,17 @@ String readTasmotaPower(const char *ip);
 bool queueProbe(const char *ip);
 void drainPendingProbe();  // call from main loop
 
+// Handler-safe variant of setTasmotaPower(). Queues an ON/OFF/TOGGLE for the
+// given IP; the main loop's drainPendingSetPower() does the blocking HTTP
+// call and writes the resulting POWER state back into the same ProbeCache
+// the GET /api/tasmota/power endpoint reads. Action is one of "ON" / "OFF"
+// / "TOGGLE" (case-insensitive). Used by the SPA's per-device control
+// buttons so the user can identify which physical switch each entry is.
+// Returns false if another power action is already queued, or the action
+// string is not one of the three accepted values.
+bool queueSetPower(const char *ip, const char *action);
+void drainPendingSetPower();  // call from main loop
+
 // Read the most recent probe result. ip will be empty until queueProbe()
 // has been called at least once and drained.
 struct ProbeCache {

--- a/marquee/TasmotaScheduler.h
+++ b/marquee/TasmotaScheduler.h
@@ -1,0 +1,154 @@
+// TasmotaScheduler — cron-driven Tasmota switch control.
+//
+// Schedules cron-style rules that fire HTTP commands at Tasmota switches
+// on the LAN. Two pieces of persisted state:
+//
+//   /tasmota_devices.json    Array of registered devices the clock controls:
+//                              [{ "ip": "192.168.1.42", "name": "Office" }]
+//                            Driven by the SPA's "devices to control" list
+//                            (the user-facing "config option that's an array
+//                            of IPs"). Schedules reference a device by IP.
+//
+//   /tasmota_schedules.json  Array of schedules:
+//                              [{ "id":1, "ip":"192.168.1.42",
+//                                 "cron":"0 22 * * *", "action":"OFF",
+//                                 "enabled":true, "name":"bedtime" }]
+//                            ID is a monotonic per-clock counter that lets
+//                            the SPA update / delete a specific entry.
+//
+// Cron syntax: standard 5-field `min hour dom mon dow`. Each field supports
+// `*`, `n`, `n,m,k`, `n-m`, `*/s`, and `n-m/s`. Day-of-week: 0-7 with both 0
+// and 7 meaning Sunday (POSIX). Compatible with crontab-style strings.
+//
+// Tasmota HTTP API: GET /cm?cmnd=Power%20<action>. No auth on default-config
+// Tasmotas; optional `&user=X&password=Y` if locked. We pass user/pass
+// per-device when set, blank otherwise.
+//
+// Auth on the clock side: the new endpoints use the trusted-LAN model
+// (no auth) — same as the rest of /api/*. Future header-based gating would
+// share the same hook as the LAN-visibility feature.
+
+#pragma once
+
+#include <Arduino.h>
+#include <stdint.h>
+
+namespace TasmotaScheduler {
+
+// ── cron mask: pre-parsed bitsets, one per cron field ─────────────────────
+//
+// Matching a (min, hour, dom, mon, dow) tuple is a constant-time set of
+// bit-tests against these masks. Parse once at config load; match every
+// minute against `now()`.
+
+struct CronMask {
+  uint64_t minute;  // bits 0-59
+  uint32_t hour;    // bits 0-23
+  uint32_t dom;     // bits 1-31  (bit 0 unused)
+  uint16_t month;   // bits 1-12  (bit 0 unused)
+  uint8_t dow;      // bits 0-6   (Sun=0; "7" in input gets folded to 0)
+  bool valid;       // false if parseCron failed
+};
+
+// Parse a 5-field cron string into a CronMask. Returns false on syntax
+// error; *out.valid is also set so callers can stash CronMask in a struct
+// and check the flag without keeping the return value.
+bool parseCron(const char *cronStr, CronMask *out);
+
+// Does the mask match the given local-time fields?
+bool cronMatches(const CronMask &m, int minute, int hour,
+                 int domOneIndexed, int monthOneIndexed, int dowSunZero);
+
+// Self-test helper, exposed for unit testing. Returns true iff every test
+// case passes; on failure, prints which one to Serial. Cheap to call.
+bool runCronSelfTest();
+
+// ── schedule model ────────────────────────────────────────────────────────
+
+constexpr int MAX_DEVICES = 16;
+constexpr int MAX_SCHEDULES = 32;
+constexpr int CRON_STR_MAX = 64;
+constexpr int IP_STR_MAX = 16;
+constexpr int NAME_STR_MAX = 32;
+
+enum class TasmotaAction : uint8_t {
+  Off,
+  On,
+  Toggle,
+};
+
+struct TasmotaDevice {
+  char ip[IP_STR_MAX];
+  char name[NAME_STR_MAX];
+};
+
+struct Schedule {
+  uint32_t id;            // monotonic, assigned at create time
+  char ip[IP_STR_MAX];    // target device (free-form; doesn't have to match
+                          // a registered device, but the UI nudges it)
+  char cronStr[CRON_STR_MAX];
+  CronMask mask;          // pre-parsed; rebuilt on every load/save
+  TasmotaAction action;
+  bool enabled;
+  char name[NAME_STR_MAX];
+  uint32_t lastFiredEpoch;  // unix timestamp of last fire; prevents
+                            // re-firing within the same minute if the loop
+                            // ticks twice or the clock corrects forward
+};
+
+// ── lifecycle ─────────────────────────────────────────────────────────────
+
+// Load both files from LittleFS into RAM caches and parse all crons.
+// Call once at boot from setup().
+void loadFromDisk();
+
+// Save both caches back to LittleFS. Used after any mutation.
+bool saveToDisk();
+
+// Called once per minute from the main loop (processEveryMinute). Walks
+// the enabled schedules and fires HTTP for each that matches the current
+// local time + hasn't already fired this minute.
+void tickMinute(time_t nowLocal);
+
+// ── device CRUD ───────────────────────────────────────────────────────────
+
+int deviceCount();
+const TasmotaDevice &getDevice(int i);
+// Replace the whole device list at once — simpler for the SPA than the
+// add/remove/update dance and there's at most MAX_DEVICES entries.
+// Caller passes count and array; count above MAX_DEVICES is clipped.
+bool replaceDevices(const TasmotaDevice *devices, int count);
+
+// ── schedule CRUD ─────────────────────────────────────────────────────────
+
+int scheduleCount();
+const Schedule &getSchedule(int i);
+
+// Create a new schedule. `id` is assigned; the input id field is ignored.
+// Returns the new id (0 on failure — e.g., MAX_SCHEDULES hit or bad cron).
+uint32_t createSchedule(const Schedule &s);
+
+// Update an existing schedule by ID. Returns false if not found or cron
+// parse fails.
+bool updateSchedule(uint32_t id, const Schedule &s);
+
+// Delete by ID. Returns false if not found.
+bool deleteSchedule(uint32_t id);
+
+// Fire a schedule's action immediately (for the SPA's "Test" button).
+// Returns the HTTP status code from the Tasmota, or -1 on transport error.
+int runScheduleNow(uint32_t id);
+
+// ── direct HTTP probe (no schedule lookup) ────────────────────────────────
+
+// Issue a Power command to a Tasmota device. `action` accepts "ON", "OFF",
+// "TOGGLE". Returns the parsed POWER state from the response ("ON" / "OFF")
+// on success, empty string on failure. Used by both the schedule executor
+// and the SPA's "device state probe" button.
+String setTasmotaPower(const char *ip, const char *action);
+
+// Read the current POWER state of a Tasmota at the given IP. Returns
+// "ON" / "OFF" on success, empty on failure. Wraps GET /cm?cmnd=Power.
+String readTasmotaPower(const char *ip);
+
+}  // namespace TasmotaScheduler

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -226,6 +226,14 @@ void WagFamBdayClient::value(String value) {
       currentConfig.configUpdatePayload = value;
     } else if (currentKey == "configUpdateSignature") {
       currentConfig.configUpdateSignature = value;
+    } else if (currentKey == "runTasmotaDiscovery") {
+      // Tasmota auto-discovery trigger. Accept the common truthy spellings
+      // ("1", "true") since the static JSON can come from any tooling. The
+      // flag is pulse-shape — applied once per calendar refresh, then
+      // cleared by the next refresh's parse (this struct is re-zeroed at
+      // the start of each fetch).
+      currentConfig.runTasmotaDiscovery =
+        (value == "1" || value.equalsIgnoreCase("true"));
     }
   } else if (currentKey == "message") {
     if (messageCounter >= 10) {

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -86,6 +86,14 @@ class WagFamBdayClient: public JsonListener {
       int configUpdateVersion;
       String configUpdatePayload;
       String configUpdateSignature;
+      // Tasmota auto-discovery trigger. When the server sets this to true,
+      // the clock kicks off one TasmotaDiscovery scan after the calendar
+      // refresh completes and writes the results to
+      // /tasmota_discovered.json. Pulse-shape: the server reverting the
+      // flag stops *future* scans but doesn't undo a stored result. The
+      // server can use this to backfill stored discovery state on a
+      // replacement clock (see TasmotaDiscovery roadmap notes).
+      boolean runTasmotaDiscovery;
     } configValues;
 
     WagFamBdayClient(String ApiKey, String JsonDataSourceUrl);

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -36,6 +36,7 @@
 #include <Fonts/Org_01.h>
 #include "WagfamFont.h"
 #include "ClockStyles.h"
+#include "TasmotaScheduler.h"
 #include <bearssl/bearssl_hash.h>  // br_sha256_* for OTA SHA256 verification (issue #96)
 
 // Scroller font registry (issue #106). Index 0 is the Adafruit_GFX builtin
@@ -145,6 +146,15 @@ void handleApiFsDelete(AsyncWebServerRequest *request);
 void handleApiFsList(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
 static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
+// Tasmota scheduler
+void handleApiTasmotaDevicesGet(AsyncWebServerRequest *request);
+void handleApiTasmotaDevicesPut(AsyncWebServerRequest *request, JsonVariant &json);
+void handleApiTasmotaSchedulesGet(AsyncWebServerRequest *request);
+void handleApiTasmotaSchedulesPost(AsyncWebServerRequest *request, JsonVariant &json);
+void handleApiTasmotaSchedulePut(AsyncWebServerRequest *request, JsonVariant &json);
+void handleApiTasmotaScheduleDelete(AsyncWebServerRequest *request);
+void handleApiTasmotaScheduleRun(AsyncWebServerRequest *request);
+void handleApiTasmotaPower(AsyncWebServerRequest *request);
 
 // LED Settings
 int spacer = 1;  // dots between letters
@@ -345,6 +355,15 @@ void setup() {
 
   readPersistentConfig();
 
+  // Tasmota scheduler — pull devices + schedules + parsed cron masks into
+  // RAM from LittleFS. Idempotent; missing files are fine.
+  TasmotaScheduler::loadFromDisk();
+  if (!TasmotaScheduler::runCronSelfTest()) {
+    Serial.println(F("[tasmota] WARNING: cron self-test failed — see lines above"));
+  } else {
+    Serial.println(F("[tasmota] cron self-test ok"));
+  }
+
   {
     File vf = LittleFS.open("/spa/version.json", "r");
     if (vf) {
@@ -446,6 +465,14 @@ void setup() {
   server.on("/api/fs/read", HTTP_GET, handleApiFsRead);
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
+  // Tasmota scheduler — devices list, schedules CRUD, immediate-run + power
+  // state probe. AsyncCallbackJsonWebHandler wires the JSON-body POSTs and
+  // PUTs further below.
+  server.on("/api/tasmota/devices", HTTP_GET, handleApiTasmotaDevicesGet);
+  server.on("/api/tasmota/schedules", HTTP_GET, handleApiTasmotaSchedulesGet);
+  server.on("/api/tasmota/schedules", HTTP_DELETE, handleApiTasmotaScheduleDelete);  // ?id=N
+  server.on("/api/tasmota/schedule/run", HTTP_POST, handleApiTasmotaScheduleRun);    // ?id=N
+  server.on("/api/tasmota/power", HTTP_GET, handleApiTasmotaPower);                  // ?ip=X
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -484,6 +511,26 @@ void setup() {
     spaUpdatePost->setMethod(HTTP_POST);
     spaUpdatePost->setMaxContentLength(512);
     server.addHandler(spaUpdatePost);
+  }
+  // Tasmota JSON-body endpoints. 2KB max each — the schedule object is ~200
+  // bytes, devices list of 16 is ~600 bytes, so 2KB has comfortable headroom.
+  {
+    auto *devicesPut = new AsyncCallbackJsonWebHandler("/api/tasmota/devices", handleApiTasmotaDevicesPut);
+    devicesPut->setMethod(HTTP_PUT);
+    devicesPut->setMaxContentLength(2048);
+    server.addHandler(devicesPut);
+  }
+  {
+    auto *schedulesPost = new AsyncCallbackJsonWebHandler("/api/tasmota/schedules", handleApiTasmotaSchedulesPost);
+    schedulesPost->setMethod(HTTP_POST);
+    schedulesPost->setMaxContentLength(2048);
+    server.addHandler(schedulesPost);
+  }
+  {
+    auto *schedulePut = new AsyncCallbackJsonWebHandler("/api/tasmota/schedules", handleApiTasmotaSchedulePut);
+    schedulePut->setMethod(HTTP_PUT);
+    schedulePut->setMaxContentLength(2048);
+    server.addHandler(schedulePut);
   }
 
   // GET /update — file-upload form. Self-contained page (no SPA chrome,
@@ -808,6 +855,12 @@ void processEverySecond() {
 }
 
 void processEveryMinute() {
+  // Tasmota scheduler tick. Runs first so a scheduled action fires at the
+  // top of its target minute regardless of how long the marquee scroll
+  // below takes. Cheap when no schedules are active (just a few bitset
+  // tests against the current minute).
+  TasmotaScheduler::tickMinute(now());
+
   // Issue #99: troll-message override — bypass everything else (weather error,
   // birthday rotation, weather/calendar mix) and scroll only the troll. This
   // intentionally fires every cycle, with no displayRefreshCount gating, so
@@ -2323,6 +2376,166 @@ void handleApiFsList(AsyncWebServerRequest *request) {
 
   listFilesRecursive("/", files);
 
+  sendJsonResponse(request, 200, doc);
+}
+
+// ── Tasmota scheduler API ───────────────────────────────────────────────────
+
+static const char *actionToCmdLocal(TasmotaScheduler::TasmotaAction a) {
+  using TasmotaScheduler::TasmotaAction;
+  switch (a) {
+    case TasmotaAction::On:     return "ON";
+    case TasmotaAction::Off:    return "OFF";
+    case TasmotaAction::Toggle: return "TOGGLE";
+  }
+  return "OFF";
+}
+
+static TasmotaScheduler::TasmotaAction parseActionLocal(const char *s) {
+  using TasmotaScheduler::TasmotaAction;
+  if (!s) return TasmotaAction::Off;
+  if (!strcasecmp(s, "ON")) return TasmotaAction::On;
+  if (!strcasecmp(s, "TOGGLE")) return TasmotaAction::Toggle;
+  return TasmotaAction::Off;
+}
+
+void handleApiTasmotaDevicesGet(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  JsonArray arr = doc["devices"].to<JsonArray>();
+  for (int i = 0; i < TasmotaScheduler::deviceCount(); i++) {
+    const auto &d = TasmotaScheduler::getDevice(i);
+    JsonObject o = arr.add<JsonObject>();
+    o["ip"] = d.ip;
+    o["name"] = d.name;
+  }
+  doc["max"] = TasmotaScheduler::MAX_DEVICES;
+  sendJsonResponse(request, 200, doc);
+}
+
+void handleApiTasmotaDevicesPut(AsyncWebServerRequest *request, JsonVariant &json) {
+  if (!json.is<JsonArray>()) {
+    return sendJsonError(request, 400, "body must be a JSON array of {ip, name}");
+  }
+  JsonArray arr = json.as<JsonArray>();
+  TasmotaScheduler::TasmotaDevice buf[TasmotaScheduler::MAX_DEVICES];
+  int n = 0;
+  for (JsonObject o : arr) {
+    if (n >= TasmotaScheduler::MAX_DEVICES) break;
+    const char *ip = o["ip"] | "";
+    if (!ip || !*ip) continue;
+    strlcpy(buf[n].ip, ip, TasmotaScheduler::IP_STR_MAX);
+    strlcpy(buf[n].name, o["name"] | "", TasmotaScheduler::NAME_STR_MAX);
+    n++;
+  }
+  if (!TasmotaScheduler::replaceDevices(buf, n)) {
+    return sendJsonError(request, 500, "couldn't persist devices");
+  }
+  return handleApiTasmotaDevicesGet(request);
+}
+
+static void scheduleToJson(const TasmotaScheduler::Schedule &s, JsonObject o) {
+  o["id"] = s.id;
+  o["ip"] = s.ip;
+  o["cron"] = s.cronStr;
+  o["action"] = actionToCmdLocal(s.action);
+  o["enabled"] = s.enabled;
+  o["name"] = s.name;
+  o["cron_valid"] = s.mask.valid;
+}
+
+void handleApiTasmotaSchedulesGet(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  JsonArray arr = doc["schedules"].to<JsonArray>();
+  for (int i = 0; i < TasmotaScheduler::scheduleCount(); i++) {
+    JsonObject o = arr.add<JsonObject>();
+    scheduleToJson(TasmotaScheduler::getSchedule(i), o);
+  }
+  doc["max"] = TasmotaScheduler::MAX_SCHEDULES;
+  sendJsonResponse(request, 200, doc);
+}
+
+static bool jsonToSchedule(JsonObject body, TasmotaScheduler::Schedule *out) {
+  using namespace TasmotaScheduler;
+  const char *ip = body["ip"] | "";
+  const char *cron = body["cron"] | "";
+  if (!ip || !*ip) return false;
+  if (!cron || !*cron) return false;
+  strlcpy(out->ip, ip, IP_STR_MAX);
+  strlcpy(out->cronStr, cron, CRON_STR_MAX);
+  strlcpy(out->name, body["name"] | "", NAME_STR_MAX);
+  out->action = parseActionLocal(body["action"] | "OFF");
+  out->enabled = body["enabled"] | true;
+  return true;
+}
+
+void handleApiTasmotaSchedulesPost(AsyncWebServerRequest *request, JsonVariant &json) {
+  if (!json.is<JsonObject>()) {
+    return sendJsonError(request, 400, "body must be a JSON object");
+  }
+  TasmotaScheduler::Schedule s = {};
+  if (!jsonToSchedule(json.as<JsonObject>(), &s)) {
+    return sendJsonError(request, 400, "schedule needs at least ip + cron");
+  }
+  uint32_t id = TasmotaScheduler::createSchedule(s);
+  if (id == 0) {
+    return sendJsonError(request, 400, "couldn't create schedule (bad cron, or limit reached)");
+  }
+  JsonDocument doc;
+  doc["id"] = id;
+  sendJsonResponse(request, 201, doc);
+}
+
+void handleApiTasmotaSchedulePut(AsyncWebServerRequest *request, JsonVariant &json) {
+  if (!request->hasParam("id")) {
+    return sendJsonError(request, 400, "missing ?id=N");
+  }
+  uint32_t id = (uint32_t)request->getParam("id")->value().toInt();
+  if (!json.is<JsonObject>()) {
+    return sendJsonError(request, 400, "body must be a JSON object");
+  }
+  TasmotaScheduler::Schedule s = {};
+  if (!jsonToSchedule(json.as<JsonObject>(), &s)) {
+    return sendJsonError(request, 400, "schedule needs at least ip + cron");
+  }
+  if (!TasmotaScheduler::updateSchedule(id, s)) {
+    return sendJsonError(request, 404, "schedule not found or cron invalid");
+  }
+  sendJsonOk(request, "updated");
+}
+
+void handleApiTasmotaScheduleDelete(AsyncWebServerRequest *request) {
+  if (!request->hasParam("id")) {
+    return sendJsonError(request, 400, "missing ?id=N");
+  }
+  uint32_t id = (uint32_t)request->getParam("id")->value().toInt();
+  if (!TasmotaScheduler::deleteSchedule(id)) {
+    return sendJsonError(request, 404, "schedule not found");
+  }
+  sendJsonOk(request, "deleted");
+}
+
+void handleApiTasmotaScheduleRun(AsyncWebServerRequest *request) {
+  if (!request->hasParam("id")) {
+    return sendJsonError(request, 400, "missing ?id=N");
+  }
+  uint32_t id = (uint32_t)request->getParam("id")->value().toInt();
+  int rc = TasmotaScheduler::runScheduleNow(id);
+  if (rc < 0) {
+    return sendJsonError(request, 502, "schedule not found or Tasmota unreachable");
+  }
+  sendJsonOk(request, "fired");
+}
+
+void handleApiTasmotaPower(AsyncWebServerRequest *request) {
+  if (!request->hasParam("ip")) {
+    return sendJsonError(request, 400, "missing ?ip=X");
+  }
+  String ip = request->getParam("ip")->value();
+  String state = TasmotaScheduler::readTasmotaPower(ip.c_str());
+  JsonDocument doc;
+  doc["ip"] = ip;
+  doc["power"] = state;
+  doc["reachable"] = state.length() > 0;
   sendJsonResponse(request, 200, doc);
 }
 

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -777,6 +777,15 @@ void loop() {
   // one ICMP ping (or one deferred HTTP probe) per call when running.
   TasmotaDiscovery::tick();
 
+  // Drain a deferred Tasmota power-state probe queued by the
+  // /api/tasmota/power handler. The actual HTTP call (~1s blocking) happens
+  // here on the main task — safe because the loop already tolerates ~1s of
+  // blocking work (display scroll, calendar fetch, etc.) but unsafe to do
+  // from an AsyncWebServer handler context.
+  TasmotaScheduler::drainPendingProbe();
+  // Same defer pattern for "Test now" schedule fires from /api/tasmota/schedule/run.
+  TasmotaScheduler::drainPendingAction();
+
   if (lastSecond != second()) {
     lastSecond = second();
     displayTime = hourMinutes(false); // rebuild once per second, not every frame
@@ -2545,28 +2554,54 @@ void handleApiTasmotaScheduleDelete(AsyncWebServerRequest *request) {
   sendJsonOk(request, "deleted");
 }
 
+// Handler-context "Test now" — queue an immediate fire of the schedule and
+// return 202. Main loop's drainPendingAction() does the HTTP call. SPA
+// confirms the action took effect by polling /api/tasmota/power for the
+// target IP afterward.
 void handleApiTasmotaScheduleRun(AsyncWebServerRequest *request) {
   if (!request->hasParam("id")) {
     return sendJsonError(request, 400, "missing ?id=N");
   }
   uint32_t id = (uint32_t)request->getParam("id")->value().toInt();
-  int rc = TasmotaScheduler::runScheduleNow(id);
-  if (rc < 0) {
-    return sendJsonError(request, 502, "schedule not found or Tasmota unreachable");
+  if (!TasmotaScheduler::queueRunSchedule(id)) {
+    return sendJsonError(request, 409, "schedule not found, or another fire is in flight");
   }
-  sendJsonOk(request, "fired");
+  JsonDocument doc;
+  doc["status"] = "queued";
+  doc["schedule_id"] = id;
+  sendJsonResponse(request, 202, doc);
 }
 
+// /api/tasmota/power?ip=X — request the live power state. The handler
+// queues a deferred probe and returns the cached state immediately
+// (could be stale or empty on the very first call). The main loop's
+// drainPendingProbe() does the actual HTTP round-trip on the next tick
+// and the result is visible to subsequent GET calls. SPA polls this
+// every 1-2 s, so the user sees the updated state shortly after their
+// click. This deferral pattern is required: doing the HTTP call directly
+// in the handler causes watchdog/exception resets when heap is tight
+// (see feedback_async_handlers_must_not_block; also OTA-from-URL).
 void handleApiTasmotaPower(AsyncWebServerRequest *request) {
   if (!request->hasParam("ip")) {
     return sendJsonError(request, 400, "missing ?ip=X");
   }
   String ip = request->getParam("ip")->value();
-  String state = TasmotaScheduler::readTasmotaPower(ip.c_str());
+  bool queued = TasmotaScheduler::queueProbe(ip.c_str());
+  const auto &cache = TasmotaScheduler::getProbeCache();
   JsonDocument doc;
   doc["ip"] = ip;
-  doc["power"] = state;
-  doc["reachable"] = state.length() > 0;
+  doc["queued"] = queued;
+  // Surface the most recent cached result if it's for the same IP, else
+  // mark "no data yet" so the SPA knows to keep polling.
+  if (cache.ip == ip && cache.lastUpdatedMs > 0) {
+    doc["power"] = cache.power;
+    doc["reachable"] = cache.reachable;
+    doc["last_updated_ms_ago"] = (uint32_t)(millis() - cache.lastUpdatedMs);
+  } else {
+    doc["power"] = "";
+    doc["reachable"] = false;
+  }
+  doc["pending"] = cache.pending || queued;
   sendJsonResponse(request, 200, doc);
 }
 

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -159,6 +159,7 @@ void handleApiTasmotaPower(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverStart(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverState(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request);
+void handleApiTasmotaDiscoveredGet(AsyncWebServerRequest *request);
 
 // LED Settings
 int spacer = 1;  // dots between letters
@@ -480,6 +481,10 @@ void setup() {
   server.on("/api/tasmota/discover", HTTP_POST, handleApiTasmotaDiscoverStart);
   server.on("/api/tasmota/discover/state", HTTP_GET, handleApiTasmotaDiscoverState);
   server.on("/api/tasmota/discover/probe", HTTP_GET, handleApiTasmotaDiscoverProbe);  // ?ip=X
+  // /api/tasmota/discovered returns the LAST persisted scan (from /tasmota_discovered.json).
+  // Designed for a future server-side fetcher that snapshots this per-clock
+  // so a replacement clock can have its inventory restored.
+  server.on("/api/tasmota/discovered", HTTP_GET, handleApiTasmotaDiscoveredGet);
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -820,6 +825,21 @@ void processEverySecond() {
       || lastRefreshDataTimestamp == 0) {
     weatherRefreshRequested = false;
     getWeatherData();
+
+    // Server-flag-driven Tasmota discovery. When the calendar response
+    // sets `runTasmotaDiscovery: true`, kick a scan; results land in
+    // /tasmota_discovered.json when the scan completes (handled by
+    // TasmotaDiscovery's main-loop tick). The flag is pulse-shape — the
+    // server sets it when it wants a fresh inventory (e.g. after the user
+    // claims a replacement clock and the server needs to compare what the
+    // new hardware sees against the upload from the old one).
+    if (serverConfig.runTasmotaDiscovery) {
+      if (TasmotaDiscovery::start()) {
+        Serial.println(F("[discover] server-requested scan kicked off"));
+      } else {
+        Serial.println(F("[discover] server-requested scan skipped — already running"));
+      }
+    }
   }
 
   // Honor a deferred restart. The deadline gives the async TCP layer time to
@@ -2616,6 +2636,24 @@ void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request) {
     doc["hostname"] = d.hostname;
   }
   sendJsonResponse(request, 200, doc);
+}
+
+// Returns the raw /tasmota_discovered.json file. Empty body if no scan has
+// ever completed. Designed for a future server-side cron that snapshots
+// every clock's known-Tasmota inventory — keeps user-visible state durable
+// even when the clock's LittleFS gets wiped (replacement hardware, fresh
+// flash, FS corruption). The server can later push this inventory back
+// down via a new config-block field on the calendar response.
+void handleApiTasmotaDiscoveredGet(AsyncWebServerRequest *request) {
+  AsyncResponseStream *resp = request->beginResponseStream(F("application/json"));
+  setCorsHeaders(request, resp);
+  String body = TasmotaDiscovery::readPersistedResults();
+  if (body.length() == 0) {
+    resp->print("{\"results\":[],\"scan_id\":0}");
+  } else {
+    resp->print(body);
+  }
+  request->send(resp);
 }
 
 // ── End REST API ────────────────────────────────────────────────────────────

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -71,7 +71,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.4.2-wagfam"
+#define BASE_VERSION "4.5.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -156,6 +156,7 @@ void handleApiTasmotaSchedulePut(AsyncWebServerRequest *request, JsonVariant &js
 void handleApiTasmotaScheduleDelete(AsyncWebServerRequest *request);
 void handleApiTasmotaScheduleRun(AsyncWebServerRequest *request);
 void handleApiTasmotaPower(AsyncWebServerRequest *request);
+void handleApiTasmotaPowerSet(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverStart(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverState(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request);
@@ -478,6 +479,7 @@ void setup() {
   server.on("/api/tasmota/schedules", HTTP_DELETE, handleApiTasmotaScheduleDelete);  // ?id=N
   server.on("/api/tasmota/schedule/run", HTTP_POST, handleApiTasmotaScheduleRun);    // ?id=N
   server.on("/api/tasmota/power", HTTP_GET, handleApiTasmotaPower);                  // ?ip=X
+  server.on("/api/tasmota/power", HTTP_POST, handleApiTasmotaPowerSet);               // ?ip=X&action=ON|OFF|TOGGLE
   server.on("/api/tasmota/discover", HTTP_POST, handleApiTasmotaDiscoverStart);
   server.on("/api/tasmota/discover/state", HTTP_GET, handleApiTasmotaDiscoverState);
   server.on("/api/tasmota/discover/probe", HTTP_GET, handleApiTasmotaDiscoverProbe);  // ?ip=X
@@ -785,6 +787,8 @@ void loop() {
   TasmotaScheduler::drainPendingProbe();
   // Same defer pattern for "Test now" schedule fires from /api/tasmota/schedule/run.
   TasmotaScheduler::drainPendingAction();
+  // Same defer pattern for direct power-control buttons (POST /api/tasmota/power).
+  TasmotaScheduler::drainPendingSetPower();
 
   if (lastSecond != second()) {
     lastSecond = second();
@@ -2603,6 +2607,30 @@ void handleApiTasmotaPower(AsyncWebServerRequest *request) {
   }
   doc["pending"] = cache.pending || queued;
   sendJsonResponse(request, 200, doc);
+}
+
+// POST /api/tasmota/power?ip=X&action=ON|OFF|TOGGLE — user-triggered switch
+// control. Same deferred pattern as the GET probe: queue, return 202, drain
+// from the main loop. The resulting POWER state lands in the same ProbeCache
+// the GET endpoint reads, so the SPA's existing live-state polling reflects
+// the new state automatically. Used by the per-device buttons in the SPA so
+// the user can identify which physical switch each entry is when setting up
+// schedules.
+void handleApiTasmotaPowerSet(AsyncWebServerRequest *request) {
+  if (!request->hasParam("ip") || !request->hasParam("action")) {
+    return sendJsonError(request, 400, "missing ?ip=X&action=ON|OFF|TOGGLE");
+  }
+  String ip = request->getParam("ip")->value();
+  String action = request->getParam("action")->value();
+  if (!TasmotaScheduler::queueSetPower(ip.c_str(), action.c_str())) {
+    return sendJsonError(request, 409,
+                         "another power action is queued, or action is not ON/OFF/TOGGLE");
+  }
+  JsonDocument doc;
+  doc["status"] = "queued";
+  doc["ip"] = ip;
+  doc["action"] = action;
+  sendJsonResponse(request, 202, doc);
 }
 
 // ── Tasmota auto-discovery ────────────────────────────────────────────────

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -37,6 +37,7 @@
 #include "WagfamFont.h"
 #include "ClockStyles.h"
 #include "TasmotaScheduler.h"
+#include "TasmotaDiscovery.h"
 #include <bearssl/bearssl_hash.h>  // br_sha256_* for OTA SHA256 verification (issue #96)
 
 // Scroller font registry (issue #106). Index 0 is the Adafruit_GFX builtin
@@ -155,6 +156,9 @@ void handleApiTasmotaSchedulePut(AsyncWebServerRequest *request, JsonVariant &js
 void handleApiTasmotaScheduleDelete(AsyncWebServerRequest *request);
 void handleApiTasmotaScheduleRun(AsyncWebServerRequest *request);
 void handleApiTasmotaPower(AsyncWebServerRequest *request);
+void handleApiTasmotaDiscoverStart(AsyncWebServerRequest *request);
+void handleApiTasmotaDiscoverState(AsyncWebServerRequest *request);
+void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request);
 
 // LED Settings
 int spacer = 1;  // dots between letters
@@ -473,6 +477,9 @@ void setup() {
   server.on("/api/tasmota/schedules", HTTP_DELETE, handleApiTasmotaScheduleDelete);  // ?id=N
   server.on("/api/tasmota/schedule/run", HTTP_POST, handleApiTasmotaScheduleRun);    // ?id=N
   server.on("/api/tasmota/power", HTTP_GET, handleApiTasmotaPower);                  // ?ip=X
+  server.on("/api/tasmota/discover", HTTP_POST, handleApiTasmotaDiscoverStart);
+  server.on("/api/tasmota/discover/state", HTTP_GET, handleApiTasmotaDiscoverState);
+  server.on("/api/tasmota/discover/probe", HTTP_GET, handleApiTasmotaDiscoverProbe);  // ?ip=X
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -760,6 +767,10 @@ void loop() {
   // Pump the mDNS responder. The sync ESP8266mDNS variant needs this every
   // loop iteration; the wrapper is cheap when no queries are pending.
   MDNS.update();
+
+  // Drive Tasmota discovery state machine. No-op when idle/done; dispatches
+  // one ICMP ping (or one deferred HTTP probe) per call when running.
+  TasmotaDiscovery::tick();
 
   if (lastSecond != second()) {
     lastSecond = second();
@@ -2536,6 +2547,74 @@ void handleApiTasmotaPower(AsyncWebServerRequest *request) {
   doc["ip"] = ip;
   doc["power"] = state;
   doc["reachable"] = state.length() > 0;
+  sendJsonResponse(request, 200, doc);
+}
+
+// ── Tasmota auto-discovery ────────────────────────────────────────────────
+
+static void discoveryProgressToJson(const TasmotaDiscovery::DiscoveryProgress &p,
+                                     JsonObject obj) {
+  switch (p.state) {
+    case TasmotaDiscovery::DiscoveryState::Idle:      obj["state"] = "idle"; break;
+    case TasmotaDiscovery::DiscoveryState::MdnsQuery: obj["state"] = "mdns"; break;
+    case TasmotaDiscovery::DiscoveryState::PingSweep: obj["state"] = "scanning"; break;
+    case TasmotaDiscovery::DiscoveryState::Done:      obj["state"] = "done"; break;
+  }
+  obj["id"] = p.id;
+  obj["started_at_ms"] = p.startedAtMs;
+  obj["completed_at_ms"] = p.completedAtMs;
+  obj["pings_sent"] = p.pingsSent;
+  obj["pings_responded"] = p.pingsResponded;
+  obj["http_probed"] = p.httpProbed;
+  obj["tasmota_found"] = p.tasmotaFound;
+  obj["current_host_byte"] = p.currentHostByte;
+  obj["base_ip"] = p.baseIp.toString();
+}
+
+static void discoveryResultsToJson(JsonArray arr) {
+  for (int i = 0; i < TasmotaDiscovery::resultCount(); i++) {
+    const auto &d = TasmotaDiscovery::getResult(i);
+    JsonObject o = arr.add<JsonObject>();
+    o["ip"] = d.ip;
+    o["name"] = d.name;
+    o["hostname"] = d.hostname;
+    o["source"] = d.source ? d.source : "scan";
+  }
+}
+
+void handleApiTasmotaDiscoverStart(AsyncWebServerRequest *request) {
+  if (!TasmotaDiscovery::start()) {
+    return sendJsonError(request, 409, "discovery already in progress (or WiFi not joined)");
+  }
+  JsonDocument doc;
+  JsonObject obj = doc.to<JsonObject>();
+  discoveryProgressToJson(TasmotaDiscovery::getProgress(), obj);
+  sendJsonResponse(request, 202, doc);
+}
+
+void handleApiTasmotaDiscoverState(AsyncWebServerRequest *request) {
+  JsonDocument doc;
+  JsonObject obj = doc["progress"].to<JsonObject>();
+  discoveryProgressToJson(TasmotaDiscovery::getProgress(), obj);
+  JsonArray arr = doc["results"].to<JsonArray>();
+  discoveryResultsToJson(arr);
+  sendJsonResponse(request, 200, doc);
+}
+
+void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request) {
+  if (!request->hasParam("ip")) {
+    return sendJsonError(request, 400, "missing ?ip=X");
+  }
+  String ip = request->getParam("ip")->value();
+  TasmotaDiscovery::DiscoveredDevice d = {};
+  bool ok = TasmotaDiscovery::probeOne(ip.c_str(), &d);
+  JsonDocument doc;
+  doc["ip"] = ip;
+  doc["is_tasmota"] = ok;
+  if (ok) {
+    doc["name"] = d.name;
+    doc["hostname"] = d.hostname;
+  }
   sendJsonResponse(request, 200, doc);
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,9 @@ lib_deps =
   ArduinoJson@^7.4
   esphome/ESPAsyncTCP-esphome@^2.0.0
   esphome/ESPAsyncWebServer-esphome@^3.3.0
+  ; Tasmota auto-discovery uses ping sweep (TasmotaDiscovery.cpp). 2018
+  ; vintage, unmaintained, but ICMP echo wire format hasn't moved.
+  akajes/AsyncPing(esp8266)@^1.1.0
 
 [env:default]
 board = d1_mini
@@ -39,6 +42,10 @@ extra_scripts = pre:scripts/build_version.py
 build_flags =
   #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
   '-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'
+  ; Bump LWIP's ARP cache from default 10 to 32 so a discovery scan can
+  ; remember every responder on a typical /24 without evicting entries.
+  ; ~28 bytes/slot, so ~900 extra bytes static RAM.
+  -DARP_TABLE_SIZE=32
 
 # Local-development environment: same as `default`, but with the
 # auto-update branch disabled. Use this when running a locally-built

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -4,6 +4,11 @@ import type {
   WeatherData,
   EventsData,
   ActionAck,
+  TasmotaDevicesData,
+  TasmotaDevice,
+  TasmotaSchedulesData,
+  TasmotaScheduleInput,
+  TasmotaPowerProbeData,
 } from "./types";
 
 const POST_HEADERS = {
@@ -70,3 +75,51 @@ export const postSpaUpdateFromUrl = (url: string): Promise<ActionAck> =>
     headers: POST_HEADERS,
     body: JSON.stringify({ url }),
   });
+
+// ── Tasmota scheduler ──────────────────────────────────────────────────────
+
+export const getTasmotaDevices = (): Promise<TasmotaDevicesData> =>
+  apiFetch<TasmotaDevicesData>("/api/tasmota/devices");
+
+export const putTasmotaDevices = (
+  devices: TasmotaDevice[],
+): Promise<TasmotaDevicesData> =>
+  apiFetch<TasmotaDevicesData>("/api/tasmota/devices", {
+    method: "PUT",
+    headers: POST_HEADERS,
+    body: JSON.stringify(devices),
+  });
+
+export const getTasmotaSchedules = (): Promise<TasmotaSchedulesData> =>
+  apiFetch<TasmotaSchedulesData>("/api/tasmota/schedules");
+
+export const createTasmotaSchedule = (
+  s: TasmotaScheduleInput,
+): Promise<{ id: number }> =>
+  apiFetch<{ id: number }>("/api/tasmota/schedules", {
+    method: "POST",
+    headers: POST_HEADERS,
+    body: JSON.stringify(s),
+  });
+
+export const updateTasmotaSchedule = (
+  id: number,
+  s: TasmotaScheduleInput,
+): Promise<ActionAck> =>
+  apiFetch<ActionAck>(`/api/tasmota/schedules?id=${id}`, {
+    method: "PUT",
+    headers: POST_HEADERS,
+    body: JSON.stringify(s),
+  });
+
+export const deleteTasmotaSchedule = (id: number): Promise<ActionAck> =>
+  apiFetch<ActionAck>(`/api/tasmota/schedules?id=${id}`, { method: "DELETE" });
+
+export const runTasmotaScheduleNow = (id: number): Promise<ActionAck> =>
+  apiFetch<ActionAck>(`/api/tasmota/schedule/run?id=${id}`, {
+    method: "POST",
+    headers: POST_HEADERS,
+  });
+
+export const getTasmotaPower = (ip: string): Promise<TasmotaPowerProbeData> =>
+  apiFetch<TasmotaPowerProbeData>(`/api/tasmota/power?ip=${encodeURIComponent(ip)}`);

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -9,6 +9,7 @@ import type {
   TasmotaSchedulesData,
   TasmotaScheduleInput,
   TasmotaPowerProbeData,
+  TasmotaDiscoveryData,
 } from "./types";
 
 const POST_HEADERS = {
@@ -123,3 +124,12 @@ export const runTasmotaScheduleNow = (id: number): Promise<ActionAck> =>
 
 export const getTasmotaPower = (ip: string): Promise<TasmotaPowerProbeData> =>
   apiFetch<TasmotaPowerProbeData>(`/api/tasmota/power?ip=${encodeURIComponent(ip)}`);
+
+export const startTasmotaDiscovery = (): Promise<unknown> =>
+  apiFetch<unknown>("/api/tasmota/discover", {
+    method: "POST",
+    headers: POST_HEADERS,
+  });
+
+export const getTasmotaDiscoveryState = (): Promise<TasmotaDiscoveryData> =>
+  apiFetch<TasmotaDiscoveryData>("/api/tasmota/discover/state");

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -125,6 +125,15 @@ export const runTasmotaScheduleNow = (id: number): Promise<ActionAck> =>
 export const getTasmotaPower = (ip: string): Promise<TasmotaPowerProbeData> =>
   apiFetch<TasmotaPowerProbeData>(`/api/tasmota/power?ip=${encodeURIComponent(ip)}`);
 
+export const postTasmotaPower = (
+  ip: string,
+  action: "ON" | "OFF" | "TOGGLE",
+): Promise<ActionAck> =>
+  apiFetch<ActionAck>(
+    `/api/tasmota/power?ip=${encodeURIComponent(ip)}&action=${action}`,
+    { method: "POST", headers: POST_HEADERS },
+  );
+
 export const startTasmotaDiscovery = (): Promise<unknown> =>
   apiFetch<unknown>("/api/tasmota/discover", {
     method: "POST",

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -3,8 +3,9 @@ import { HomePage } from "./pages/HomePage";
 import { StatusPage } from "./pages/StatusPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { ActionsPage } from "./pages/ActionsPage";
+import { SchedulesPage } from "./pages/SchedulesPage";
 
-type Tab = "home" | "status" | "settings" | "actions";
+type Tab = "home" | "status" | "settings" | "actions" | "schedules";
 
 const activeTab = signal<Tab>("home");
 
@@ -13,6 +14,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: "status", label: "Status" },
   { id: "settings", label: "Settings" },
   { id: "actions", label: "Actions" },
+  { id: "schedules", label: "Schedules" },
 ];
 
 export function App() {
@@ -36,6 +38,7 @@ export function App() {
       {activeTab.value === "status" && <StatusPage />}
       {activeTab.value === "settings" && <SettingsPage />}
       {activeTab.value === "actions" && <ActionsPage />}
+      {activeTab.value === "schedules" && <SchedulesPage />}
     </main>
   );
 }

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -4,6 +4,7 @@ import { StatusPage } from "./pages/StatusPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { ActionsPage } from "./pages/ActionsPage";
 import { SchedulesPage } from "./pages/SchedulesPage";
+import { Footer } from "./pages/Footer";
 
 type Tab = "home" | "status" | "settings" | "actions" | "schedules";
 
@@ -39,6 +40,7 @@ export function App() {
       {activeTab.value === "settings" && <SettingsPage />}
       {activeTab.value === "actions" && <ActionsPage />}
       {activeTab.value === "schedules" && <SchedulesPage />}
+      <Footer />
     </main>
   );
 }

--- a/webui/src/pages/Footer.tsx
+++ b/webui/src/pages/Footer.tsx
@@ -1,0 +1,128 @@
+// Footer — shows the SPA version baked into the JS bundle, fetches the
+// device's API-reported spa_version, and prompts a force-refresh when they
+// disagree. The bundle version is injected at build time via Vite `define`
+// (see vite.config.ts and the `__SPA_VERSION__` global declared below).
+//
+// Why this exists: when LittleFS is reflashed on the device, the in-flight
+// JS bundle in any open browser tab is *still the old one* until the
+// browser revalidates. Until that happens, /api/status.spa_version will
+// report the new version while the cached bundle silently runs the old
+// code — confusing during diagnosis. The footer makes the gap visible.
+
+import { useEffect } from "preact/hooks";
+import { signal } from "@preact/signals";
+import { getStatus } from "../api";
+
+declare const __SPA_VERSION__: string;
+
+const bundleVersion = __SPA_VERSION__;
+
+const deviceVersion = signal<string | null>(null);
+const fetchFailed = signal(false);
+
+async function refreshDeviceVersion() {
+  try {
+    const s = await getStatus();
+    deviceVersion.value = s.spa_version || null;
+    fetchFailed.value = false;
+  } catch {
+    fetchFailed.value = true;
+  }
+}
+
+// Detect the user's OS so we can show the right force-refresh shortcut as
+// the *first* hint. Other platforms still get listed below. Falls back to
+// generic if UA sniffing fails.
+function detectPlatform(): "mac" | "windows" | "linux" | "ios" | "android" | "other" {
+  const ua = (typeof navigator !== "undefined" && navigator.userAgent) || "";
+  if (/iPad|iPhone|iPod/i.test(ua)) return "ios";
+  if (/Android/i.test(ua)) return "android";
+  if (/Macintosh|Mac OS X/i.test(ua)) return "mac";
+  if (/Windows/i.test(ua)) return "windows";
+  if (/Linux/i.test(ua)) return "linux";
+  return "other";
+}
+
+function ForceRefreshInstructions() {
+  const plat = detectPlatform();
+  return (
+    <details class="refresh-instructions">
+      <summary>How to force-refresh</summary>
+      <ul>
+        <li class={plat === "mac" ? "primary-platform" : ""}>
+          <strong>macOS</strong> (Chrome / Firefox / Edge / Safari):
+          press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd>
+        </li>
+        <li class={plat === "windows" || plat === "linux" ? "primary-platform" : ""}>
+          <strong>Windows / Linux</strong> (Chrome / Firefox / Edge):
+          press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>R</kbd>
+          {" "}(or <kbd>Ctrl</kbd> + <kbd>F5</kbd>)
+        </li>
+        <li class={plat === "ios" ? "primary-platform" : ""}>
+          <strong>iOS Safari</strong>: Settings → Safari → Clear History
+          and Website Data, then reopen this page. (Private-tab reload
+          also bypasses the cache.)
+        </li>
+        <li class={plat === "android" ? "primary-platform" : ""}>
+          <strong>Android Chrome</strong>: ⋮ menu → History → Clear
+          browsing data → "Cached images and files", then reload.
+        </li>
+        <li>
+          Or: open DevTools (<kbd>F12</kbd>), right-click the reload
+          button, and pick <em>Empty Cache and Hard Reload</em>.
+        </li>
+      </ul>
+    </details>
+  );
+}
+
+export function Footer() {
+  useEffect(() => {
+    void refreshDeviceVersion();
+  }, []);
+
+  const dv = deviceVersion.value;
+  // Mismatch: both known and different. We don't warn when device reports
+  // "unknown" (older firmware, or version.json missing on the FS) — that's
+  // a different problem and would be noisy.
+  const mismatch =
+    dv !== null && dv !== "" && dv !== "unknown" && dv !== bundleVersion;
+
+  return (
+    <footer class="spa-footer">
+      {mismatch && (
+        <div class="version-mismatch">
+          <p>
+            <strong>⚠ Cached SPA is out of date.</strong> This browser is
+            running <code>{bundleVersion}</code> but the device reports{" "}
+            <code>{dv}</code>. Force-refresh to load the latest bundle.
+          </p>
+          <ForceRefreshInstructions />
+        </div>
+      )}
+      <div class="footer-line">
+        <span>
+          SPA bundle: <code>{bundleVersion}</code>
+        </span>
+        <span>
+          {fetchFailed.value ? (
+            <span class="muted">device version unavailable</span>
+          ) : dv === null ? (
+            <span class="muted">checking device…</span>
+          ) : (
+            <>
+              device: <code>{dv || "unknown"}</code>
+            </>
+          )}
+        </span>
+        <button
+          class="link-btn"
+          onClick={() => void refreshDeviceVersion()}
+          title="Re-poll /api/status"
+        >
+          recheck
+        </button>
+      </div>
+    </footer>
+  );
+}

--- a/webui/src/pages/SchedulesPage.tsx
+++ b/webui/src/pages/SchedulesPage.tsx
@@ -27,11 +27,14 @@ import {
   deleteTasmotaSchedule,
   runTasmotaScheduleNow,
   getTasmotaPower,
+  startTasmotaDiscovery,
+  getTasmotaDiscoveryState,
 } from "../api";
 import type {
   TasmotaDevice,
   TasmotaSchedule,
   TasmotaActionStr,
+  TasmotaDiscoveryData,
 } from "../types";
 
 // ── shared state ──────────────────────────────────────────────────────────
@@ -46,6 +49,14 @@ const livePower = signal<Record<string, string>>({});
 
 const schedules = signal<TasmotaSchedule[]>([]);
 const schedulesError = signal<string | null>(null);
+
+// Auto-discovery state — open/visible while a scan is in flight or results
+// are waiting to be imported.
+const discoveryOpen = signal(false);
+const discoveryData = signal<TasmotaDiscoveryData | null>(null);
+const discoveryError = signal<string | null>(null);
+// Which IPs the user has checked to import. Keyed by IP so we don't double-add.
+const discoveryPicked = signal<Set<string>>(new Set());
 
 // Edit form state (works for both create and update — `editingId` switches).
 const editingId = signal<number | null>(null);
@@ -98,6 +109,76 @@ async function saveDevices() {
   } catch (e) {
     devicesError.value = (e as Error).message;
   }
+}
+
+// ── auto-discovery ────────────────────────────────────────────────────────
+
+let discoveryPollHandle: ReturnType<typeof setInterval> | null = null;
+
+function stopDiscoveryPoll() {
+  if (discoveryPollHandle !== null) {
+    clearInterval(discoveryPollHandle);
+    discoveryPollHandle = null;
+  }
+}
+
+async function pollDiscovery() {
+  try {
+    const data = await getTasmotaDiscoveryState();
+    discoveryData.value = data;
+    if (data.progress.state === "done" || data.progress.state === "idle") {
+      stopDiscoveryPoll();
+    }
+  } catch (e) {
+    discoveryError.value = (e as Error).message;
+    stopDiscoveryPoll();
+  }
+}
+
+async function startDiscovery() {
+  discoveryError.value = null;
+  discoveryPicked.value = new Set();
+  discoveryOpen.value = true;
+  try {
+    await startTasmotaDiscovery();
+  } catch (e) {
+    discoveryError.value = (e as Error).message;
+    return;
+  }
+  // Fast poll while running. The full scan takes ~60s on a /24; polling
+  // every 2s gives ~30 progress updates, which is enough for the bar.
+  void pollDiscovery();
+  stopDiscoveryPoll();
+  discoveryPollHandle = setInterval(() => void pollDiscovery(), 2000);
+}
+
+function toggleDiscoveryPick(ip: string) {
+  const next = new Set(discoveryPicked.value);
+  if (next.has(ip)) next.delete(ip);
+  else next.add(ip);
+  discoveryPicked.value = next;
+}
+
+function importPickedDiscoveries() {
+  const data = discoveryData.value;
+  if (!data) return;
+  // Add picked IPs to the devices list (skip ones already there).
+  const existing = new Set(devices.value.map((d) => d.ip));
+  const additions = data.results
+    .filter((r) => discoveryPicked.value.has(r.ip) && !existing.has(r.ip))
+    .map<TasmotaDevice>((r) => ({
+      ip: r.ip,
+      name: r.name || r.hostname || "",
+    }));
+  if (additions.length === 0) {
+    discoveryOpen.value = false;
+    return;
+  }
+  devices.value = [...devices.value, ...additions];
+  devicesDirty.value = true;
+  discoveryOpen.value = false;
+  discoveryData.value = null;
+  discoveryPicked.value = new Set();
 }
 
 // ── cron picker helpers ──────────────────────────────────────────────────
@@ -173,6 +254,7 @@ export function SchedulesPage() {
   return (
     <div class="schedules-page">
       <DevicesCard />
+      {discoveryOpen.value && <DiscoveryCard />}
       <ScheduleFormCard />
       <SchedulesListCard />
     </div>
@@ -186,6 +268,7 @@ function DevicesCard() {
       <header class="card-header">
         <h2>Tasmota devices</h2>
         <button onClick={() => void reloadDevices()}>Refresh</button>
+        <button onClick={() => void startDiscovery()}>Auto-detect</button>
       </header>
       <p class="muted">
         IPs the clock controls. Schedules reference these by IP. Power state
@@ -271,6 +354,114 @@ function DevicesCard() {
           {devicesDirty.value ? "Save changes" : "No changes"}
         </button>
       </div>
+    </section>
+  );
+}
+
+function DiscoveryCard() {
+  const data = discoveryData.value;
+  const progress = data?.progress;
+  const isRunning = progress?.state === "mdns" || progress?.state === "scanning";
+  const isDone = progress?.state === "done";
+  // Scan progress %: based on /24 sweep (1..254). mDNS phase happens first
+  // and is fast, so we show 0% during it; ping sweep dominates the bar.
+  const pct = progress?.state === "scanning"
+    ? Math.min(100, Math.round((progress.pings_sent / 254) * 100))
+    : isDone ? 100 : 0;
+  const existingIps = new Set(devices.value.map((d) => d.ip));
+
+  return (
+    <section class="card">
+      <header class="card-header">
+        <h2>Auto-detect Tasmota devices</h2>
+        <button onClick={() => {
+          stopDiscoveryPoll();
+          discoveryOpen.value = false;
+          discoveryData.value = null;
+        }}>
+          Close
+        </button>
+      </header>
+
+      <p class="muted">
+        Combined mDNS query + /24 ping sweep + HTTP probe. Catches Tasmotas
+        regardless of <code>SetOption55</code> setting. Full scan takes
+        ~60s on a typical /24.
+      </p>
+
+      {discoveryError.value && (
+        <p class="error">{discoveryError.value}</p>
+      )}
+
+      {progress && (
+        <div class="scan-progress">
+          {isRunning ? `Scanning… ${progress.pings_sent}/254 sent, ` : ""}
+          {progress.tasmota_found} Tasmota(s) found,
+          {" "}{progress.pings_responded} hosts responding to ping.
+          <div class="progress-bar">
+            <div class="progress-fill" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+      )}
+
+      {data && data.results.length > 0 && (
+        <>
+          <table class="net-table">
+            <thead>
+              <tr>
+                <th />
+                <th>IP</th>
+                <th>Name</th>
+                <th>Hostname</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.results.map((d) => {
+                const already = existingIps.has(d.ip);
+                const picked = discoveryPicked.value.has(d.ip);
+                return (
+                  <tr key={d.ip} class={already ? "row-muted" : ""}>
+                    <td>
+                      <input
+                        type="checkbox"
+                        checked={picked || already}
+                        disabled={already}
+                        onChange={() => toggleDiscoveryPick(d.ip)}
+                      />
+                    </td>
+                    <td><code>{d.ip}</code></td>
+                    <td>{d.name || <span class="muted">—</span>}</td>
+                    <td><code>{d.hostname || ""}</code></td>
+                    <td>
+                      <span class={`tag tag-${d.source}`}>{d.source}</span>
+                      {already && <span class="muted small"> · already added</span>}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+
+          <div class="card-actions">
+            <button
+              class="primary"
+              disabled={discoveryPicked.value.size === 0}
+              onClick={importPickedDiscoveries}
+            >
+              Import {discoveryPicked.value.size} selected
+            </button>
+          </div>
+        </>
+      )}
+
+      {isDone && data?.results.length === 0 && (
+        <p class="muted">
+          No Tasmotas found. If you know a specific IP is a Tasmota,
+          add it manually in the Devices table above — auto-detect
+          can miss devices behind aggressive firewalls.
+        </p>
+      )}
     </section>
   );
 }

--- a/webui/src/pages/SchedulesPage.tsx
+++ b/webui/src/pages/SchedulesPage.tsx
@@ -1,0 +1,620 @@
+// Schedules tab — Tasmota switch control on a timer.
+//
+// Two sections stacked on the page:
+//
+//   1. Devices: the "array of IPs" config. Each row is { ip, name, live }.
+//      live state ("ON"/"OFF"/—) is probed asynchronously via /api/tasmota/power
+//      so the user can sanity-check connectivity before scheduling. Whole
+//      list is PUT-replaced on Save (simplest for finite arrays; max 16).
+//
+//   2. Schedules: cron-driven actions. Each schedule has a target device IP,
+//      a 5-field cron string, an action (ON/OFF/TOGGLE), enable toggle, and
+//      a name. Cron picker has two views:
+//        - Mortals: HH:MM time picker + DoW checkboxes + 3 preset buttons
+//        - Nerds: raw text input
+//      The two views share the same string state; toggling "raw" just hides
+//      the form helpers. Either way the cron lands as a single string in
+//      the backend, which validates with the same parser used at runtime.
+
+import { useEffect } from "preact/hooks";
+import { signal } from "@preact/signals";
+import {
+  getTasmotaDevices,
+  putTasmotaDevices,
+  getTasmotaSchedules,
+  createTasmotaSchedule,
+  updateTasmotaSchedule,
+  deleteTasmotaSchedule,
+  runTasmotaScheduleNow,
+  getTasmotaPower,
+} from "../api";
+import type {
+  TasmotaDevice,
+  TasmotaSchedule,
+  TasmotaActionStr,
+} from "../types";
+
+// ── shared state ──────────────────────────────────────────────────────────
+
+const devices = signal<TasmotaDevice[]>([]);
+const devicesDirty = signal(false);
+const devicesError = signal<string | null>(null);
+
+// Power-state cache, keyed by IP. Refreshed lazily — clicking "probe" or
+// adding a new device kicks one off.
+const livePower = signal<Record<string, string>>({});
+
+const schedules = signal<TasmotaSchedule[]>([]);
+const schedulesError = signal<string | null>(null);
+
+// Edit form state (works for both create and update — `editingId` switches).
+const editingId = signal<number | null>(null);
+const formIp = signal("");
+const formCron = signal("0 22 * * *");
+const formAction = signal<TasmotaActionStr>("OFF");
+const formEnabled = signal(true);
+const formName = signal("");
+const formRawMode = signal(false);
+const formError = signal<string | null>(null);
+
+// ── loaders ───────────────────────────────────────────────────────────────
+
+async function reloadDevices() {
+  try {
+    const data = await getTasmotaDevices();
+    devices.value = data.devices;
+    devicesDirty.value = false;
+    devicesError.value = null;
+  } catch (e) {
+    devicesError.value = (e as Error).message;
+  }
+}
+
+async function reloadSchedules() {
+  try {
+    const data = await getTasmotaSchedules();
+    schedules.value = data.schedules;
+    schedulesError.value = null;
+  } catch (e) {
+    schedulesError.value = (e as Error).message;
+  }
+}
+
+async function probePower(ip: string) {
+  try {
+    const data = await getTasmotaPower(ip);
+    livePower.value = { ...livePower.value, [ip]: data.reachable ? data.power : "—" };
+  } catch {
+    livePower.value = { ...livePower.value, [ip]: "—" };
+  }
+}
+
+async function saveDevices() {
+  try {
+    const data = await putTasmotaDevices(devices.value);
+    devices.value = data.devices;
+    devicesDirty.value = false;
+    devicesError.value = null;
+  } catch (e) {
+    devicesError.value = (e as Error).message;
+  }
+}
+
+// ── cron picker helpers ──────────────────────────────────────────────────
+
+const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// Build a cron string from "mortals' mode" state.
+function buildCron(
+  hour: number,
+  minute: number,
+  daysOfWeek: number[],  // 0=Sun..6=Sat
+): string {
+  let dow = "*";
+  if (daysOfWeek.length > 0 && daysOfWeek.length < 7) {
+    // Try to detect contiguous ranges for readability; otherwise list.
+    const sorted = [...daysOfWeek].sort((a, b) => a - b);
+    let contiguous = true;
+    for (let i = 1; i < sorted.length; i++) {
+      if (sorted[i] !== sorted[i - 1] + 1) {
+        contiguous = false;
+        break;
+      }
+    }
+    if (contiguous && sorted.length > 1) {
+      dow = `${sorted[0]}-${sorted[sorted.length - 1]}`;
+    } else {
+      dow = sorted.join(",");
+    }
+  }
+  return `${minute} ${hour} * * ${dow}`;
+}
+
+// Parse a cron back into the mortals'-mode fields. Returns null if the cron
+// is too exotic for the picker (e.g. uses */N, specific months, etc.) —
+// caller falls back to raw-text mode.
+function parseSimpleCron(s: string): {
+  hour: number;
+  minute: number;
+  daysOfWeek: number[];
+} | null {
+  const parts = s.trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [m, h, dom, mon, dow] = parts;
+  if (dom !== "*" || mon !== "*") return null;
+  if (!/^\d+$/.test(m) || !/^\d+$/.test(h)) return null;
+  const minute = Number(m);
+  const hour = Number(h);
+  if (minute < 0 || minute > 59 || hour < 0 || hour > 23) return null;
+
+  let days: number[];
+  if (dow === "*") {
+    days = [0, 1, 2, 3, 4, 5, 6];
+  } else if (/^\d-\d$/.test(dow)) {
+    const [a, b] = dow.split("-").map(Number);
+    days = [];
+    for (let i = a; i <= b; i++) days.push(i);
+  } else if (/^\d(,\d)*$/.test(dow)) {
+    days = dow.split(",").map(Number);
+  } else {
+    return null;
+  }
+  return { hour, minute, daysOfWeek: days };
+}
+
+// ── components ────────────────────────────────────────────────────────────
+
+export function SchedulesPage() {
+  useEffect(() => {
+    void reloadDevices();
+    void reloadSchedules();
+  }, []);
+
+  return (
+    <div class="schedules-page">
+      <DevicesCard />
+      <ScheduleFormCard />
+      <SchedulesListCard />
+    </div>
+  );
+}
+
+function DevicesCard() {
+  const list = devices.value;
+  return (
+    <section class="card">
+      <header class="card-header">
+        <h2>Tasmota devices</h2>
+        <button onClick={() => void reloadDevices()}>Refresh</button>
+      </header>
+      <p class="muted">
+        IPs the clock controls. Schedules reference these by IP. Power state
+        is probed live (✓ = reachable + state, "—" = no response).
+      </p>
+
+      {devicesError.value && <p class="error">{devicesError.value}</p>}
+
+      <table class="net-table">
+        <thead>
+          <tr>
+            <th>IP</th>
+            <th>Name</th>
+            <th>State</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((d, i) => (
+            <tr key={i}>
+              <td>
+                <input
+                  type="text"
+                  value={d.ip}
+                  onInput={(e) => {
+                    const next = [...list];
+                    next[i] = { ...next[i], ip: (e.target as HTMLInputElement).value };
+                    devices.value = next;
+                    devicesDirty.value = true;
+                  }}
+                  placeholder="192.168.1.42"
+                />
+              </td>
+              <td>
+                <input
+                  type="text"
+                  value={d.name}
+                  onInput={(e) => {
+                    const next = [...list];
+                    next[i] = { ...next[i], name: (e.target as HTMLInputElement).value };
+                    devices.value = next;
+                    devicesDirty.value = true;
+                  }}
+                  placeholder="(optional)"
+                />
+              </td>
+              <td>
+                <code>{livePower.value[d.ip] ?? "?"}</code>{" "}
+                <button class="link-btn" onClick={() => void probePower(d.ip)}>
+                  probe
+                </button>
+              </td>
+              <td>
+                <button
+                  class="link-btn"
+                  onClick={() => {
+                    devices.value = list.filter((_, j) => j !== i);
+                    devicesDirty.value = true;
+                  }}
+                >
+                  remove
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div class="card-actions">
+        <button
+          onClick={() => {
+            devices.value = [...list, { ip: "", name: "" }];
+            devicesDirty.value = true;
+          }}
+        >
+          + Add device
+        </button>
+        <button
+          class={devicesDirty.value ? "primary" : ""}
+          disabled={!devicesDirty.value}
+          onClick={() => void saveDevices()}
+        >
+          {devicesDirty.value ? "Save changes" : "No changes"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function ScheduleFormCard() {
+  const isEdit = editingId.value !== null;
+
+  // Build / re-parse for the mortals' mode controls.
+  const simple = parseSimpleCron(formCron.value);
+  const canUseMortals = simple !== null;
+  const showRaw = formRawMode.value || !canUseMortals;
+
+  const updateMortals = (
+    hour: number,
+    minute: number,
+    daysOfWeek: number[],
+  ) => {
+    formCron.value = buildCron(hour, minute, daysOfWeek);
+  };
+
+  const submit = async () => {
+    formError.value = null;
+    try {
+      const payload = {
+        ip: formIp.value,
+        cron: formCron.value,
+        action: formAction.value,
+        enabled: formEnabled.value,
+        name: formName.value,
+      };
+      if (isEdit && editingId.value !== null) {
+        await updateTasmotaSchedule(editingId.value, payload);
+      } else {
+        await createTasmotaSchedule(payload);
+      }
+      // Reset form
+      editingId.value = null;
+      formIp.value = "";
+      formCron.value = "0 22 * * *";
+      formAction.value = "OFF";
+      formEnabled.value = true;
+      formName.value = "";
+      formRawMode.value = false;
+      void reloadSchedules();
+    } catch (e) {
+      formError.value = (e as Error).message;
+    }
+  };
+
+  return (
+    <section class="card">
+      <header class="card-header">
+        <h2>{isEdit ? "Edit schedule" : "Add a schedule"}</h2>
+        {isEdit && (
+          <button
+            onClick={() => {
+              editingId.value = null;
+              formIp.value = "";
+              formCron.value = "0 22 * * *";
+              formAction.value = "OFF";
+              formEnabled.value = true;
+              formName.value = "";
+            }}
+          >
+            Cancel edit
+          </button>
+        )}
+      </header>
+
+      <div class="schedule-form">
+        <label>
+          Name (optional)
+          <input
+            value={formName.value}
+            onInput={(e) => (formName.value = (e.target as HTMLInputElement).value)}
+            placeholder="Office lights off"
+          />
+        </label>
+
+        <label>
+          Device
+          <select
+            value={formIp.value}
+            onChange={(e) =>
+              (formIp.value = (e.target as HTMLSelectElement).value)
+            }
+          >
+            <option value="">— select device —</option>
+            {devices.value.map((d) => (
+              <option key={d.ip} value={d.ip}>
+                {d.ip} {d.name ? `(${d.name})` : ""}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Action
+          <select
+            value={formAction.value}
+            onChange={(e) =>
+              (formAction.value = (e.target as HTMLSelectElement)
+                .value as TasmotaActionStr)
+            }
+          >
+            <option value="OFF">OFF</option>
+            <option value="ON">ON</option>
+            <option value="TOGGLE">TOGGLE</option>
+          </select>
+        </label>
+
+        <div class="cron-picker">
+          <div class="cron-header">
+            <label class="inline">
+              <input
+                type="checkbox"
+                checked={showRaw}
+                disabled={!canUseMortals}
+                onChange={(e) =>
+                  (formRawMode.value = (e.target as HTMLInputElement).checked)
+                }
+              />
+              Raw cron mode (for the nerds)
+            </label>
+            {!canUseMortals && (
+              <span class="muted small">
+                (current cron is too exotic for the picker — raw-mode is forced)
+              </span>
+            )}
+          </div>
+
+          {showRaw ? (
+            <label>
+              Cron string (5 fields: <code>min hour dom month dow</code>)
+              <input
+                value={formCron.value}
+                onInput={(e) =>
+                  (formCron.value = (e.target as HTMLInputElement).value)
+                }
+                placeholder="0 22 * * *"
+              />
+            </label>
+          ) : simple ? (
+            <>
+              <div class="row">
+                <label>
+                  Hour
+                  <input
+                    type="number"
+                    min={0}
+                    max={23}
+                    value={simple.hour}
+                    onInput={(e) =>
+                      updateMortals(
+                        Number((e.target as HTMLInputElement).value) || 0,
+                        simple.minute,
+                        simple.daysOfWeek,
+                      )
+                    }
+                  />
+                </label>
+                <label>
+                  Minute
+                  <input
+                    type="number"
+                    min={0}
+                    max={59}
+                    value={simple.minute}
+                    onInput={(e) =>
+                      updateMortals(
+                        simple.hour,
+                        Number((e.target as HTMLInputElement).value) || 0,
+                        simple.daysOfWeek,
+                      )
+                    }
+                  />
+                </label>
+              </div>
+
+              <div class="dow-row">
+                {DOW_LABELS.map((label, idx) => {
+                  const on = simple.daysOfWeek.includes(idx);
+                  return (
+                    <label key={idx} class="dow-chip">
+                      <input
+                        type="checkbox"
+                        checked={on}
+                        onChange={(e) => {
+                          const checked = (e.target as HTMLInputElement).checked;
+                          const next = checked
+                            ? [...simple.daysOfWeek, idx]
+                            : simple.daysOfWeek.filter((d) => d !== idx);
+                          updateMortals(simple.hour, simple.minute, next);
+                        }}
+                      />
+                      {label}
+                    </label>
+                  );
+                })}
+              </div>
+
+              <div class="presets">
+                <button
+                  onClick={() =>
+                    updateMortals(simple.hour, simple.minute, [0, 1, 2, 3, 4, 5, 6])
+                  }
+                >
+                  Daily
+                </button>
+                <button
+                  onClick={() =>
+                    updateMortals(simple.hour, simple.minute, [1, 2, 3, 4, 5])
+                  }
+                >
+                  Weekdays
+                </button>
+                <button
+                  onClick={() =>
+                    updateMortals(simple.hour, simple.minute, [0, 6])
+                  }
+                >
+                  Weekends
+                </button>
+              </div>
+            </>
+          ) : null}
+
+          <p class="muted small">
+            Resulting cron: <code>{formCron.value}</code>
+          </p>
+        </div>
+
+        <label class="inline">
+          <input
+            type="checkbox"
+            checked={formEnabled.value}
+            onChange={(e) =>
+              (formEnabled.value = (e.target as HTMLInputElement).checked)
+            }
+          />
+          Enabled
+        </label>
+
+        {formError.value && <p class="error">{formError.value}</p>}
+
+        <button onClick={() => void submit()} disabled={!formIp.value}>
+          {isEdit ? "Save changes" : "Create schedule"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+function SchedulesListCard() {
+  const list = schedules.value;
+  if (schedulesError.value) {
+    return (
+      <section class="card">
+        <h2>Schedules</h2>
+        <p class="error">{schedulesError.value}</p>
+      </section>
+    );
+  }
+  if (list.length === 0) {
+    return (
+      <section class="card">
+        <h2>Schedules</h2>
+        <p class="muted">No schedules yet. Add one using the form above.</p>
+      </section>
+    );
+  }
+  return (
+    <section class="card">
+      <h2>Schedules ({list.length})</h2>
+      <table class="net-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Device</th>
+            <th>Cron</th>
+            <th>Action</th>
+            <th>Enabled</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {list.map((s) => (
+            <tr key={s.id} class={s.cron_valid ? "" : "row-bad"}>
+              <td>{s.name || <span class="muted">—</span>}</td>
+              <td><code>{s.ip}</code></td>
+              <td>
+                <code>{s.cron}</code>
+                {!s.cron_valid && (
+                  <span class="error-inline"> (invalid)</span>
+                )}
+              </td>
+              <td><code>{s.action}</code></td>
+              <td>{s.enabled ? "✓" : "—"}</td>
+              <td>
+                <button
+                  class="link-btn"
+                  onClick={() => {
+                    editingId.value = s.id;
+                    formIp.value = s.ip;
+                    formCron.value = s.cron;
+                    formAction.value = s.action;
+                    formEnabled.value = s.enabled;
+                    formName.value = s.name;
+                    formRawMode.value = false;
+                  }}
+                >
+                  edit
+                </button>{" "}
+                <button
+                  class="link-btn"
+                  onClick={async () => {
+                    try {
+                      await runTasmotaScheduleNow(s.id);
+                    } catch (e) {
+                      alert(`Test failed: ${(e as Error).message}`);
+                    }
+                  }}
+                >
+                  test now
+                </button>{" "}
+                <button
+                  class="link-btn"
+                  onClick={async () => {
+                    if (!confirm(`Delete "${s.name || s.cron}"?`)) return;
+                    try {
+                      await deleteTasmotaSchedule(s.id);
+                      void reloadSchedules();
+                    } catch (e) {
+                      alert(`Delete failed: ${(e as Error).message}`);
+                    }
+                  }}
+                >
+                  delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/webui/src/pages/SchedulesPage.tsx
+++ b/webui/src/pages/SchedulesPage.tsx
@@ -27,6 +27,7 @@ import {
   deleteTasmotaSchedule,
   runTasmotaScheduleNow,
   getTasmotaPower,
+  postTasmotaPower,
   startTasmotaDiscovery,
   getTasmotaDiscoveryState,
 } from "../api";
@@ -98,6 +99,41 @@ async function probePower(ip: string) {
   } catch {
     livePower.value = { ...livePower.value, [ip]: "—" };
   }
+}
+
+// Fire a power action against a Tasmota by IP, then re-probe so the cached
+// state row updates. Used by the per-device control buttons — lets the user
+// physically identify which switch each entry is when setting up schedules
+// (click ON, see which light comes on across the room).
+async function controlPower(ip: string, action: "ON" | "OFF" | "TOGGLE") {
+  livePower.value = { ...livePower.value, [ip]: "…" };
+  try {
+    await postTasmotaPower(ip, action);
+  } catch (e) {
+    livePower.value = { ...livePower.value, [ip]: "err" };
+    alert(`Power ${action} failed: ${(e as Error).message}`);
+    return;
+  }
+  // Backend queues the HTTP call and the main loop drains it on its next
+  // tick; the new POWER state lands in the same probe cache. Poll a couple
+  // of times until "pending" clears or we time out.
+  for (let i = 0; i < 6; i++) {
+    await new Promise((r) => setTimeout(r, 600));
+    try {
+      const data = await getTasmotaPower(ip);
+      if (!data.pending) {
+        livePower.value = {
+          ...livePower.value,
+          [ip]: data.reachable ? data.power : "—",
+        };
+        return;
+      }
+    } catch {
+      // keep polling
+    }
+  }
+  // Timed out — leave a hint that something is off rather than wedging "…".
+  livePower.value = { ...livePower.value, [ip]: "?" };
 }
 
 async function saveDevices() {
@@ -261,6 +297,39 @@ export function SchedulesPage() {
   );
 }
 
+// Per-device power control buttons. Used in both the Devices table (post-
+// import) and the Auto-detect results table (pre-import) so the user can
+// identify which physical switch each entry maps to before committing it
+// to a schedule.
+function PowerControls({ ip, disabled }: { ip: string; disabled?: boolean }) {
+  const off = disabled || !ip;
+  return (
+    <span class="power-controls">
+      <button
+        class="link-btn"
+        disabled={off}
+        onClick={() => void controlPower(ip, "ON")}
+      >
+        ON
+      </button>{" "}
+      <button
+        class="link-btn"
+        disabled={off}
+        onClick={() => void controlPower(ip, "OFF")}
+      >
+        OFF
+      </button>{" "}
+      <button
+        class="link-btn"
+        disabled={off}
+        onClick={() => void controlPower(ip, "TOGGLE")}
+      >
+        TOGGLE
+      </button>
+    </span>
+  );
+}
+
 function DevicesCard() {
   const list = devices.value;
   return (
@@ -272,7 +341,9 @@ function DevicesCard() {
       </header>
       <p class="muted">
         IPs the clock controls. Schedules reference these by IP. Power state
-        is probed live (✓ = reachable + state, "—" = no response).
+        is probed live (✓ = reachable + state, "—" = no response). Use the
+        ON / OFF / TOGGLE buttons to identify which physical switch each
+        entry maps to before scheduling.
       </p>
 
       {devicesError.value && <p class="error">{devicesError.value}</p>}
@@ -283,6 +354,7 @@ function DevicesCard() {
             <th>IP</th>
             <th>Name</th>
             <th>State</th>
+            <th>Control</th>
             <th />
           </tr>
         </thead>
@@ -320,6 +392,9 @@ function DevicesCard() {
                 <button class="link-btn" onClick={() => void probePower(d.ip)}>
                   probe
                 </button>
+              </td>
+              <td>
+                <PowerControls ip={d.ip} disabled={!d.ip} />
               </td>
               <td>
                 <button
@@ -406,6 +481,10 @@ function DiscoveryCard() {
 
       {data && data.results.length > 0 && (
         <>
+          <p class="muted small">
+            Tip: use the ON / OFF / TOGGLE buttons to identify each device
+            before importing.
+          </p>
           <table class="net-table">
             <thead>
               <tr>
@@ -414,6 +493,7 @@ function DiscoveryCard() {
                 <th>Name</th>
                 <th>Hostname</th>
                 <th>Source</th>
+                <th>Control</th>
               </tr>
             </thead>
             <tbody>
@@ -436,6 +516,9 @@ function DiscoveryCard() {
                     <td>
                       <span class={`tag tag-${d.source}`}>{d.source}</span>
                       {already && <span class="muted small"> · already added</span>}
+                    </td>
+                    <td>
+                      <PowerControls ip={d.ip} />
                     </td>
                   </tr>
                 );

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -484,3 +484,50 @@ input[type="checkbox"].toggle:checked::after {
   color: var(--muted);
   margin-top: 0.5rem;
 }
+
+/* ── Schedules tab ─────────────────────────────────────────────────────── */
+
+.schedules-page { display: flex; flex-direction: column; gap: 1.25rem; }
+.schedules-page .card-header {
+  display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;
+}
+.schedules-page .card-header h2 { margin: 0; flex: 1; }
+
+.card-actions {
+  display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.75rem;
+}
+.card-actions .primary { font-weight: 600; }
+
+.net-table {
+  width: 100%; border-collapse: collapse; font-size: 0.95rem; margin: 0.5rem 0;
+}
+.net-table th, .net-table td {
+  text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid var(--border);
+}
+.net-table th { font-weight: 600; color: var(--muted); font-size: 0.85rem; }
+.net-table input { width: 100%; box-sizing: border-box; }
+.net-table .row-bad { background: rgba(255, 80, 80, 0.06); }
+
+.schedule-form { display: flex; flex-direction: column; gap: 0.75rem; }
+.schedule-form label { display: flex; flex-direction: column; gap: 0.25rem; font-size: 0.85rem; }
+.schedule-form label.inline {
+  flex-direction: row; align-items: center; gap: 0.4rem; font-size: 0.95rem;
+}
+.schedule-form input, .schedule-form select { padding: 0.4rem; }
+.schedule-form .row { display: flex; gap: 0.75rem; }
+.schedule-form .row label { flex: 1; }
+
+.cron-picker { padding: 0.5rem; border: 1px dashed var(--border); border-radius: 6px; }
+.cron-header { display: flex; align-items: center; gap: 1rem; font-size: 0.9rem; margin-bottom: 0.5rem; }
+.dow-row { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.5rem 0; }
+.dow-chip {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  padding: 0.25rem 0.5rem; border: 1px solid var(--border); border-radius: 999px;
+  font-size: 0.85rem;
+}
+.presets { display: flex; gap: 0.4rem; }
+.presets button { font-size: 0.85rem; padding: 0.3rem 0.75rem; }
+
+.error-inline { color: var(--red, #b00020); font-size: 0.85em; }
+.link-btn { background: none; border: none; color: var(--accent, #0066cc); cursor: pointer; padding: 0; font: inherit; }
+.link-btn:hover { text-decoration: underline; }

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -554,3 +554,64 @@ input[type="checkbox"].toggle:checked::after {
 .tag-mdns { background: rgba(102, 187, 106, 0.2); color: #2e7d32; }
 .tag-scan { background: rgba(96, 165, 250, 0.2); color: #1565c0; }
 .tag-manual { background: rgba(245, 158, 11, 0.2); color: #b45309; }
+
+/* ── SPA footer ── */
+
+.spa-footer {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid color-mix(in srgb, var(--muted) 20%, transparent);
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.spa-footer .footer-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.5rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.spa-footer code {
+  font-size: 0.85rem;
+  color: var(--fg);
+}
+
+.version-mismatch {
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid color-mix(in srgb, #d97706 40%, transparent);
+  background: color-mix(in srgb, #fbbf24 12%, transparent);
+  border-radius: var(--radius);
+  color: var(--fg);
+}
+
+.version-mismatch p { margin: 0 0 0.5rem 0; }
+
+.refresh-instructions summary {
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.refresh-instructions ul {
+  margin: 0.5rem 0 0 0;
+  padding-left: 1.25rem;
+}
+
+.refresh-instructions li { margin: 0.25rem 0; }
+
+.refresh-instructions .primary-platform {
+  list-style: "→ ";
+  font-weight: 500;
+}
+
+.refresh-instructions kbd {
+  display: inline-block;
+  padding: 0.05rem 0.35rem;
+  border: 1px solid color-mix(in srgb, var(--muted) 40%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--muted) 8%, transparent);
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -531,3 +531,26 @@ input[type="checkbox"].toggle:checked::after {
 .error-inline { color: var(--red, #b00020); font-size: 0.85em; }
 .link-btn { background: none; border: none; color: var(--accent, #0066cc); cursor: pointer; padding: 0; font: inherit; }
 .link-btn:hover { text-decoration: underline; }
+
+/* ── Discovery card ─────────────────────────────────────────────────────── */
+
+.progress-bar {
+  height: 6px; background: var(--border); border-radius: 3px;
+  overflow: hidden; margin-top: 0.5rem;
+}
+.progress-fill {
+  height: 100%; background: var(--accent, #0066cc); transition: width 0.3s;
+}
+.scan-progress {
+  font-size: 0.9rem; padding: 0.5rem 0.75rem;
+  background: var(--bg-elev, rgba(0, 0, 0, 0.03));
+  border-radius: 4px; margin: 0.5rem 0;
+}
+.net-table .row-muted { opacity: 0.5; }
+.tag {
+  display: inline-block; padding: 0.1rem 0.4rem; border-radius: 999px;
+  font-size: 0.75rem; background: var(--border);
+}
+.tag-mdns { background: rgba(102, 187, 106, 0.2); color: #2e7d32; }
+.tag-scan { background: rgba(96, 165, 250, 0.2); color: #1565c0; }
+.tag-manual { background: rgba(245, 158, 11, 0.2); color: #b45309; }

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -159,3 +159,28 @@ export interface TasmotaPowerProbeData {
   power: string;       // "ON" | "OFF" | "" if unreachable
   reachable: boolean;
 }
+
+export interface TasmotaDiscoveryProgress {
+  state: "idle" | "mdns" | "scanning" | "done";
+  id: number;
+  started_at_ms: number;
+  completed_at_ms: number;
+  pings_sent: number;
+  pings_responded: number;
+  http_probed: number;
+  tasmota_found: number;
+  current_host_byte: number;
+  base_ip: string;
+}
+
+export interface TasmotaDiscoveredDevice {
+  ip: string;
+  name: string;
+  hostname: string;
+  source: "mdns" | "scan" | "manual";
+}
+
+export interface TasmotaDiscoveryData {
+  progress: TasmotaDiscoveryProgress;
+  results: TasmotaDiscoveredDevice[];
+}

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -116,3 +116,46 @@ export interface ConfigData {
   auto_update_enabled?: boolean;
   auto_update_compile_disabled?: boolean;
 }
+
+// ── Tasmota scheduler ──────────────────────────────────────────────────────
+
+export interface TasmotaDevice {
+  ip: string;
+  name: string;
+}
+
+export interface TasmotaDevicesData {
+  devices: TasmotaDevice[];
+  max: number;
+}
+
+export type TasmotaActionStr = "ON" | "OFF" | "TOGGLE";
+
+export interface TasmotaSchedule {
+  id: number;
+  ip: string;
+  cron: string;
+  action: TasmotaActionStr;
+  enabled: boolean;
+  name: string;
+  cron_valid: boolean;
+}
+
+export interface TasmotaSchedulesData {
+  schedules: TasmotaSchedule[];
+  max: number;
+}
+
+export interface TasmotaScheduleInput {
+  ip: string;
+  cron: string;
+  action: TasmotaActionStr;
+  enabled?: boolean;
+  name?: string;
+}
+
+export interface TasmotaPowerProbeData {
+  ip: string;
+  power: string;       // "ON" | "OFF" | "" if unreachable
+  reachable: boolean;
+}

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -158,6 +158,11 @@ export interface TasmotaPowerProbeData {
   ip: string;
   power: string;       // "ON" | "OFF" | "" if unreachable
   reachable: boolean;
+  // Both fields below are set by the firmware (≥ this PR). Optional so the
+  // SPA still typechecks against older /api/tasmota/power responses.
+  pending?: boolean;
+  queued?: boolean;
+  last_updated_ms_ago?: number;
 }
 
 export interface TasmotaDiscoveryProgress {

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, loadEnv } from "vite";
 import preact from "@preact/preset-vite";
 import { compression } from "vite-plugin-compression2";
+import fs from "node:fs";
+import path from "node:path";
 
 // Vite config for the WagFam CalClock SPA.
 //
@@ -12,12 +14,35 @@ import { compression } from "vite-plugin-compression2";
 // can iterate against real device state. Set CLOCK_HOST in .env.local
 // (e.g. CLOCK_HOST=http://192.168.168.66) and CLOCK_AUTH (admin:password) to
 // enable; otherwise dev mode skips the proxy and you get an empty fetch.
+
+// Bake the SPA version into the JS bundle as __SPA_VERSION__.
+// scripts/write_spa_version.py runs before `make webui` and writes
+// data/spa/version.json with the same version string the device reads at
+// boot and exposes via /api/status.spa_version. Embedding it lets the
+// Footer detect when a browser is running a *cached* old bundle whose
+// version differs from the device's API-reported one, and prompt the user
+// to force-refresh. Falls back to "dev" when version.json is absent (e.g.
+// `npm run dev` from a fresh checkout).
+function readBundleVersion(): string {
+  try {
+    const p = path.resolve(__dirname, "..", "data", "spa", "version.json");
+    const j = JSON.parse(fs.readFileSync(p, "utf8")) as { spa_version?: string };
+    return j.spa_version || "unknown";
+  } catch {
+    return "dev";
+  }
+}
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const clockHost = env.CLOCK_HOST || "";
   const clockAuth = env.CLOCK_AUTH || "";
+  const spaVersion = env.SPA_VERSION || readBundleVersion();
   return {
     base: "/spa/",
+    define: {
+      __SPA_VERSION__: JSON.stringify(spaVersion),
+    },
     plugins: [
       preact(),
       compression({


### PR DESCRIPTION
## Feature stack (four commits)

```
2dcde84  SPA footer with version display + stale-cache detection
b2af9dc  Per-device Tasmota power control + minor version bump
e56f758  Add Tasmota auto-discovery — mDNS + /24 probe, pre-populate the UI
48b0546  Add Tasmota scheduler — cron-driven LAN switch control
```

Per-commit revert/bisect: `git revert 2dcde84` drops just the footer; `git revert b2af9dc` drops the per-device buttons (and reverts the minor bump back to 4.4.2-wagfam); `git revert e56f758` keeps the scheduler but drops auto-detect; reverting all four takes the firmware back to master.

## What this delivers

Turns the clock into a small home-automation controller for [Tasmota smart switches](https://tasmota.github.io/docs/). Four layers:

### Scheduler (commit 1)

- Register switches by IP in a Devices list (max 16; persisted at `/tasmota_devices.json`).
- Add cron-driven schedules (max 32; `/tasmota_schedules.json`) that fire `Power ON`/`Power OFF`/`Power TOGGLE` via Tasmota's HTTP API.
- Standard 5-field cron with full POSIX syntax. `runCronSelfTest()` runs at every boot — 14 cases covering happy path + parse-failure cases.
- SPA picker has two modes: **mortals** (HH:MM + DoW chips + Daily/Weekdays/Weekends preset buttons) and **nerds** (raw cron text). Forced raw-mode for cron strings too exotic for the picker (e.g. `*/15`).
- "Test now" button per schedule fires the action immediately for verification.

### Auto-discovery (commit 2)

- mDNS query for `_tasmota._tcp` instantly finds devices with `SetOption55=1`.
- ICMP ping sweep of the local /24 finds everything else (including devices like the test "Office Light" at 192.168.168.241 that ships with `SetOption55=0`).
- For every ping responder, HTTP probe `/cm?cmnd=Status%200` and parse for `Status.DeviceName` + `StatusNET.Hostname` to identify Tasmotas regardless of mDNS state.
- SPA gets a "Auto-detect" button + DiscoveryCard with live progress, checkbox-per-result table, source tag (mdns/scan), and bulk import. Already-imported IPs are shown pre-checked + disabled so duplicates can't be added.
- Full scan time: ~60s on a typical /24.

### Per-device ON/OFF/TOGGLE buttons (commit 3)

- ON / OFF / TOGGLE buttons in **both** the Devices table (post-import) and the Auto-detect results table (pre-import) so the user can physically identify each switch ("click ON, see which light comes on across the room") before committing it to a schedule. Closes the verification gap when wiring up cron rules against discovered IPs.
- New `POST /api/tasmota/power?ip=X&action=ON|OFF|TOGGLE` endpoint mirrors the existing handler-defer / drain pattern: handler returns 202, main loop's `drainPendingSetPower()` does the blocking HTTP call, result lands in the same ProbeCache the GET endpoint reads so the existing live-state row reflects the new state automatically.
- BASE_VERSION bumped 4.4.2-wagfam → **4.5.0-wagfam** to mark the new feature.

### SPA footer with stale-cache detection (commit 4)

- Bakes the SPA version into the JS bundle itself (Vite `define` reads `data/spa/version.json` and injects `__SPA_VERSION__`).
- A `Footer` component renders on every page showing both the baked-in bundle version and the device's `/api/status.spa_version`. When the two disagree it shows a warning banner with platform-aware force-refresh instructions (Cmd/Ctrl+Shift+R, iOS Safari cache clear, Android Chrome cache clear).
- Why: when LittleFS is reflashed, an open browser tab keeps running the old cached bundle. The API already reports the new version, but the running JS is still the old one — confusing during diagnosis. The footer makes the gap visible at a glance.
- `makefile` `webui` target now calls `scripts/write_spa_version.py` both before docker (so vite can read it) and after (since vite's `emptyOutDir` wipes `data/spa/`), keeping the bundle-stamped version and the on-device `version.json` in sync.

## REST API

```text
GET    /api/tasmota/devices               list registered devices
PUT    /api/tasmota/devices               replace whole devices list
GET    /api/tasmota/schedules             list all schedules
POST   /api/tasmota/schedules             create one (returns new id)
PUT    /api/tasmota/schedules?id=N        update by id
DELETE /api/tasmota/schedules?id=N        delete by id
POST   /api/tasmota/schedule/run?id=N     fire immediately ("test now")
GET    /api/tasmota/power?ip=X            live power-state probe
POST   /api/tasmota/power?ip=X&action=Y   set power ON/OFF/TOGGLE (commit 3)
POST   /api/tasmota/discover              start auto-discovery
GET    /api/tasmota/discover/state        poll progress + current results
GET    /api/tasmota/discover/probe?ip=X   one-shot manual-IP check
```

All open per the trusted-LAN model — same as the rest of `/api/*`. The eventual auth-bolt-on point is the single function in TasmotaScheduler.cpp, untouched in this PR.

## Tasmota API used (per [official docs](https://tasmota.github.io/docs/Commands/#http) + live verification)

```
GET /cm?cmnd=Power            → {"POWER":"OFF"}
GET /cm?cmnd=Power%20OFF      → {"POWER":"OFF"}  (sets + returns new state)
GET /cm?cmnd=Status%200       → {"Status":{"DeviceName":"Office Light",...},
                                  "StatusNET":{"Hostname":"office-light-6908",...},
                                  ...}
```

Verified against Tasmota 15.0.1 running on the user's switch. No auth needed by default; `&user=X&password=Y` query params if locked (not currently used, easy to add per-device).

## Cost vs master (4MB d1_mini, after commit 4)

| | Before | After | Delta |
|---|---|---|---|
| Sketch flash | 610,473 / 1,044,464 (58.4%) | 637,397 / 1,044,464 (61.0%) | **+26.9 KB** |
| Static RAM | 38,732 / 81,920 (47.3%) | 43,728 / 81,920 (53.4%) | **+5.0 KB** |
| SPA bundle | ~25 KB | ~68 KB (~22 KB gzip) | **+43 KB** |

`MAX_DEVICES` / `MAX_SCHEDULES` / `MAX_RESULTS` are all `#define`s in the respective headers — easy dial if RAM tightens later.

## Dependency note

Both scheduler commits add `akajes/AsyncPing(esp8266)` and `ARP_TABLE_SIZE=32` to platformio.ini. PR #115 (LAN visibility) adds the same. When both PRs merge, the platformio.ini edits will trivially conflict — keep one set of each entry; the underlying intent is identical.

## Tests

- [x] `pio run -e default` clean
- [x] `make webui` clean
- [x] `make test-native` — 138 / 138
- [x] Live HTTP-API verification against Tasmota 15.0.1 (Office Light at .241): clean ON→OFF cycle, Status JSON shape matches parser expectations
- [x] Cron self-test runs at boot
- [x] SPA bundle confirmed to contain the baked-in version string `4.5.0-wagfam-...` matching `data/spa/version.json`
- [x] Hardware smoke: flash, click Auto-detect → verify Office Light is found with its name + hostname. Click ON/OFF in the Devices row → light flips. Schedule a `*/1 * * * *` test firing OFF; watch the Tasmota state flip every minute. Reflash LittleFS only → confirm Footer shows the stale-cache banner in an already-open browser tab.