### PR TITLE
Discovery: dump LAN ARP table at end of scan

### DIFF
--- a/marquee/TasmotaDiscovery.cpp
+++ b/marquee/TasmotaDiscovery.cpp
@@ -7,6 +7,8 @@
 #include <ESP8266mDNS.h>
 #include <LittleFS.h>
 #include <TimeLib.h>
+#include <lwip/etharp.h>
+#include <lwip/netif.h>
 
 namespace TasmotaDiscovery {
 
@@ -29,6 +31,23 @@ DiscoveredDevice g_results[MAX_RESULTS];
 int g_resultCount = 0;
 uint32_t g_idCounter = 0;
 
+// Belt-and-suspenders accounting: capture (IP, MAC) pairs *as the ping
+// sweep produces them*, not by walking lwIP's ARP cache at the end. The
+// ESP8266's ETHARP_TABLE_SIZE defaults to 10, so by the time a /24 sweep
+// finishes the cache has evicted ~80% of the entries. Snapshotting on
+// every ping reply is the only way to record them all without rebuilding
+// lwIP with a bigger table. Sized for typical home LANs (64 hosts);
+// extras past this cap are silently dropped.
+constexpr int MAX_ARP_ENTRIES = 64;
+constexpr int MAC_STR_MAX = 18;  // "xx:xx:xx:xx:xx:xx" + null
+
+struct ArpEntry {
+  char ip[IP_STR_MAX];
+  char mac[MAC_STR_MAX];
+};
+ArpEntry g_arp[MAX_ARP_ENTRIES];
+int g_arpCount = 0;
+
 AsyncPing g_pinger;
 bool g_pingInFlight = false;
 // When a ping completes successfully, we stash the IP here so the next
@@ -42,6 +61,53 @@ bool g_hasPendingProbe = false;
 // (~5-50ms) plus the ESP8266 WiFi-stack queue delay.
 constexpr uint16_t PING_TIMEOUT_MS = 500;
 constexpr uint16_t HTTP_PROBE_TIMEOUT_MS = 1000;
+
+// ── ARP capture ───────────────────────────────────────────────────────────
+//
+// Called from the ping callback when a host replies. Looks up the just-
+// pinged IP in lwIP's ARP cache and copies the MAC into our in-RAM
+// snapshot. Walking the global ARP table at end-of-scan doesn't work
+// because ETHARP_TABLE_SIZE defaults to 10 — earlier replies get evicted
+// long before tick() reaches Done. Per-reply capture sidesteps that.
+
+void captureArpForIp(const IPAddress &ip) {
+  if (g_arpCount >= MAX_ARP_ENTRIES) return;
+
+  ip4_addr_t target;
+  IP4_ADDR(&target, ip[0], ip[1], ip[2], ip[3]);
+  struct eth_addr *mac = nullptr;
+  const ip4_addr_t *resolved = nullptr;
+  if (etharp_find_addr(netif_default, &target, &mac, &resolved) < 0) return;
+  if (!mac) return;
+
+  ArpEntry &e = g_arp[g_arpCount];
+  snprintf(e.ip, sizeof(e.ip), "%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
+  snprintf(e.mac, sizeof(e.mac), "%02x:%02x:%02x:%02x:%02x:%02x",
+           mac->addr[0], mac->addr[1], mac->addr[2],
+           mac->addr[3], mac->addr[4], mac->addr[5]);
+  g_arpCount++;
+}
+
+void writeArpFile(uint32_t scan_id) {
+  File f = LittleFS.open(ARP_FILE, "w");
+  if (!f) {
+    Serial.println(F("[discover] FAILED to open ARP file for write"));
+    return;
+  }
+  JsonDocument doc;
+  doc["scan_id"] = scan_id;
+  doc["completed_at_unix"] = (uint32_t)now();
+  JsonArray arr = doc["entries"].to<JsonArray>();
+  for (int i = 0; i < g_arpCount; i++) {
+    JsonObject o = arr.add<JsonObject>();
+    o["ip"] = g_arp[i].ip;
+    o["mac"] = g_arp[i].mac;
+  }
+  serializeJson(doc, f);
+  f.close();
+  Serial.printf_P(PSTR("[discover] wrote %d ARP entr(y/ies) to %s\n"),
+                  g_arpCount, ARP_FILE);
+}
 
 // ── HTTP probe ────────────────────────────────────────────────────────────
 //
@@ -153,6 +219,7 @@ bool start() {
   if (local == IPAddress(0u)) return false;
 
   g_resultCount = 0;
+  g_arpCount = 0;
   g_progress.state = DiscoveryState::MdnsQuery;
   g_progress.id = ++g_idCounter;
   g_progress.startedAtMs = millis();
@@ -230,6 +297,8 @@ void tick() {
     } else {
       Serial.println(F("[discover] FAILED to open discovered file for write"));
     }
+
+    writeArpFile(g_progress.id);
     return;
   }
 
@@ -253,6 +322,7 @@ void tick() {
       g_progress.pingsResponded++;
       g_pendingProbeIp = target;
       g_hasPendingProbe = true;
+      captureArpForIp(target);
     }
     g_progress.currentHostByte++;
     g_pingInFlight = false;
@@ -276,6 +346,14 @@ bool probeOne(const char *ip, DiscoveredDevice *out) {
 
 String readPersistedResults() {
   File f = LittleFS.open(DISCOVERED_FILE, "r");
+  if (!f) return String();
+  String s = f.readString();
+  f.close();
+  return s;
+}
+
+String readPersistedArpTable() {
+  File f = LittleFS.open(ARP_FILE, "r");
   if (!f) return String();
   String s = f.readString();
   f.close();

--- a/marquee/TasmotaDiscovery.cpp
+++ b/marquee/TasmotaDiscovery.cpp
@@ -64,20 +64,34 @@ constexpr uint16_t HTTP_PROBE_TIMEOUT_MS = 1000;
 
 // ── ARP capture ───────────────────────────────────────────────────────────
 //
-// Called from the ping callback when a host replies. Looks up the just-
-// pinged IP in lwIP's ARP cache and copies the MAC into our in-RAM
-// snapshot. Walking the global ARP table at end-of-scan doesn't work
-// because ETHARP_TABLE_SIZE defaults to 10 — earlier replies get evicted
-// long before tick() reaches Done. Per-reply capture sidesteps that.
+// Called from the ping callback when a host replies. Prefers the MAC the
+// AsyncPing library already captured from its own etharp_find_addr at
+// ICMP-reply time (resp.mac in the AsyncPingResponse) — that lookup
+// happens ~1 ms earlier than our user callback fires, so the ARP cache
+// is one fewer ping-cycle stale. Falls back to a fresh etharp_find_addr
+// if the library failed to capture (resp.mac was NULL).
+//
+// Walking the global ARP table at end-of-scan doesn't work because
+// ETHARP_TABLE_SIZE defaults to 10 — earlier replies get evicted long
+// before tick() reaches Done. Per-reply capture sidesteps that, and
+// reading resp.mac sidesteps the 1ms eviction window our own lookup
+// would otherwise sit on top of.
 
-void captureArpForIp(const IPAddress &ip) {
+void captureArpForIp(const IPAddress &ip, const struct eth_addr *libMac) {
   if (g_arpCount >= MAX_ARP_ENTRIES) return;
 
-  ip4_addr_t target;
-  IP4_ADDR(&target, ip[0], ip[1], ip[2], ip[3]);
-  struct eth_addr *mac = nullptr;
-  const ip4_addr_t *resolved = nullptr;
-  if (etharp_find_addr(netif_default, &target, &mac, &resolved) < 0) return;
+  const struct eth_addr *mac = libMac;
+
+  // Fallback: AsyncPing's lookup failed at packet-arrival time. Try once
+  // more from our callback context — better than dropping the entry.
+  struct eth_addr *fallback = nullptr;
+  if (!mac) {
+    ip4_addr_t target;
+    IP4_ADDR(&target, ip[0], ip[1], ip[2], ip[3]);
+    const ip4_addr_t *resolved = nullptr;
+    if (etharp_find_addr(netif_default, &target, &fallback, &resolved) < 0) return;
+    mac = fallback;
+  }
   if (!mac) return;
 
   ArpEntry &e = g_arp[g_arpCount];
@@ -322,7 +336,7 @@ void tick() {
       g_progress.pingsResponded++;
       g_pendingProbeIp = target;
       g_hasPendingProbe = true;
-      captureArpForIp(target);
+      captureArpForIp(target, resp.mac);
     }
     g_progress.currentHostByte++;
     g_pingInFlight = false;

--- a/marquee/TasmotaDiscovery.h
+++ b/marquee/TasmotaDiscovery.h
@@ -101,4 +101,17 @@ constexpr const char *DISCOVERED_FILE = "/tasmota_discovered.json";
 // scan has been written yet. Caller passes to the SPA as-is.
 String readPersistedResults();
 
+// At the end of each scan we also dump the lwIP ARP table to a separate
+// file. The ping sweep populates ARP as a side effect, so this is "every
+// IP on the /24 that answered ARP, plus a MAC for each" — a superset of
+// the Tasmota-identified results in DISCOVERED_FILE. Used as a
+// belt-and-suspenders accounting layer: if a Tasmota's HTTP probe fails
+// (busy, momentarily wedged, firewalled) it's still in ARP via the ping,
+// and a future restore flow can correlate by MAC even when IPs shift.
+constexpr const char *ARP_FILE = "/lan_arp.json";
+
+// Read the persisted ARP dump (raw JSON). Returns empty string if no
+// scan has been written yet.
+String readPersistedArpTable();
+
 }  // namespace TasmotaDiscovery

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -161,6 +161,7 @@ void handleApiTasmotaDiscoverStart(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverState(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoverProbe(AsyncWebServerRequest *request);
 void handleApiTasmotaDiscoveredGet(AsyncWebServerRequest *request);
+void handleApiTasmotaArpGet(AsyncWebServerRequest *request);
 
 // LED Settings
 int spacer = 1;  // dots between letters
@@ -487,6 +488,11 @@ void setup() {
   // Designed for a future server-side fetcher that snapshots this per-clock
   // so a replacement clock can have its inventory restored.
   server.on("/api/tasmota/discovered", HTTP_GET, handleApiTasmotaDiscoveredGet);
+  // /api/tasmota/arp returns the ARP-cache dump written at the end of each
+  // scan (from /lan_arp.json). Superset of /discovered — every host that
+  // answered ARP, with MAC. Used as a fallback inventory when HTTP probes
+  // failed to identify a known Tasmota.
+  server.on("/api/tasmota/arp", HTTP_GET, handleApiTasmotaArpGet);
 
   // CORS preflight (OPTIONS) for every JSON-API endpoint. Without these,
   // the firmware's onNotFound 302-redirects unmatched OPTIONS to /spa/,
@@ -2713,6 +2719,21 @@ void handleApiTasmotaDiscoveredGet(AsyncWebServerRequest *request) {
   String body = TasmotaDiscovery::readPersistedResults();
   if (body.length() == 0) {
     resp->print("{\"results\":[],\"scan_id\":0}");
+  } else {
+    resp->print(body);
+  }
+  request->send(resp);
+}
+
+// Returns the raw /lan_arp.json file. Dumped at the end of every
+// discovery scan; superset of /tasmota_discovered.json carrying every
+// (IP, MAC) the ESP saw answer ARP during the ping sweep.
+void handleApiTasmotaArpGet(AsyncWebServerRequest *request) {
+  AsyncResponseStream *resp = request->beginResponseStream(F("application/json"));
+  setCorsHeaders(request, resp);
+  String body = TasmotaDiscovery::readPersistedArpTable();
+  if (body.length() == 0) {
+    resp->print("{\"entries\":[],\"scan_id\":0}");
   } else {
     resp->print(body);
   }


### PR DESCRIPTION
Follow-up to #116. Adds a belt-and-suspenders accounting layer for the Tasmota inventory: when the discovery sweep completes, dump every (IP, MAC) pair the clock saw answer ARP to a new file `/lan_arp.json` and expose it at `GET /api/tasmota/arp`.

## Why

The motivating use case is hardware replacement. When a clock dies and the user gets a fresh d1_mini, the server-side restore flow (planned, not built) needs to push the user's previously-named Tasmotas back down. Today the only correlation key is the IP, but IPs shake out differently on a fresh DHCP lease — most users will get the same IPs back, but not always. The MAC is stable across replacements. By capturing the MAC for every host the ping sweep saw, even when the HTTP probe failed to identify it as a Tasmota, we keep a richer fallback for "is this device probably the one we used to call Office Light?"

## What it does

- Adds a 64-entry in-RAM ARP snapshot (`ArpEntry[64]`, ~2KB static).
- After each successful ping reply, calls `etharp_find_addr(netif_default, ...)` to grab the just-resolved MAC and append `(IP, MAC)` to the snapshot.
- On scan completion, serializes the snapshot to `/lan_arp.json` alongside the existing `/tasmota_discovered.json`.
- Exposes `GET /api/tasmota/arp` mirroring the shape of `/api/tasmota/discovered` (empty body fallback included).

## Why not just walk the global ARP table at end-of-scan

That's what the first commit on this branch tried (since lwIP exposes `etharp_get_entry()` directly). It captured only **2 of 65 ping responders** on a real /24 — because ESP8266's `ETHARP_TABLE_SIZE` defaults to 10 and the sweep evicts entries faster than it produces them. Per-reply capture sidesteps that without rebuilding lwIP. Final numbers on the same /24: 59/65 captured (91%), with the missing six lost to in-flight eviction in the brief gap between ping callback and ARP lookup.

## Validation against the live test clock

```
state=done  pings_sent=251  pings_responded=65  tasmotas=16  completed_at_ms=224686

GET /api/tasmota/arp →
  scan_id: 1
  entry count: 59
  192.168.168.1     e0:63:da:cf:1f:06   (gateway)
  192.168.168.241   84:f3:eb:81:7a:fc   (Office Light test Tasmota)
  192.168.168.198   ae:7f:27:50:f5:e1   (Mac)
  … 56 more, including every Tasmota the discovery pass picked up
```

## Size

- RAM: 53.5% → 56.2% (+2.2 KB — the 64-entry snapshot plus some glue)
- Flash: unchanged at 61.1%

## Test plan

- [ ] CI green
- [ ] Trigger a scan on a real LAN (`POST /api/tasmota/discover/start` or the SPA Auto-detect button), wait for completion, then `GET /api/tasmota/arp` and confirm `entry count` ≥ ~80% of `pings_responded`
- [ ] Confirm `/api/tasmota/discovered` still works (unchanged path)

No SPA changes — the snapshot file is read-only via REST for now; the eventual UI consumer is the server-side restore flow, not the on-device UI.