### PR TITLE
Clock family tagging: welcome message + SPA header

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ and tolerates missing ones:
 | --- | --- |
 | `eventToday` | `1` enables an animated dot border around the clock display for the day |
 | `deviceName` | Stored on the device and shown in the SPA |
+| `family` | Lowercase family tag (`"butterfield"` / `"wagner"` / `null`). When set, personalizes the bootup welcome message and the SPA header. Unknown values are logged and ignored |
 | `latestVersion` + `firmwareUrl` | When `latestVersion` differs from the firmware's compiled-in `VERSION`, auto-update fires (subject to compile-time + runtime opt-out flags — see "Features"). HTTP only; HTTPS not supported by ESP8266HTTPUpdate without large heap cost |
 | `latestSpaVersion` + `spaFsUrl` | Same model as firmware, but for the LittleFS partition (SPA bundle). `/conf.txt` is preserved across the flash |
 | `trollMessage` | When non-empty the clock displays *only* this string and ignores calendar messages. RAM-only on the clock — a power cycle clears it. Issue #99 |

--- a/marquee/FamilyHelpers.cpp
+++ b/marquee/FamilyHelpers.cpp
@@ -1,0 +1,11 @@
+#include "FamilyHelpers.h"
+
+bool isKnownFamily(const String &wire) {
+  return wire == "butterfield" || wire == "wagner";
+}
+
+String familyDisplay(const String &wire) {
+  if (wire == "butterfield") return F("Butterfield");
+  if (wire == "wagner") return F("Wagner");
+  return String();
+}

--- a/marquee/FamilyHelpers.h
+++ b/marquee/FamilyHelpers.h
@@ -1,0 +1,19 @@
+// Clock family tagging helpers. Pulled out of marquee.ino so the wire-to-
+// display mapping can be unit-tested under tests/native/ without dragging
+// in WiFi / LittleFS / web-server globals. Pure String-in / String-out —
+// no hardware dependencies.
+#pragma once
+
+#include <Arduino.h>
+
+// True iff `wire` is one of the families the firmware knows how to render.
+// The server agrees on this allowlist (see wagfam-server check-in handler);
+// anything else is treated as "unset" rather than rendered as-is so a
+// server-side typo can't display garbled text on the matrix.
+bool isKnownFamily(const String &wire);
+
+// Map the lowercase wire value ("butterfield" / "wagner" / "") to the
+// capitalized display form rendered by the bootup welcome message and the
+// SPA header. Unknown / empty returns "" so callers can fall back to their
+// generic label.
+String familyDisplay(const String &wire);

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -159,6 +159,7 @@ void WagFamBdayClient::whitespace(char c) {
 //       "latestVersion": "3.08.0-wagfam",
 //       "firmwareUrl": "http://example.com/marquee-v3.08.0.bin",
 //       "deviceName": "Kitchen Clock",
+//       "family": "wagner",
 //       "latestSpaVersion": "3.10.0-wagfam-abc1234",
 //       "spaFsUrl": "http://example.com/marquee-v3.10.0-littlefs.bin"
 //     }
@@ -226,6 +227,14 @@ void WagFamBdayClient::value(String value) {
       currentConfig.configUpdatePayload = value;
     } else if (currentKey == "configUpdateSignature") {
       currentConfig.configUpdateSignature = value;
+    } else if (currentKey == "family") {
+      // Coordinated with wagfam-server: wire form is lowercase ASCII.
+      // Caller (marquee.ino) validates against the {butterfield, wagner}
+      // allowlist and decides whether to persist; we just surface the raw
+      // value so the validation message can log what the server actually
+      // sent.
+      currentConfig.familyValid = true;
+      currentConfig.family = value;
     } else if (currentKey == "runTasmotaDiscovery") {
       // Tasmota auto-discovery trigger. Accept the common truthy spellings
       // ("1", "true") since the static JSON can come from any tooling. The

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -86,6 +86,13 @@ class WagFamBdayClient: public JsonListener {
       int configUpdateVersion;
       String configUpdatePayload;
       String configUpdateSignature;
+      // Family tag for the clock — assigned by the server, used at render
+      // time to personalize the welcome message and SPA header. Wire form
+      // is lowercase ASCII; only "butterfield" and "wagner" are accepted
+      // — any other string is logged as a warning and treated as unset
+      // so a server typo can't display garbled text on the matrix.
+      boolean familyValid;
+      String family;
       // Tasmota auto-discovery trigger. When the server sets this to true,
       // the clock kicks off one TasmotaDiscovery scan after the calendar
       // refresh completes and writes the results to

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -28,6 +28,7 @@
 #include "Settings.h"
 #include "SecurityHelpers.h"
 #include "MdnsHelpers.h"
+#include "FamilyHelpers.h"
 #include "ConfigUpdateVerify.h"
 #include "CorsSupport.h"
 #include "HwVerifyTest.h"
@@ -71,7 +72,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.5.0-wagfam"
+#define BASE_VERSION "4.6.0-wagfam"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else
@@ -186,6 +187,11 @@ WagFamBdayClient bdayClient(WAGFAM_API_KEY, WAGFAM_DATA_URL);
 int bdayMessageIndex = 0;
 WagFamBdayClient::configValues serverConfig = {};
 String DEVICE_NAME = "";     // Human-friendly name assigned by server (not user-editable)
+// Family tag assigned by the wagfam-server check-in response (lowercase ASCII
+// wire form: "butterfield", "wagner", or ""). Display capitalization is the
+// firmware's job — see familyDisplay() below. Persisted in /conf.txt under
+// FAMILY=. Not user-editable on the device; only the server can set it.
+String FAMILY = "";
 String mdnsHostname = "";    // DNS-safe label registered with ESP8266mDNS (e.g.
                              // "kitchen-clock"); resolves as "<name>.local" on
                              // any mDNS-capable client. Recomputed in startMdns()
@@ -408,7 +414,18 @@ void setup() {
   delay(1000);
   matrix.setIntensity(displayIntensity);
 
-  scrollMessageWait(F("Welcome to the Wagner Family Calendar Clock!!!"));
+  {
+    // FAMILY is loaded from /conf.txt by readPersistentConfig() above, so a
+    // clock that has previously checked in with the server shows its tagged
+    // family on the very first scroll after boot. Brand-new / untagged clocks
+    // fall back to the historical generic message verbatim.
+    String fam = familyDisplay(FAMILY);
+    if (fam.length() > 0) {
+      scrollMessageWait("Welcome to the " + fam + " Family Calendar Clock!!!");
+    } else {
+      scrollMessageWait(F("Welcome to the Wagner Family Calendar Clock!!!"));
+    }
+  }
 
   //ESPAsyncWiFiManager — shares our AsyncWebServer for the captive portal.
   //Local initialization. Once its business is done, there is no need to keep it around.
@@ -1478,6 +1495,29 @@ void getWeatherData() //client function to send/receive GET request data.
     // without waiting for a reboot.
     startMdns();
   }
+  if (serverConfig.familyValid) {
+    // Coordinated with wagfam-server: wire form is lowercase ASCII. Treat
+    // null / empty / unknown values as "unset" — for unknown, log a warning
+    // (server typo or future family the firmware doesn't recognize yet) and
+    // fall through to the generic-message fallback rather than crash or
+    // render garbled text on the matrix.
+    String wire = serverConfig.family;
+    wire.toLowerCase();
+    if (wire.length() == 0 || wire == "null") {
+      if (FAMILY.length() != 0) {
+        FAMILY = "";
+        needToSave = true;
+      }
+    } else if (isKnownFamily(wire)) {
+      if (FAMILY != wire) {
+        FAMILY = wire;
+        needToSave = true;
+      }
+    } else {
+      Serial.println("[family] WARN: unknown family value from server: '" + wire +
+                     "' — leaving as '" + FAMILY + "'");
+    }
+  }
   if (needToSave) {
     Serial.println("Saving new config received from server");
     savePersistentConfig();
@@ -1793,6 +1833,7 @@ void savePersistentConfig() {
     f.println("SHOW_DATE=" + String(SHOW_DATE));
     f.println("OTA_SAFE_URL=" + OTA_SAFE_URL);
     f.println("DEVICE_NAME=" + DEVICE_NAME);
+    f.println("FAMILY=" + FAMILY);
     f.println("LAST_APPLIED_CONFIG_VERSION=" + String(lastAppliedConfigVersion));
     f.println("AUTO_UPDATE_ENABLED=" + String(AUTO_UPDATE_ENABLED ? 1 : 0));
   }
@@ -1898,6 +1939,14 @@ void readPersistentConfig() {
     } else if (key == "DEVICE_NAME") {
       DEVICE_NAME = value;
       Serial.println("DEVICE_NAME: " + DEVICE_NAME);
+    } else if (key == "FAMILY") {
+      // Defensive sanitization on read-back so a hand-edited /conf.txt with a
+      // capitalized or unknown value can't slip a bad display label past the
+      // server-side validator on a subsequent fetch.
+      String wire = value;
+      wire.toLowerCase();
+      FAMILY = isKnownFamily(wire) ? wire : "";
+      Serial.println("FAMILY: '" + FAMILY + "'");
     } else if (key == "LAST_APPLIED_CONFIG_VERSION") {
       lastAppliedConfigVersion = value.toInt();
       Serial.println("LAST_APPLIED_CONFIG_VERSION=" + String(lastAppliedConfigVersion));
@@ -2067,6 +2116,12 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   doc["heap_fragmentation"] = ESP.getHeapFragmentation();
   doc["chip_id"] = String(ESP.getChipId(), HEX);
   doc["device_name"] = DEVICE_NAME;
+  // Family tag from the server's check-in response. `family` is the canonical
+  // lowercase wire value; `family_display` is the firmware-mapped capitalized
+  // form ("Wagner" / "Butterfield") that the SPA renders directly. Both are
+  // empty strings when the device is untagged.
+  doc["family"] = FAMILY;
+  doc["family_display"] = familyDisplay(FAMILY);
   doc["mdns_name"] = mdnsHostname;
   doc["lan_ip"] = WiFi.localIP().toString();
   doc["flash_size"] = ESP.getFlashChipRealSize();
@@ -2132,6 +2187,8 @@ void handleApiConfigGet(AsyncWebServerRequest *request) {
   doc["show_highlow"] = SHOW_HIGHLOW;
   doc["ota_safe_url"] = OTA_SAFE_URL;
   doc["device_name"] = DEVICE_NAME;
+  doc["family"] = FAMILY;
+  doc["family_display"] = familyDisplay(FAMILY);
   // Issue #95: runtime auto-update toggle. `auto_update_enabled` is the
   // user-controllable boolean; `auto_update_compile_disabled` is read-only
   // and lets the SPA show "force-disabled at build time" when applicable.

--- a/tests/native/test_family_helpers/test_family_helpers.cpp
+++ b/tests/native/test_family_helpers/test_family_helpers.cpp
@@ -1,0 +1,86 @@
+#include <unity.h>
+#include "Arduino.h"
+
+#include "FamilyHelpers.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+// ── isKnownFamily ───────────────────────────────────────────────────────────
+
+void test_known_family_wagner() {
+    TEST_ASSERT_TRUE(isKnownFamily("wagner"));
+}
+
+void test_known_family_butterfield() {
+    TEST_ASSERT_TRUE(isKnownFamily("butterfield"));
+}
+
+void test_unknown_family_rejected() {
+    TEST_ASSERT_FALSE(isKnownFamily("hogwarts"));
+}
+
+void test_empty_string_not_known() {
+    TEST_ASSERT_FALSE(isKnownFamily(""));
+}
+
+void test_case_sensitivity_lowercase_only() {
+    // Wire form is lowercase ASCII per the contract. Caller (marquee.ino's
+    // applyServerConfig block) lowercases before checking; the helper itself
+    // is strict so a caller forgetting to lowercase doesn't silently pass.
+    TEST_ASSERT_FALSE(isKnownFamily("Wagner"));
+    TEST_ASSERT_FALSE(isKnownFamily("WAGNER"));
+    TEST_ASSERT_FALSE(isKnownFamily("Butterfield"));
+}
+
+// ── familyDisplay ───────────────────────────────────────────────────────────
+
+void test_display_wagner_capitalized() {
+    TEST_ASSERT_EQUAL_STRING("Wagner", familyDisplay("wagner").c_str());
+}
+
+void test_display_butterfield_capitalized() {
+    TEST_ASSERT_EQUAL_STRING("Butterfield", familyDisplay("butterfield").c_str());
+}
+
+void test_display_empty_for_empty_wire() {
+    TEST_ASSERT_EQUAL_STRING("", familyDisplay("").c_str());
+}
+
+void test_display_empty_for_unknown_value() {
+    // Unknown wire value falls back to "" so the caller can show its
+    // generic label (welcome message, app header) instead of rendering a
+    // garbled string the user can't identify.
+    TEST_ASSERT_EQUAL_STRING("", familyDisplay("hogwarts").c_str());
+}
+
+void test_display_empty_for_null_literal_string() {
+    // Defensive: the JSON parser only sees string values, but if some
+    // future code path passes through the literal "null" we still bail.
+    TEST_ASSERT_EQUAL_STRING("", familyDisplay("null").c_str());
+}
+
+void test_display_empty_for_wrongcase_input() {
+    // Display mapping is strict on case — same reason as isKnownFamily.
+    TEST_ASSERT_EQUAL_STRING("", familyDisplay("Wagner").c_str());
+    TEST_ASSERT_EQUAL_STRING("", familyDisplay("BUTTERFIELD").c_str());
+}
+
+int main() {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_known_family_wagner);
+    RUN_TEST(test_known_family_butterfield);
+    RUN_TEST(test_unknown_family_rejected);
+    RUN_TEST(test_empty_string_not_known);
+    RUN_TEST(test_case_sensitivity_lowercase_only);
+
+    RUN_TEST(test_display_wagner_capitalized);
+    RUN_TEST(test_display_butterfield_capitalized);
+    RUN_TEST(test_display_empty_for_empty_wire);
+    RUN_TEST(test_display_empty_for_unknown_value);
+    RUN_TEST(test_display_empty_for_null_literal_string);
+    RUN_TEST(test_display_empty_for_wrongcase_input);
+
+    return UNITY_END();
+}

--- a/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
+++ b/tests/native/test_wagfam_parser/test_wagfam_parser.cpp
@@ -326,6 +326,72 @@ void test_config_device_name_with_other_fields() {
     TEST_ASSERT_FALSE(cfg.eventToday);
 }
 
+// ── family field (clock family tagging) ─────────────────────────────────────
+
+void test_config_family_butterfield_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"family\":\"butterfield\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.familyValid);
+    TEST_ASSERT_EQUAL_STRING("butterfield", cfg.family.c_str());
+}
+
+void test_config_family_wagner_parsed() {
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"family\":\"wagner\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.familyValid);
+    TEST_ASSERT_EQUAL_STRING("wagner", cfg.family.c_str());
+}
+
+void test_config_family_absent_not_valid() {
+    // No `family` key — must leave familyValid false so marquee.ino's apply
+    // step leaves the persisted value (and the welcome message) alone.
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"deviceName\":\"Kitchen Clock\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_FALSE(cfg.familyValid);
+}
+
+void test_config_family_empty_string_marks_valid_with_empty_value() {
+    // Explicit "" from the server means "clear the tag". familyValid=true so
+    // the apply step in marquee.ino sees it and unsets FAMILY (vs. unset key,
+    // which leaves the persisted value alone).
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"family\":\"\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.familyValid);
+    TEST_ASSERT_EQUAL_STRING("", cfg.family.c_str());
+}
+
+void test_config_family_unknown_value_passes_through_raw() {
+    // Parser is permissive — surfaces whatever the server sent. The
+    // validation-and-warn step lives in marquee.ino (isKnownFamily +
+    // familyDisplay), tested separately by the firmware build.
+    WagFamBdayClient client("", "");
+    feed_json(client, "[{\"config\":{\"family\":\"hogwarts\"}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.familyValid);
+    TEST_ASSERT_EQUAL_STRING("hogwarts", cfg.family.c_str());
+}
+
+void test_config_family_alongside_other_fields() {
+    WagFamBdayClient client("", "");
+    feed_json(client,
+        "[{\"config\":{"
+        "\"deviceName\":\"Kitchen\","
+        "\"family\":\"butterfield\","
+        "\"eventToday\":\"1\""
+        "}}]");
+    auto cfg = client.getLastConfig();
+    TEST_ASSERT_TRUE(cfg.familyValid);
+    TEST_ASSERT_EQUAL_STRING("butterfield", cfg.family.c_str());
+    TEST_ASSERT_TRUE(cfg.deviceNameValid);
+    TEST_ASSERT_EQUAL_STRING("Kitchen", cfg.deviceName.c_str());
+    TEST_ASSERT_TRUE(cfg.eventTodayValid);
+    TEST_ASSERT_TRUE(cfg.eventToday);
+}
+
 void test_config_with_messages_both_parsed() {
     WagFamBdayClient client("", "");
     feed_json(client,
@@ -398,6 +464,12 @@ int main() {
     RUN_TEST(test_config_spa_fields_with_firmware_fields);
     RUN_TEST(test_config_device_name_parsed);
     RUN_TEST(test_config_device_name_with_other_fields);
+    RUN_TEST(test_config_family_butterfield_parsed);
+    RUN_TEST(test_config_family_wagner_parsed);
+    RUN_TEST(test_config_family_absent_not_valid);
+    RUN_TEST(test_config_family_empty_string_marks_valid_with_empty_value);
+    RUN_TEST(test_config_family_unknown_value_passes_through_raw);
+    RUN_TEST(test_config_family_alongside_other_fields);
     RUN_TEST(test_config_with_messages_both_parsed);
 
     RUN_TEST(test_get_message_negative_index_returns_empty);

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "preact/hooks";
 import { signal } from "@preact/signals";
 import { HomePage } from "./pages/HomePage";
 import { StatusPage } from "./pages/StatusPage";
@@ -5,10 +6,12 @@ import { SettingsPage } from "./pages/SettingsPage";
 import { ActionsPage } from "./pages/ActionsPage";
 import { SchedulesPage } from "./pages/SchedulesPage";
 import { Footer } from "./pages/Footer";
+import { getStatus } from "./api";
 
 type Tab = "home" | "status" | "settings" | "actions" | "schedules";
 
 const activeTab = signal<Tab>("home");
+const familyDisplay = signal<string>("");
 
 const TABS: { id: Tab; label: string }[] = [
   { id: "home", label: "Home" },
@@ -19,9 +22,25 @@ const TABS: { id: Tab; label: string }[] = [
 ];
 
 export function App() {
+  useEffect(() => {
+    // One-shot fetch on mount — the header label only changes when the
+    // server re-tags the clock, which is rare. StatusPage already polls
+    // /api/status every 30 s for everything else; the header just reads
+    // the field from a single boot-time fetch.
+    getStatus()
+      .then((s) => {
+        familyDisplay.value = s.family_display || "";
+      })
+      .catch(() => {
+        // Untagged device or unreachable — fall back to the generic title.
+      });
+  }, []);
+  const title = familyDisplay.value
+    ? `${familyDisplay.value} Family CalClock`
+    : "WagFam CalClock";
   return (
     <main class="container">
-      <h1>WagFam CalClock</h1>
+      <h1>{title}</h1>
       <nav class="tab-bar">
         {TABS.map((t) => (
           <button

--- a/webui/src/pages/StatusPage.tsx
+++ b/webui/src/pages/StatusPage.tsx
@@ -197,6 +197,9 @@ export function StatusPage() {
       {d && (
         <div class="stat-grid">
           <StatCard label="Device" value={d.device_name || d.chip_id} />
+          {d.family_display && (
+            <StatCard label="Family" value={d.family_display} />
+          )}
           <StatCard label="Version" value={d.version} />
           {d.spa_version && (
             <StatCard label="SPA Version" value={d.spa_version} />

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -19,6 +19,13 @@ export interface StatusData {
   heap_fragmentation: number;
   chip_id: string;
   device_name: string;
+  // Family tag from the wagfam-server check-in response. `family` is the
+  // lowercase wire form ("butterfield" | "wagner" | ""); `family_display`
+  // is the firmware-mapped capitalized form rendered directly by the SPA.
+  // Both optional so the SPA still renders against firmware that predates
+  // them — fields are absent rather than empty in that case.
+  family?: string;
+  family_display?: string;
   flash_size: number;
   sketch_size: number;
   free_sketch_space: number;
@@ -106,6 +113,10 @@ export interface ConfigData {
   show_highlow: boolean;
   ota_safe_url: string;
   device_name: string;
+  // Read-only — set by the server, persisted on the device. The SPA shows
+  // it but cannot change it (no PATCH path for `family` on /api/config).
+  family?: string;
+  family_display?: string;
   // Issue #95: runtime auto-update toggle. `auto_update_enabled` is the
   // user-controllable boolean (default true) shown in Settings. The
   // optional `auto_update_compile_disabled` is read-only metadata: when


### PR DESCRIPTION
## Motivation

The wagfam-server admin can now tag each clock as belonging to a family
("Butterfield" or "Wagner"). This PR is the firmware side: consume that
tag, persist it, and surface it in the bootup welcome message and the
SPA header so the device identifies its household clearly.

Sibling server-side PR: *(to be added in a follow-up comment once the
server task posts its URL)*. Both PRs implement the same contract and
should land together for a coherent rollout.

## API contract (verbatim from the coordinated task)

- Server's check-in response gets a new top-level field on the existing
  calendar JSON `config` block: `"family": "butterfield" | "wagner" | null`.
- Wire format is lowercase ASCII. Display capitalization is the
  firmware/UI's responsibility (`"butterfield"` → "Butterfield",
  `"wagner"` → "Wagner").
- If the server returns `null` or omits the field, the firmware falls
  back to the current behavior (the existing welcome message and the
  generic SPA header).

Exact JSON shape this PR parses for:

```json
[
  {
    "config": {
      "deviceName": "Kitchen Clock",
      "family": "wagner"
    }
  }
]
```

`family` lives alongside the other config fields (`deviceName`,
`latestVersion`, etc.); all keys remain optional and missing keys are
ignored. Only `"butterfield"` and `"wagner"` are accepted as known
values — anything else logs a warning and is treated as unset so a
server-side typo can't display garbled text on the matrix. The literal
empty string `""` is treated as an explicit clear (untags the clock).

## Where the family field is parsed and persisted

- **Parse**: `marquee/WagFamBdayClient.cpp` — new branch in the
  `value()` callback (sits next to `deviceName` and the existing fields).
  Surfaces the raw value into `configValues.family` / `.familyValid`
  for the caller to validate.
- **Validate + apply**: `marquee/marquee.ino` — new block in the
  `serverConfig.familyValid` apply path, right after the `deviceName`
  block. Lowercases, runs through `isKnownFamily()`, sets `FAMILY`
  global, marks needsSave.
- **Persist**: `marquee/marquee.ino` — `FAMILY=` line in both
  `savePersistentConfig()` and `readPersistentConfig()`. Defensive
  sanitization on read-back: a hand-edited `/conf.txt` with an unknown
  value is reset to "".
- **Display helper**: new `marquee/FamilyHelpers.{h,cpp}` —
  `isKnownFamily()` and `familyDisplay()` extracted so they're
  unit-testable under `tests/native/` without dragging in the firmware's
  WiFi / LittleFS / web-server globals. Same pattern as `MdnsHelpers`.

## Bootup welcome change

Before:

```cpp
scrollMessageWait(F("Welcome to the Wagner Family Calendar Clock!!!"));
```

After:

```cpp
String fam = familyDisplay(FAMILY);
if (fam.length() > 0) {
  scrollMessageWait("Welcome to the " + fam + " Family Calendar Clock!!!");
} else {
  scrollMessageWait(F("Welcome to the Wagner Family Calendar Clock!!!"));
}
```

`readPersistentConfig()` runs before the welcome scroll in `setup()`,
so a previously-tagged clock shows its family on the very first scroll
after boot. Untagged clocks (no previous check-in) show the historical
generic message.

## SPA UI change

- `webui/src/app.tsx` — the `<h1>` page title becomes
  `"<Family> Family CalClock"` when `family_display` is non-empty, or
  the legacy `"WagFam CalClock"` otherwise. One-shot fetch on mount;
  the tag rarely changes so polling for it would be wasted bandwidth.
- `webui/src/pages/StatusPage.tsx` — new `Family` stat card next to
  `Device`, only rendered when `family_display` is set.
- `webui/src/types.ts` — `family` and `family_display` added as
  optional fields on `StatusData` and `ConfigData` (optional so the
  SPA still typechecks against firmware that predates this PR).

Both fields are read-only in the SPA — there's no PATCH path for
`family` on `/api/config`. Only the server can set it.

No screenshots — the change is one line of title text and one extra
stat row, in the existing styling.

## Test coverage

- `tests/native/test_family_helpers/` — 11 cases covering
  `isKnownFamily()` + `familyDisplay()`: known values, unknown values,
  empty wire, case-sensitivity, literal "null" string.
- `tests/native/test_wagfam_parser/` — 6 new cases covering the
  parser branch: butterfield, wagner, absent (familyValid stays
  false), explicit empty string (familyValid=true with empty value
  so the caller can untag), unknown value passes through raw, family
  field alongside other config fields.

All 53 native tests pass (`pio test -e native_test`). Firmware builds
clean (`pio run -e default`), TypeScript typechecks (`make
webui-typecheck`), SPA builds (`make webui`), markdownlint clean.

### Manual repro

1. Flash this firmware to a device that has previously checked in.
2. Update the server-side check-in response to include
   `"family": "butterfield"` in the config block.
3. Trigger a calendar refresh (`POST /api/refresh` or wait for the
   next interval). Observe the serial log shows `FAMILY: 'butterfield'`
   on save.
4. Reboot the device. The welcome scroll should read
   `"Welcome to the Butterfield Family Calendar Clock!!!"`.
5. Open `/spa/`. The title bar should read
   `"Butterfield Family CalClock"`, and the Status tab should show
   a `Family` stat card with the value `Butterfield`.
6. Change the server-side value to `"family": "wagner"` and repeat
   step 3 — the page title and stat card should update on the next
   poll cycle.
7. Set `"family": "klingon"` on the server. Watch the serial log for
   `[family] WARN: unknown family value from server: 'klingon' —
   leaving as '<previous>'`. The welcome message and SPA stay on the
   prior value.

## Version

`4.5.0-wagfam` → `4.6.0-wagfam` (minor — new feature).

## Sibling coordination

This is the firmware half of a two-PR feature. The wagfam-server PR
(schema, admin UI, response payload) is being prepared in parallel.
Server PR link to be added as a follow-up comment. **Both PRs should
land together** for a coherent rollout — landing this one alone is
safe (firmware tolerates a missing `family` field) but the feature
isn't user-visible until the server starts publishing the tag.