### PR TITLE
SPA: Files tab — browse, preview, download LittleFS files

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -146,6 +146,7 @@ void handleApiFsRead(AsyncWebServerRequest *request);
 void handleApiFsWrite(AsyncWebServerRequest *request, JsonVariant &json);
 void handleApiFsDelete(AsyncWebServerRequest *request);
 void handleApiFsList(AsyncWebServerRequest *request);
+void handleApiFsRaw(AsyncWebServerRequest *request);
 void handleApiSpaUpdateFromUrl(AsyncWebServerRequest *request, JsonVariant &json);
 static void doOtaFsFlash(const String &fsUrl, const String &expectedSha256);
 // Tasmota scheduler
@@ -489,6 +490,11 @@ void setup() {
   server.on("/api/fs/read", HTTP_GET, handleApiFsRead);
   server.on("/api/fs/delete", HTTP_DELETE, handleApiFsDelete);
   server.on("/api/fs/list", HTTP_GET, handleApiFsList);
+  // Stream the raw file bytes (any size). The /read endpoint is JSON-wrapped
+  // and capped at 4KB for backwards compatibility; /raw is what the SPA Files
+  // tab uses for both viewing larger logs (Tasmota discovery, ARP dumps) and
+  // for downloading via Blob.
+  server.on("/api/fs/raw", HTTP_GET, handleApiFsRaw);
   // Tasmota scheduler — devices list, schedules CRUD, immediate-run + power
   // state probe. AsyncCallbackJsonWebHandler wires the JSON-body POSTs and
   // PUTs further below.
@@ -2484,6 +2490,24 @@ void handleApiFsList(AsyncWebServerRequest *request) {
   listFilesRecursive("/", files);
 
   sendJsonResponse(request, 200, doc);
+}
+
+// Streams the raw bytes of a file. No size cap (AsyncWebServer handles
+// chunked transfer for us via beginResponse(FS, path)). Content-Type is
+// always text/plain; the SPA detects JSON-shaped content client-side and
+// pretty-prints it, while binary files (.bin) are routed through the
+// "Download" button instead of preview.
+void handleApiFsRaw(AsyncWebServerRequest *request) {
+  String path = request->arg("path");
+  if (path == "") { sendJsonError(request, 400, "missing 'path' parameter"); return; }
+  if (!path.startsWith("/")) path = "/" + path;
+  if (path.indexOf("..") >= 0) { sendJsonError(request, 400, "invalid path"); return; }
+  if (!LittleFS.exists(path)) { sendJsonError(request, 404, "file not found"); return; }
+
+  AsyncWebServerResponse *resp =
+      request->beginResponse(LittleFS, path, "text/plain", false);
+  setCorsHeaders(request, resp);
+  request->send(resp);
 }
 
 // ── Tasmota scheduler API ───────────────────────────────────────────────────

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -72,7 +72,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.7.0"
+#define BASE_VERSION "4.8.0"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/webui/src/app.tsx
+++ b/webui/src/app.tsx
@@ -5,10 +5,11 @@ import { StatusPage } from "./pages/StatusPage";
 import { SettingsPage } from "./pages/SettingsPage";
 import { ActionsPage } from "./pages/ActionsPage";
 import { SchedulesPage } from "./pages/SchedulesPage";
+import { FilesPage } from "./pages/FilesPage";
 import { Footer } from "./pages/Footer";
 import { getStatus } from "./api";
 
-type Tab = "home" | "status" | "settings" | "actions" | "schedules";
+type Tab = "home" | "status" | "settings" | "actions" | "schedules" | "files";
 
 const activeTab = signal<Tab>("home");
 const familyDisplay = signal<string>("");
@@ -19,6 +20,7 @@ const TABS: { id: Tab; label: string }[] = [
   { id: "settings", label: "Settings" },
   { id: "actions", label: "Actions" },
   { id: "schedules", label: "Schedules" },
+  { id: "files", label: "Files" },
 ];
 
 export function App() {
@@ -59,6 +61,7 @@ export function App() {
       {activeTab.value === "settings" && <SettingsPage />}
       {activeTab.value === "actions" && <ActionsPage />}
       {activeTab.value === "schedules" && <SchedulesPage />}
+      {activeTab.value === "files" && <FilesPage />}
       <Footer />
     </main>
   );

--- a/webui/src/pages/FilesPage.tsx
+++ b/webui/src/pages/FilesPage.tsx
@@ -1,0 +1,261 @@
+// Files tab — browse + preview + download anything on LittleFS.
+//
+// The motivation is iterating on the artifacts the discovery + ARP scans
+// dump (e.g. /tasmota_discovered.json, /lan_arp.json) before deciding to
+// ship them up to the server. Endpoints used:
+//
+//   GET /api/fs/list                 — list every file with size
+//   GET /api/fs/raw?path=/X          — stream raw bytes for view + download
+//   DELETE /api/fs/delete?path=/X    — remove (refuses protected paths)
+//
+// Download is a client-side Blob trick rather than a server-side
+// Content-Disposition: keeps the firmware path simple and lets the SPA
+// own the filename derivation.
+
+import { useEffect } from "preact/hooks";
+import { signal, computed } from "@preact/signals";
+
+interface FileEntry {
+  name: string;
+  size: number;
+}
+
+const files = signal<FileEntry[]>([]);
+const selectedPath = signal<string | null>(null);
+const previewContent = signal<string>("");
+const previewError = signal<string | null>(null);
+const previewLoading = signal(false);
+const listError = signal<string | null>(null);
+const listLoading = signal(false);
+const action = signal<string | null>(null);
+
+const totalBytes = computed(() =>
+  files.value.reduce((acc, f) => acc + f.size, 0),
+);
+
+function formatSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MB`;
+}
+
+function basename(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+function isLikelyJson(path: string, content: string): boolean {
+  if (path.endsWith(".json")) return true;
+  const t = content.trimStart();
+  return t.startsWith("{") || t.startsWith("[");
+}
+
+function prettyJsonOrRaw(content: string, path: string): string {
+  if (!isLikelyJson(path, content)) return content;
+  try {
+    return JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    return content;
+  }
+}
+
+async function loadList(): Promise<void> {
+  listLoading.value = true;
+  listError.value = null;
+  try {
+    const res = await fetch("/api/fs/list");
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const json = (await res.json()) as { files: FileEntry[] };
+    // Sort by name for stable display.
+    files.value = json.files.slice().sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  } catch (e) {
+    listError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    listLoading.value = false;
+  }
+}
+
+async function loadPreview(path: string): Promise<void> {
+  selectedPath.value = path;
+  previewLoading.value = true;
+  previewError.value = null;
+  previewContent.value = "";
+  try {
+    const res = await fetch(
+      `/api/fs/raw?path=${encodeURIComponent(path)}`,
+    );
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    previewContent.value = await res.text();
+  } catch (e) {
+    previewError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    previewLoading.value = false;
+  }
+}
+
+async function downloadFile(path: string): Promise<void> {
+  action.value = `Downloading ${path}…`;
+  try {
+    const res = await fetch(
+      `/api/fs/raw?path=${encodeURIComponent(path)}`,
+    );
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = basename(path);
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    action.value = `Downloaded ${basename(path)}`;
+  } catch (e) {
+    action.value = `Download failed: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+async function deleteFile(path: string): Promise<void> {
+  if (!confirm(`Delete ${path} from LittleFS? This cannot be undone.`)) return;
+  action.value = `Deleting ${path}…`;
+  try {
+    const res = await fetch(
+      `/api/fs/delete?path=${encodeURIComponent(path)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const body = await res.text().catch(() => res.statusText);
+      throw new Error(`${res.status}: ${body}`);
+    }
+    action.value = `Deleted ${path}`;
+    if (selectedPath.value === path) {
+      selectedPath.value = null;
+      previewContent.value = "";
+    }
+    await loadList();
+  } catch (e) {
+    action.value = `Delete failed: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+export function FilesPage() {
+  useEffect(() => {
+    loadList();
+  }, []);
+
+  const sel = selectedPath.value;
+  const selFile = sel ? files.value.find((f) => f.name === sel) : undefined;
+  const displayContent = sel
+    ? prettyJsonOrRaw(previewContent.value, sel)
+    : "";
+
+  return (
+    <div class="files-page">
+      <section class="card">
+        <header class="card-header">
+          <h2>Files on LittleFS</h2>
+          <div class="card-actions">
+            <button class="btn" onClick={() => loadList()}>
+              Refresh
+            </button>
+          </div>
+        </header>
+        <p class="muted small">
+          {files.value.length} file{files.value.length === 1 ? "" : "s"},{" "}
+          {formatSize(totalBytes.value)} total
+        </p>
+        {listError.value && (
+          <p class="muted" style={{ color: "var(--red)" }}>
+            {listError.value}
+          </p>
+        )}
+        {listLoading.value && <p class="muted">Loading…</p>}
+        <table class="net-table">
+          <thead>
+            <tr>
+              <th style={{ width: "60%" }}>Path</th>
+              <th style={{ width: "20%" }}>Size</th>
+              <th style={{ width: "20%" }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {files.value.map((f) => (
+              <tr
+                key={f.name}
+                class={selectedPath.value === f.name ? "row-muted" : ""}
+              >
+                <td>
+                  <button
+                    class="btn"
+                    style={{
+                      padding: 0,
+                      background: "transparent",
+                      color: "var(--link, #4ea1ff)",
+                      textDecoration: "underline",
+                    }}
+                    onClick={() => loadPreview(f.name)}
+                  >
+                    {f.name}
+                  </button>
+                </td>
+                <td>{formatSize(f.size)}</td>
+                <td style={{ display: "flex", gap: "0.4rem" }}>
+                  <button
+                    class="btn"
+                    onClick={() => downloadFile(f.name)}
+                    title="Download to your computer"
+                  >
+                    download
+                  </button>
+                  <button
+                    class="btn btn-danger"
+                    onClick={() => deleteFile(f.name)}
+                  >
+                    delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {action.value && <p class="muted small">{action.value}</p>}
+      </section>
+
+      {sel && (
+        <section class="card">
+          <header class="card-header">
+            <h2>Preview: {sel}</h2>
+            <div class="card-actions">
+              <button class="btn" onClick={() => downloadFile(sel)}>
+                Download
+              </button>
+              <button
+                class="btn"
+                onClick={() => {
+                  selectedPath.value = null;
+                  previewContent.value = "";
+                }}
+              >
+                Close
+              </button>
+            </div>
+          </header>
+          {selFile && (
+            <p class="muted small">{formatSize(selFile.size)}</p>
+          )}
+          {previewLoading.value && <p class="muted">Loading…</p>}
+          {previewError.value && (
+            <p class="muted" style={{ color: "var(--red)" }}>
+              {previewError.value}
+            </p>
+          )}
+          {!previewLoading.value && !previewError.value && (
+            <pre class="files-preview">{displayContent}</pre>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -615,3 +615,19 @@ input[type="checkbox"].toggle:checked::after {
   font-family: ui-monospace, monospace;
   font-size: 0.8rem;
 }
+
+/* Files tab — full-width JSON/text preview. The pre block sits inside a
+   .card and needs to wrap long lines (e.g. minified JSON) instead of
+   producing a horizontal scrollbar that hides the right-hand columns. */
+.files-page { display: flex; flex-direction: column; gap: 1rem; }
+.files-preview {
+  max-height: 60vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: color-mix(in srgb, var(--muted) 6%, transparent);
+  padding: 0.75rem;
+  border-radius: 4px;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
Adds a new "Files" tab to the SPA so we can browse, preview, and download anything on LittleFS — primarily for iterating on `/tasmota_discovered.json` and `/lan_arp.json` (added by #116 and #118) before deciding whether to ship those artifacts up to the server.

## What it adds

**Firmware** — one new endpoint:

- `GET /api/fs/raw?path=/X` — streams the file's raw bytes via `beginResponse(LittleFS, path, "text/plain", false)`. No 4 KB cap like the existing `/api/fs/read` (that JSON-wraps the content). Used by the SPA for both preview and download; download is a client-side `Blob` trick rather than a `Content-Disposition: attachment` header, which keeps the firmware path simple and lets the SPA own the filename.

Path validation: must start with `/`, no `..` segments, must exist. Already-existing `/api/fs/delete` validation rejects writes to `/conf.txt` and `/ota_pending.txt`; this endpoint is read-only so no new protected-path logic is needed.

**SPA** — `webui/src/pages/FilesPage.tsx`:

- Listing card: every file with size, paginated table (currently 10 files, ~99 KB total on my test clock — well under any browser limit).
- Per-row Download + Delete buttons (delete confirms first).
- Click a path → preview card opens below. Pretty-prints JSON (`.json` suffix OR content starts with `{`/`[`) via `JSON.stringify(..., null, 2)`. Falls back to raw text otherwise.
- Preview card has its own Download + Close buttons.

## Validated on live hardware

OTA-flashed both halves to my d1_mini (`192.168.168.66`); ran a Playwright smoke test (`/tmp/pw_files_tab.py`) + visual check:

- Files tab appears in tab bar
- Table renders all 10 files (`/conf.txt`, `/lan_arp.json`, `/tasmota_discovered.json`, the `/spa/*` bundle assets, `/spa/version.json`)
- Clicking `/lan_arp.json` opens preview with 4977 chars of pretty-printed JSON (the 63-entry ARP dump from #118)
- Download triggers a browser save with `lan_arp.json` as the filename
- Delete with confirm-dialog works
- Close button collapses the preview pane

Visual evidence: screenshot at `/tmp/pw_files/03-arp-preview.png`.

## Size

- RAM: 56.2% → ~57%
- Flash: 61.1% → 61.3% (a few hundred bytes for the new handler + path validation)

The SPA bundle gains ~3 KB of compiled JS for the page itself (negligible against the ~22 KB gzip total).

## Test plan
- [ ] CI green
- [ ] Open `/spa/`, click Files, see the LittleFS contents
- [ ] Click a JSON file, see it pretty-printed
- [ ] Click Download, get the raw file
- [ ] Confirm `/conf.txt` is listed but `Delete /conf.txt` is rejected (the firmware-side `isProtectedPath` check still applies via `/api/fs/delete`)