### PR TITLE
Persist timezone across reboots; gate setter on valid weather (#121)

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -72,7 +72,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.8.0"
+#define BASE_VERSION "4.8.1"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -1427,12 +1427,17 @@ void getWeatherData() //client function to send/receive GET request data.
   weatherClient.updateWeather();
   if (weatherClient.getErrorMessage() != "") {
     scrollMessageWait(weatherClient.getErrorMessage());
-  } else {
-    // Set current timezone (adapts to DST when region supports that)
-    // when time was potentially changed, stop quick auto sync
+  } else if (weatherClient.getWeatherDataValid()) {
+    // Issue #121: only push the timezone into NTP when the OWM response was
+    // actually valid. A failed fetch must not clobber the previously-good
+    // offset — otherwise the clock drifts to UTC until the next success.
     if (set_timeZoneSec(weatherClient.getTimeZoneSeconds())) {
       // Stop automatic NTP sync and do it explicitly below
       setSyncProvider(NULL);
+      // Persist so the offset survives reboots; without this, every power
+      // cycle restarts at UTC and the device shows the wrong time until OWM
+      // succeeds again.
+      savePersistentConfig();
     }
   }
   lastRefreshDataTimestamp = now();
@@ -1842,6 +1847,7 @@ void savePersistentConfig() {
     f.println("FAMILY=" + FAMILY);
     f.println("LAST_APPLIED_CONFIG_VERSION=" + String(lastAppliedConfigVersion));
     f.println("AUTO_UPDATE_ENABLED=" + String(AUTO_UPDATE_ENABLED ? 1 : 0));
+    f.println("TIMEZONE_SEC=" + String(get_timeZoneSec()));
   }
   f.close();
   // Apply current settings to hardware and clients directly.
@@ -1959,6 +1965,12 @@ void readPersistentConfig() {
     } else if (key == "AUTO_UPDATE_ENABLED") {
       AUTO_UPDATE_ENABLED = value.toInt() != 0;
       Serial.println("AUTO_UPDATE_ENABLED=" + String(AUTO_UPDATE_ENABLED ? 1 : 0));
+    } else if (key == "TIMEZONE_SEC") {
+      // Issue #121: restore the last-known timezone offset so NTP syncs
+      // before the first successful OWM fetch land on the user's local
+      // wall clock instead of UTC.
+      set_timeZoneSec(value.toInt());
+      Serial.println("TIMEZONE_SEC=" + String(value.toInt()));
     }
   }
   fr.close();

--- a/marquee/timeNTP.cpp
+++ b/marquee/timeNTP.cpp
@@ -64,6 +64,11 @@ bool set_timeZoneSec(int timeZoneSeconds)
   return timechange;
 }
 
+int get_timeZoneSec()
+{
+  return timeZoneSec;
+}
+
 /*-------- NTP code ----------*/
 
 const int NTP_PACKET_SIZE = 48; // NTP time is in the first 48 bytes of message

--- a/marquee/timeNTP.h
+++ b/marquee/timeNTP.h
@@ -11,4 +11,5 @@
 
 void timeNTPsetup();
 bool set_timeZoneSec(int timeZoneSeconds);
+int get_timeZoneSec();
 time_t getNtpTime();


### PR DESCRIPTION
Fixes #121.

## Symptom

> Currently whenever a weather data call fails on the clock it forgets its time zone and starts displaying the wrong time zone

> adjust this so that a failed Weather data pull does not override the time zone but just simply doesn't display weather related information since it would otherwise be stale.

## Root cause

`timeZoneSec` lived only in RAM (`marquee/timeNTP.cpp:26`, initialized to `0` = UTC) and was set exclusively from a successful OpenWeatherMap fetch at `marquee/marquee.ino:1433`. Two failure modes follow:

1. **Reboot then failed OWM fetch (primary).** After any reboot — power cycle, OTA, watchdog reset — `timeZoneSec` is back at 0. NTP syncs immediately via `getNtpTime()` (`marquee/timeNTP.cpp:97`), which adds `timeZoneSec` (= 0) to the NTP epoch, so the clock starts in UTC. If the post-boot weather fetch fails (slow Wi-Fi association, OWM 5xx, expired key) the clock keeps displaying UTC until OWM next succeeds — up to `minutesBetweenDataRefresh` minutes later. To the user this looks like the device "forgetting" its zone.
2. **OWM 200-OK with missing `timezone` field (defensive).** The current call site only checks `getErrorMessage() != \"\"`. If OWM ever returned a 200 with a body that parses but lacks `timezone`, `jdoc[\"timezone\"]` would yield 0 and `set_timeZoneSec(0)` would clobber a previously-good offset.

## Fix

- Add a `TIMEZONE_SEC=` line to `/conf.txt` via `savePersistentConfig()` / `readPersistentConfig()`.
- Restore the offset on boot in `readPersistentConfig()` so NTP sync lands on the user's wall clock before OWM is reached.
- Save the offset in `getWeatherData()` only when `set_timeZoneSec()` reports an actual change (typically once after first success, plus DST transitions) — bounds flash wear.
- Tighten the gate at the call site: change `else` to `else if (weatherClient.getWeatherDataValid())`. Eliminates failure mode #2.
- Expose `get_timeZoneSec()` in `timeNTP.h` so the persistence code doesn't poke the global directly.

## Files changed

- `marquee/timeNTP.h`, `marquee/timeNTP.cpp` — new `get_timeZoneSec()` accessor.
- `marquee/marquee.ino` — gate the `set_timeZoneSec` call, persist on change, read on boot.

## Verification

- \`pio run -e dev\` — builds clean (Flash 61.2%, RAM 56.4%).
- \`pio test -e native_test\` — 155/155 tests pass (no regressions).

### Manual on-device repro (issue's described scenario)

1. Flash device, configure WiFi + OWM key + a non-UTC location. Wait for a successful weather pull; verify the clock shows local time.
2. Reboot the device (power cycle is fine).
3. **Before** this fix: the clock shows UTC until the first post-boot OWM success. If the OWM key is removed or the upstream is unreachable, it never recovers.
4. **After** this fix: the clock shows local time immediately on boot, because `TIMEZONE_SEC` was persisted. A failed OWM fetch leaves the offset alone.

### Manual stale-state repro (defensive gate)

1. Confirm `/api/config` returns `display_intensity` etc. as expected.
2. Temporarily invalidate the OWM key so fetches return 401. Reboot. Observe local time displays (from persisted offset). Restore key.

## Diagnosis process

Per the issue brief, I used three subagents:

- **A (issue context):** confirmed the symptom and requested behavior, no prior comments/refs.
- **B (code trace):** walked `getWeatherData()` → `updateWeather()` → `set_timeZoneSec()` → `getNtpTime()`. Confirmed the only writer to `timeZoneSec` is the post-OWM path and that the value is not persisted anywhere.
- **C (recent-change context):** the timezone-from-OWM pattern has been in place since 2019 (commits 355e32b, e7bcbfd). Not a recent regression — a longstanding gap that becomes user-visible whenever a boot is followed by a failed OWM call.