### PR TITLE
Fix event-day border bottom-row erasure after custom-font scroll

### DIFF
--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -2008,6 +2008,16 @@ static void scrollMessageWaitCustomFont(const String &msg, const ScrollerFont &s
   }
 
   matrix.setFont();  // restore builtin for the clock face
+  // Restore the default "transparent background" text mode (textcolor ==
+  // textbgcolor). Adafruit_GFX's drawChar paints every pixel of the 5x8 cell
+  // — including the bottom row of the GLCD glyph, which is almost always
+  // OFF — when textbgcolor differs from textcolor. Leaving the (HIGH, LOW)
+  // pair set above corrupts later clock-face frames: the event-day border
+  // draws row 7 (bottom edge) FIRST and the centered "HH:MM" then erases
+  // every column it covers in row 7 — issue #113, where only the left and
+  // right sides of the animated border remained visible until reboot.
+  matrix.setTextColor(HIGH);
+  matrix.setTextWrap(true);
 }
 
 void scrollMessageWait(const String &msg) {


### PR DESCRIPTION
## Summary

Fixes #113 — after playing with scroller font settings on v4.4.1, the
birthday event-day animation showed only on the left/right edges of the
display, not along the bottom. A power cycle made it go away.

## Root cause

`scrollMessageWaitCustomFont` (`marquee/marquee.ino:1978`) sets:

```cpp
matrix.setFont(sf.font);
matrix.setTextWrap(false);
matrix.setTextColor(HIGH, LOW);
```

but only restores `setFont()` on exit. Text color and wrap state persist
for the rest of the boot.

When `textcolor != textbgcolor`, Adafruit_GFX's builtin-font `drawChar`
paints every pixel of the 5x8 GLCD cell — including the (almost always
OFF) row 7. The clock face draws the event-day border first (animated dots
on the left, bottom, and right edges) and then prints `HH:MM` at
`setCursor(x, 0)`. With the leaked `(HIGH, LOW)` pair, every column the
centered time string covers — cols 1-5, 7-11, 13-17, 19-23, 25-29 —
gets forced LOW in row 7, erasing the bottom dots. Side dots at col 0 and
col 31 survive, exactly matching the screenshot in #113. Power cycle
resets the Adafruit_GFX defaults (`textcolor == textbgcolor`, transparent
background mode), so the corruption stays gone until the next custom-font
scroll.

## Fix

Restore `setTextColor(HIGH)` (single-arg form sets color == bgcolor) and
`setTextWrap(true)` symmetrically with the existing `setFont()` restore,
at the end of `scrollMessageWaitCustomFont`. Two lines plus an inline
comment explaining the invariant.

## Test plan

- [x] `make test-native` — 155/155 pass
- [x] `make build` — 640621 / 1044464 bytes flash, no regressions
- [ ] Flash to a clock, set a non-Classic scroller font (e.g. Tall),
      wait for a marquee scroll, set `WAGFAM_EVENT_TODAY=1`, and confirm
      the bottom border row of the dotted animation now renders
- [ ] Repeat with the Classic scroller font (id 0) — control case where
      `scrollMessageWaitCustomFont` is never invoked

No regression test added: `tests/native/` has no Adafruit_GFX stub, and per
CLAUDE.md ("Never write source-reading tests") simulating the GFX state
machine to assert this contract would be heavy infrastructure for one
assertion. The commit message documents the invariant.

Fixes #113