### PR TITLE
Device enrollment mode: self-register against wagfam-server (#125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ All firmware source lives in [marquee/](marquee/):
 | [Settings.h](marquee/Settings.h) | Hardware pin config + all `#include` directives; default values for first-run only |
 | [OpenWeatherMapClient.h/.cpp](marquee/OpenWeatherMapClient.h) | Fetches weather from OpenWeatherMap API using ArduinoJson |
 | [WagFamBdayClient.h/.cpp](marquee/WagFamBdayClient.h) | Fetches family calendar JSON over HTTPS; parses messages and remote config |
+| [EnrollmentClient.h/.cpp](marquee/EnrollmentClient.h) | Device self-enrollment client — polls wagfam-server `/api/v1/enroll`, parses the response, surfaces the signed config bundle (issue #125). `parse()` is pure so it's testable under tests/native/ |
 | [SecurityHelpers.h/.cpp](marquee/SecurityHelpers.h) | Firmware URL validation, path protection, domain extraction |
 | [MdnsHelpers.h/.cpp](marquee/MdnsHelpers.h) | DNS-safe hostname sanitization for mDNS bringup (extracted so it's testable under tests/native/) |
 | [timeNTP.h/.cpp](marquee/timeNTP.h) | NTP time sync; exposes `timeNTPsetup()`, `getNtpTime()`, and `set_timeZoneSec()` |
@@ -93,7 +94,9 @@ changes there require a filesystem erase to take effect.
 
 `WAGFAM_EVENT_TODAY` and `DEVICE_NAME` are not user-configurable via the web form — they are set
 exclusively by the server's `config.eventToday` and `config.deviceName` fields in the calendar
-JSON response and persisted across reboots via `/conf.txt`.
+JSON response and persisted across reboots via `/conf.txt`. `ENROLLMENT_SECRET` and
+`ENROLLMENT_CODE` are likewise server-minted (during device enrollment, see below) and not
+user-editable — `ENROLLMENT_SECRET` is proof-of-possession and is never echoed back over the API.
 
 ### Adding a New Config Key
 
@@ -413,6 +416,38 @@ out-of-band if the parameter set changes or the calendar URL moves to a differen
 static-JSON host. The corresponding regression test was removed because the CDN
 returned race-flaky results when the target file was being updated; see the
 "Back assertions about external services" rule above for the policy.
+
+## Device Enrollment (issue #125)
+
+A factory-fresh clock with no `WAGFAM_API_KEY` self-registers against the
+wagfam-server instead of needing hand configuration. Companion to
+[wagfam-server#62](https://github.com/jrwagz/wagfam-server/issues/62).
+
+- **Trigger.** Decided once at the end of `setup()`: `enrollmentMode` is set
+  true when `WAGFAM_ENROLL_URL` is non-empty (a build flag, see `Settings.h` +
+  `platformio.ini`) **and** `WAGFAM_API_KEY` is empty. A build without the flag
+  never enrolls.
+- **Loop.** `loop()` branches to `runEnrollmentLoop()` right after
+  `MDNS.update()` and returns — the normal clock, Tasmota, and weather paths
+  are all skipped. mDNS and the async web server stay live, so the device is
+  still reachable. The clock face is **not** shown in this mode; the LED
+  scrolls `Setup Code: <code>` (or `Enrolling...` before the first response).
+- **Polling.** `EnrollmentClient::poll()` GETs `WAGFAM_ENROLL_URL` every
+  ~15 s over HTTPS with `setInsecure()` (same posture as `WagFamBdayClient` —
+  the bundle's ECDSA signature, not TLS, is the integrity guarantee). The
+  response parser `EnrollmentClient::parse()` is pure and unit-tested under
+  `tests/native/test_enrollment/`.
+- **Authorized bundle.** An `authorized` response carries a
+  `configUpdateVersion`/`Payload`/`Signature` triple — the **same shape as the
+  calendar config-update** (issue #99). `applyEnrollmentBundle()` reuses
+  `verifyConfigUpdateSignature()` + `applyConfigJson()` + the monotonic
+  `lastAppliedConfigVersion` guard verbatim, then `ESP.restart()`s into normal
+  operation.
+- **Escape hatch.** `runEnrollmentLoop()` re-checks `WAGFAM_API_KEY` each
+  iteration; setting it by hand via the SPA exits enrollment (reboot).
+- `ENROLLMENT_SECRET` (proof-of-possession) and `ENROLLMENT_CODE` are persisted
+  to `/conf.txt`. Any response carrying `enrollment_secret` overwrites the
+  stored one — that is the recovery path after a server-side enrollment reset.
 
 ## OTA Update Architecture
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ Once connected to WiFi, the device displays its IP address. Open
 `http://<ip>/spa/` in a browser to access the web interface (`http://<ip>/`
 also works — it 302-redirects to `/spa/`).
 
+### Device enrollment
+
+A factory-fresh clock (no calendar API key stored) self-registers against the
+wagfam-server after WiFi connects — it does **not** need to be configured by
+hand. The clock polls the server's enrollment endpoint every ~15 seconds and
+scrolls a short **setup code** (`Setup Code: ABC234`) on the LED. An admin
+matches that code to the pending device in the wagfam-server admin UI and
+authorizes it; the server then hands back a signed config bundle (calendar
+URL, auth key, name, display settings), the clock applies it and reboots into
+normal operation. See [issue #125](https://github.com/jrwagz/marquee-scroller/issues/125)
+and [wagfam-server#62](https://github.com/jrwagz/wagfam-server/issues/62).
+
+The enrollment endpoint is baked in at build time via the `WAGFAM_ENROLL_URL`
+flag (`platformio.ini`); a build without that flag skips enrollment and runs as
+a normal clock. While a clock waits to be authorized you can still configure it
+by hand on the SPA **Settings** tab — entering a calendar API key there exits
+enrollment mode.
+
 ## Configuration
 
 All settings are managed through the web interface and persisted to the device filesystem.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,7 @@ marquee-scroller/
 │   ├── Settings.h              # Pin config + #include directives + compile-time defaults
 │   ├── OpenWeatherMapClient.h/.cpp  # Weather fetching + JSON parsing
 │   ├── WagFamBdayClient.h/.cpp      # Calendar/birthday fetching + streaming JSON parse
+│   ├── EnrollmentClient.h/.cpp      # Device self-enrollment client (issue #125)
 │   ├── SecurityHelpers.h/.cpp       # Firmware URL validation, path protection
 │   ├── timeNTP.h/.cpp               # NTP time sync
 │   └── timeStr.h/.cpp               # Time formatting helpers
@@ -186,6 +187,24 @@ whole document in RAM.
 Stores up to 10 display messages. Also parses an optional `config` block that can push
 remote config updates back to the device.
 
+Also exposes `buildHeartbeatQuery(DeviceInfo)` as a header-only inline (issue #125) — a
+shared helper that constructs the device-telemetry query string appended to both the
+calendar URL and the enrollment poll URL.
+
+### `EnrollmentClient` — Device Self-Registration
+
+Polls `GET WAGFAM_ENROLL_URL` over HTTPS while the device is in enrollment mode (no
+`WAGFAM_API_KEY` configured). The server returns a `status` of `"pending"` or
+`"authorized"`, plus `enrollment_code` (shown on the LED for an admin to match) and —
+after authorization — a signed `configUpdateVersion`/`Payload`/`Signature` bundle in the
+same format as the calendar config-update (issue #99).
+
+Implements `JsonListener` with depth-tracking (via `objectDepth_`/`configDepth_`) so
+bundle fields are accepted only as direct children of the top-level `"config"` object.
+`parse()` is pure (no network, no globals) and unit-tested under
+`tests/native/test_enrollment/`. The HTTPS poll uses `setInsecure()` + reduced BearSSL
+buffer sizes to conserve heap during the enrollment phase.
+
 ### `SecurityHelpers.h/.cpp` — Security Utilities
 
 Extracted from `marquee.ino` to enable unit testing. Provides:
@@ -235,6 +254,9 @@ All runtime state lives as global variables in `marquee.ino`. The most important
 | `WAGFAM_API_KEY` | `String` | Bearer token for calendar endpoint |
 | `WAGFAM_EVENT_TODAY` | `boolean` | Drives the animated event-day border |
 | `DEVICE_NAME` | `String` | Human-friendly name assigned by server |
+| `ENROLLMENT_SECRET` | `String` | Per-device proof-of-possession minted by the server (never echoed over API) |
+| `ENROLLMENT_CODE` | `String` | Short human code shown on the LED during enrollment (e.g. `"K7M2QP"`) |
+| `enrollmentMode` | `bool` | True when the device has no API key and is self-registering; set once at end of `setup()` |
 | `geoLocation` | `String` | Weather location (city ID, lat/lon, or name) |
 | `IS_METRIC` | `boolean` | Unit system toggle |
 | `IS_24HOUR` | `boolean` | 12h vs 24h clock |
@@ -272,6 +294,8 @@ Format: one `key=value` pair per line, terminated with `\n`.
 WAGFAM_DATA_URL=https://example.com/family.json
 WAGFAM_API_KEY=ghp_xxxxx
 WAGFAM_EVENT_TODAY=0
+ENROLLMENT_SECRET=a1b2c3d4e5f6
+ENROLLMENT_CODE=K7M2QP
 APIKEY=abc123openweather
 CityID=Chicago,US
 ledIntensity=4
@@ -301,6 +325,13 @@ then calls `readPersistentConfig()` to re-apply the new values.
 web form**. They are only set by the calendar server's `config.eventToday` and
 `config.deviceName` fields, then persisted so they survive reboots.
 
+**`ENROLLMENT_SECRET`** and **`ENROLLMENT_CODE`** are likewise server-minted and not
+user-editable. They are written by `pollEnrollmentOnce()` when the server's enrollment
+response carries new values, and are cleared only if the enrollment endpoint resets them.
+`ENROLLMENT_SECRET` is the per-device proof-of-possession — it is accepted from the
+server response but **never returned** through `GET /api/status` (only `has_secret: true`
+is reported).
+
 ---
 
 ## Data Flow: Weather + Calendar
@@ -322,7 +353,8 @@ getWeatherData()
 │   └── Returns adjusted Unix time
 ├── setTime(t)                             → Updates TimeLib clock
 ├── bdayClient.updateData(devInfo)          → HTTPS GET to WAGFAM_DATA_URL
-│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi=&utc_offset_sec= (heartbeat)
+│   └── Appends heartbeat params via buildHeartbeatQuery():
+│       chip_id, version, uptime, heap, rssi, utc_offset_sec, lan_ip, mdns_name
 │   └── Streams JSON through parser
 │   └── Fills messages[0..9]
 │   └── Returns configValues (remote config)
@@ -391,11 +423,13 @@ spacer = 6 pixels total. This is the `width` variable; `scrollMessageWait` uses 
 compute how many scroll steps are needed for a given message in the default path.
 
 The marquee scroll font is selectable per device via the `display_font` config (issue #106).
-Five fonts are registered in `SCROLLER_FONTS[]` near the top of `marquee.ino`: Classic
-(default), Block (custom 5×7 from `marquee/WagfamFont.h`), Org, Picopixel, TomThumb.
-Non-default fonts go through `scrollMessageWaitCustomFont()`, which uses Adafruit_GFX's
-variable-width path (`setFont` + `setCursor` + `print`) and re-renders the whole message
-each frame. The clock face always uses Classic regardless of selection.
+Fifteen fonts are registered in `SCROLLER_FONTS[]` near the top of `marquee.ino`: five short
+fonts (Classic, Block, Org, Picopixel, TomThumb), five full-height hand-designed fonts (Tall,
+Bold, Slim, Outline, Digi), and five full-height stylistic variants derived from Tall (Italic,
+Serif, Pixel, Inverse, Stencil). Custom glyphs live in `marquee/WagfamFont.h`. Non-default
+fonts go through `scrollMessageWaitCustomFont()`, which uses Adafruit_GFX's variable-width
+path (`setFont` + `setCursor` + `print`) and re-renders the whole message each frame. The
+clock face always uses Classic regardless of selection.
 
 ---
 

--- a/docs/CODE_FLOW.md
+++ b/docs/CODE_FLOW.md
@@ -73,11 +73,19 @@ setup()
 │
 ├── timeNTPsetup()                   // Open UDP socket, set 20s sync interval
 │
+├── if WAGFAM_ENROLL_URL non-empty AND WAGFAM_API_KEY empty:
+│   └── enrollmentMode = true        // Enter enrollment mode (issue #125)
+│       └── loop() will call runEnrollmentLoop() instead of the normal clock
+│
 └── flashLED(1, 500)                 // Blink status LED once
 ```
 
 **After `setup()` completes**, the device is on WiFi, serving HTTP, and ready.
 Time is not yet synced (NTP first sync happens on the first `getWeatherData()` call).
+
+When `enrollmentMode` is true the device skips the clock, Tasmota, and weather
+paths in `loop()` and instead runs the enrollment polling loop — see
+[Main Loop](#main-loop-loop) below.
 
 ---
 
@@ -90,6 +98,14 @@ when not scrolling).
 
 ```text
 loop()
+│
+├── MDNS.update()                    // Pump mDNS (always, even in enrollment mode)
+│
+├── if enrollmentMode:               // Issue #125 — no calendar API key
+│   ├── runEnrollmentLoop()          // Poll server, scroll setup code, apply bundle
+│   └── return                       // Normal clock, Tasmota, weather all skipped
+│
+├── TasmotaDiscovery::tick()
 │
 ├── if second() changed → processEverySecond()
 │
@@ -106,7 +122,14 @@ loop()
 (The web server is `AsyncWebServer`; HTTP requests are handled in the background
 via TCP callbacks, so `server.handleClient()` is *not* called from `loop()`.)
 
-The display is **redrawn every loop iteration**. `matrix.write()` (inside `centerPrint`)
+When `enrollmentMode` is true the clock does **not** show the time; `runEnrollmentLoop()`
+scrolls `Setup Code: <code>` (or `Enrolling...` before the first server response) on the
+LED. mDNS and the async web server stay live, so the SPA is still accessible. The device
+exits this mode only by `ESP.restart()` — either after a successful authorized bundle
+(which saves the API key and reboots) or when a calendar API key is set manually via the
+SPA Settings tab.
+
+The display is **redrawn every loop iteration** in normal mode. `matrix.write()` (inside `centerPrint`)
 does a full SPI transfer on every frame. This is fast on ESP8266 but could be optimized
 to only redraw when the content actually changes.
 
@@ -206,7 +229,8 @@ getWeatherData()
 ├── Update firstTimeSync if this is first successful sync
 │
 ├── bdayClient.updateData(devInfo)    // HTTPS GET to WAGFAM_DATA_URL
-│   └── Appends ?chip_id=&version=&uptime=&heap=&rssi= (heartbeat)
+│   └── Appends heartbeat params via buildHeartbeatQuery():
+│       chip_id, version, uptime, heap, rssi, utc_offset_sec, lan_ip, mdns_name
 │   └── Streams JSON through streaming parser
 │   └── Fills messages[] and returns configValues
 │
@@ -480,6 +504,6 @@ transitions are handled automatically after the next weather refresh.
 | `marquee.ino:95–189` | All global settings variables (APIKEY, geoLocation, IS_*, SHOW_*, security, OTA) |
 | `marquee.ino:133–179` | All PROGMEM HTML string constants |
 | `Settings.h` | Library includes and compile-time hardware defaults |
-| `WagFamBdayClient.h:31–37` | `DeviceInfo` struct (heartbeat telemetry) |
-| `WagFamBdayClient.h:42–55` | `configValues` struct returned by `updateData()` |
+| `WagFamBdayClient.h` | `DeviceInfo` struct (heartbeat telemetry) + `buildHeartbeatQuery()` inline |
+| `WagFamBdayClient.h` | `configValues` struct returned by `updateData()` |
 | `OpenWeatherMapClient.h:31–55` | `weather` struct (all weather fields) |

--- a/marquee/EnrollmentClient.cpp
+++ b/marquee/EnrollmentClient.cpp
@@ -1,0 +1,190 @@
+#include "EnrollmentClient.h"
+
+#include <memory>
+#include <ESP8266WiFi.h>
+#include <ESP8266HTTPClient.h>
+#include <WiFiClientSecureBearSSL.h>
+#include <JsonStreamingParser.h>
+
+// Cap on the response body we will buffer. An authorized bundle is ~600 bytes
+// (a short JSON payload + a base64 signature); 2 KB is comfortable headroom
+// and bounds heap use if a misbehaving server streams without a Content-Length.
+static const size_t ENROLL_MAX_BODY = 2048;
+
+// Wall-clock ceiling on reading the response, so a stalled connection can't
+// wedge the enrollment loop.
+static const uint32_t ENROLL_READ_TIMEOUT_MS = 10000;
+
+// ── JSON parsing ─────────────────────────────────────────────────────────────
+//
+// The parser classifies a field by its position in the document, tracked via
+// objectDepth_ / arrayDepth_ / configDepth_:
+//   - top-level fields (status, enrollment_secret, enrollment_code) are read
+//     only at objectDepth_ == 1, outside any array;
+//   - bundle fields (configUpdate*) are read only as direct children of the
+//     "config" object (objectDepth_ == configDepth_).
+// A boolean "in config" flag is not enough — JSON nesting the firmware does
+// not control (an object inside "config", a stray "config" key elsewhere)
+// could otherwise relocate a trust-sensitive field across the boundary.
+
+void EnrollmentClient::startObject() {
+  objectDepth_++;
+  // The "config" object's direct children sit one level below its key. Record
+  // that depth (only for a top-level "config" key) so bundle fields are picked
+  // up there and nowhere else.
+  if (configDepth_ == -1 && arrayDepth_ == 0 && objectDepth_ == 2 &&
+      currentKey_ == "config") {
+    configDepth_ = objectDepth_;
+  }
+  currentKey_ = "";
+}
+
+void EnrollmentClient::endObject() {
+  // Closing the "config" object (or anything shallower) leaves config scope.
+  if (configDepth_ != -1 && objectDepth_ <= configDepth_) {
+    configDepth_ = -1;
+  }
+  objectDepth_--;
+  currentKey_ = "";
+}
+
+void EnrollmentClient::startArray() {
+  arrayDepth_++;
+}
+
+void EnrollmentClient::endArray() {
+  arrayDepth_--;
+  currentKey_ = "";
+}
+
+void EnrollmentClient::key(String key) {
+  currentKey_ = key;
+}
+
+void EnrollmentClient::value(String value) {
+  // The enrollment schema has no arrays — values inside one are never ours.
+  if (arrayDepth_ > 0) {
+    return;
+  }
+  if (configDepth_ != -1 && objectDepth_ == configDepth_) {
+    // Direct child of "config" — the signed bundle.
+    if (currentKey_ == "configUpdateVersion") {
+      result_.configUpdateVersion = value.toInt();
+    } else if (currentKey_ == "configUpdatePayload") {
+      result_.configUpdatePayload = value;
+    } else if (currentKey_ == "configUpdateSignature") {
+      result_.configUpdateSignature = value;
+    }
+  } else if (objectDepth_ == 1) {
+    // Top-level classification fields.
+    if (currentKey_ == "status") {
+      result_.status = value;
+    } else if (currentKey_ == "enrollment_secret") {
+      result_.secret = value;
+    } else if (currentKey_ == "enrollment_code") {
+      result_.code = value;
+    }
+  }
+  currentKey_ = "";
+}
+
+void EnrollmentClient::endDocument() {
+  // A response is usable only if it carried a status the firmware acts on.
+  result_.ok = (result_.status == "pending" || result_.status == "authorized");
+}
+
+EnrollmentClient::Result EnrollmentClient::parse(const String &body) {
+  EnrollmentClient listener;
+  JsonStreamingParser parser;
+  parser.setListener(&listener);
+  parser.reset();
+  for (unsigned int i = 0; i < body.length(); i++) {
+    parser.parse(body[i]);
+  }
+  return listener.result_;
+}
+
+// ── HTTPS poll ───────────────────────────────────────────────────────────────
+
+EnrollmentClient::Result EnrollmentClient::poll(const String &enrollUrl,
+                                                const DeviceInfo &device,
+                                                const String &secret) {
+  Result failure; // ok == false
+
+  if (enrollUrl.length() == 0) {
+    Serial.println(F("[ENROLL] no enrollment URL configured"));
+    return failure;
+  }
+
+  std::unique_ptr<BearSSL::WiFiClientSecure> client(new BearSSL::WiFiClientSecure);
+  // Issue #125: setInsecure() — consistent with WagFamBdayClient. The config
+  // bundle is ECDSA-signed and verified against the embedded public key, so a
+  // MITM cannot forge it. The one-time enrollment secret is the only thing
+  // protected by transport alone — a documented, accepted residual risk.
+  client->setInsecure();
+  // Reduce the TLS record buffers from the 16 KB default; the enrollment
+  // payload is tiny. Saves ~12-19 KB of heap per poll.
+  client->setBufferSizes(2048, 512);
+
+  // Build the URL: the shared heartbeat telemetry (so the admin sees live data
+  // on the pending device) plus the secret once we have one.
+  String url;
+  url.reserve(enrollUrl.length() + 220);
+  url = enrollUrl;
+  url += (url.indexOf('?') >= 0) ? '&' : '?';
+  url += buildHeartbeatQuery(device);
+  if (secret.length() > 0) {
+    // The server mints the secret with secrets.token_hex() — hex is URL-safe,
+    // so no percent-encoding is needed (see wagfam-server#62).
+    url += "&secret=";
+    url += secret;
+  }
+
+  HTTPClient https;
+  if (!https.begin(*client, url)) {
+    Serial.println(F("[ENROLL] HTTPS begin failed"));
+    return failure;
+  }
+
+  int httpCode = https.GET();
+  if (httpCode != HTTP_CODE_OK) {
+    Serial.print(F("[ENROLL] GET failed, code "));
+    Serial.println(httpCode);
+    https.end();
+    return failure;
+  }
+
+  // Accumulate the (small) response body, then hand it to the shared parser.
+  String body;
+  body.reserve(768);
+  WiFiClient *stream = https.getStreamPtr();
+  int len = https.getSize();
+  uint32_t startMs = millis();
+  while (https.connected() && (len > 0 || len == -1)) {
+    if (millis() - startMs > ENROLL_READ_TIMEOUT_MS) {
+      Serial.println(F("[ENROLL] response read timed out"));
+      https.end();
+      return failure;
+    }
+    size_t avail = stream->available();
+    if (avail) {
+      char buf[128];
+      int c = stream->readBytes(buf, (avail > sizeof(buf)) ? sizeof(buf) : avail);
+      for (int i = 0; i < c; i++) {
+        body += buf[i];
+      }
+      if (len > 0) {
+        len -= c;
+      }
+      if (body.length() > ENROLL_MAX_BODY) {
+        Serial.println(F("[ENROLL] response body too large — aborting"));
+        https.end();
+        return failure;
+      }
+    }
+    delay(1);
+  }
+  https.end();
+
+  return parse(body);
+}

--- a/marquee/EnrollmentClient.h
+++ b/marquee/EnrollmentClient.h
@@ -1,0 +1,75 @@
+// Device-enrollment client for the wagfam-server `/api/v1/enroll` endpoint
+// (issue #125, companion to jrwagz/wagfam-server#62).
+//
+// A factory-fresh clock with no stored calendar API key polls this endpoint,
+// shows the server-minted code on its LED, and — once an admin authorizes the
+// device from the admin SPA — receives a signed config bundle carrying the
+// calendar URL + auth key. The bundle reuses the issue #99 config-update
+// format, so marquee.ino verifies it with the same verifyConfigUpdateSignature()
+// and applies it with the same applyConfigJson().
+//
+// EnrollmentClient is a JsonListener (same pattern as WagFamBdayClient). The
+// parser tracks object/array nesting depth, so a field is classified strictly
+// by where it sits in the document — bundle fields are read only as direct
+// children of "config", classification fields only at the top level. parse()
+// is pure (no network, no globals) and is unit-tested under tests/native/.
+#pragma once
+
+#include <Arduino.h>
+#include <JsonListener.h>            // base class
+#include "WagFamBdayClient.h"        // DeviceInfo + buildHeartbeatQuery()
+// The HTTPS stack (ESP8266WiFi / HTTPClient / BearSSL) and JsonStreamingParser
+// are implementation details — included in EnrollmentClient.cpp, not here.
+
+class EnrollmentClient : public JsonListener {
+ public:
+  // Parsed `/api/v1/enroll` response.
+  struct Result {
+    bool ok = false; // body parsed into a recognized status
+    String status;   // "pending" | "authorized" | "" (parse failure)
+
+    // `secret` is returned only on the first-contact response and again after
+    // a server-side enrollment reset; `code` is echoed on every pending
+    // response. Both are empty when the field is absent.
+    String secret;
+    String code;
+
+    // Signed config bundle — populated only when status == "authorized".
+    // Same shape as the calendar response's config-update fields (issue #99).
+    int configUpdateVersion = 0;
+    String configUpdatePayload;
+    String configUpdateSignature;
+  };
+
+  // Perform one enrollment poll. `enrollUrl` is the bare endpoint (e.g.
+  // https://host/api/v1/enroll); chip_id, telemetry, and — when non-empty —
+  // `secret` are appended as query params. HTTPS via BearSSL with
+  // setInsecure() (issue #125: the bundle's ECDSA signature, not TLS, is the
+  // integrity guarantee). Returns a Result with ok == false on any
+  // network/HTTP/parse failure.
+  static Result poll(const String &enrollUrl, const DeviceInfo &device,
+                     const String &secret);
+
+  // Parse an `/api/v1/enroll` JSON response body. Pure — no network, no
+  // globals. Returns ok == false on malformed input or an unrecognized status.
+  static Result parse(const String &body);
+
+  // JsonListener callbacks — public because JsonStreamingParser drives them;
+  // not meant to be called directly (use parse()).
+  void whitespace(char c) override {}
+  void startDocument() override {}
+  void key(String key) override;
+  void value(String value) override;
+  void startArray() override;
+  void endArray() override;
+  void startObject() override;
+  void endObject() override;
+  void endDocument() override;
+
+ private:
+  Result result_;
+  String currentKey_;
+  int objectDepth_ = 0;  // count of currently-open objects
+  int arrayDepth_ = 0;   // count of currently-open arrays
+  int configDepth_ = -1; // objectDepth_ at which "config"'s children sit; -1 = outside
+};

--- a/marquee/Settings.h
+++ b/marquee/Settings.h
@@ -63,6 +63,15 @@ String WAGFAM_DATA_URL = ""; // URL to Pull WagFam Calendar Data from
 String WAGFAM_API_KEY = ""; // Authorization token to use to authenticate to access the DATA_URL, only used if provided
 boolean WAGFAM_EVENT_TODAY = false; // Whether or not an event is happening today
 
+// Issue #125: device enrollment. A factory-fresh clock with no WAGFAM_API_KEY
+// polls the wagfam-server enrollment endpoint until an admin authorizes it.
+// Both values are minted by the server and persisted to /conf.txt; neither is
+// user-editable. ENROLLMENT_SECRET is the per-device proof-of-possession
+// (never echoed back over the API); ENROLLMENT_CODE is the short human code
+// shown on the LED for the admin to match against the pending device.
+String ENROLLMENT_SECRET = "";
+String ENROLLMENT_CODE = "";
+
 // SEC-03: Compile-time allowlist of domains that are *always* trusted as firmware
 // sources, regardless of the calendar URL's domain. Comma-separated list of bare
 // hostnames (no scheme, no port, no path). The runtime check (isTrustedFirmwareDomain)
@@ -91,6 +100,18 @@ boolean WAGFAM_EVENT_TODAY = false; // Whether or not an event is happening toda
 //   pio run --build-flag '-DWAGFAM_CONFIG_PUBLIC_KEY="\"0485b4...\""'
 #ifndef WAGFAM_CONFIG_PUBLIC_KEY
 #define WAGFAM_CONFIG_PUBLIC_KEY "0429ad542d32ded3469e0e87c5a66bc59c3fd0bbc2f3b62721bed3204620a751bf06ad1b393f708ca6f82565ab2699a39f83a6c666c9e99eb683aba674a1ef347b"
+#endif
+
+// Issue #125: base URL of the wagfam-server device-enrollment endpoint. A
+// clock with no stored WAGFAM_API_KEY polls this on boot to self-register.
+// HTTPS so the minted secret and the config bundle are encrypted in transit.
+//
+// Empty default => enrollment is disabled: a build without the flag (Arduino
+// IDE, or a generic non-wagfam build) just runs as a normal clock. Production
+// PlatformIO envs set it via build flag — see platformio.ini. Override:
+//   pio run --build-flag '-DWAGFAM_ENROLL_URL="\"https://host/api/v1/enroll\""'
+#ifndef WAGFAM_ENROLL_URL
+#define WAGFAM_ENROLL_URL ""
 #endif
 
 int TODAY_DISPLAY_DOT_SPACING = 5;  // How far apart the dots for the Today display are spaced

--- a/marquee/WagFamBdayClient.cpp
+++ b/marquee/WagFamBdayClient.cpp
@@ -48,31 +48,13 @@ WagFamBdayClient::configValues WagFamBdayClient::updateData(const DeviceInfo& de
 
   HTTPClient https;
 
-  // Build URL with device telemetry query params for heartbeat/identification
+  // Build URL with device telemetry query params for heartbeat/identification.
+  // The param string is shared with the enrollment poll — see buildHeartbeatQuery().
   String url;
-  url.reserve(myJsonSourceUrl.length() + 180);
+  url.reserve(myJsonSourceUrl.length() + 220);
   url = myJsonSourceUrl;
   url += (url.indexOf('?') >= 0) ? '&' : '?';
-  url += "chip_id=";
-  url += device.chipId;
-  url += "&version=";
-  url += device.version;
-  url += "&uptime=";
-  url += String(device.uptimeMs);
-  url += "&heap=";
-  url += String(device.freeHeap);
-  url += "&rssi=";
-  url += String(device.rssi);
-  url += "&utc_offset_sec=";
-  url += String(device.utcOffsetSec);
-  if (device.lanIp.length() > 0) {
-    url += "&lan_ip=";
-    url += device.lanIp;
-  }
-  if (device.mdnsName.length() > 0) {
-    url += "&mdns_name=";
-    url += device.mdnsName;
-  }
+  url += buildHeartbeatQuery(device);
 
   Serial.println("Getting Birthdays Data");
   Serial.println(F("[calendar URL redacted]"));

--- a/marquee/WagFamBdayClient.h
+++ b/marquee/WagFamBdayClient.h
@@ -45,6 +45,38 @@ struct DeviceInfo {
                           // directory page's redirect target.
 };
 
+// Build the device-telemetry query string shared by the calendar fetch
+// (WagFamBdayClient::updateData) and the enrollment poll (EnrollmentClient::
+// poll). Returns "chip_id=...&version=...&..." with NO leading '?' or '&' —
+// each caller prepends the right separator. lan_ip / mdns_name are appended
+// only when non-empty. Kept here, next to DeviceInfo, as a header-only inline
+// so both clients share one definition without an extra translation unit.
+inline String buildHeartbeatQuery(const DeviceInfo &device) {
+  String q;
+  q.reserve(200);
+  q += "chip_id=";
+  q += device.chipId;
+  q += "&version=";
+  q += device.version;
+  q += "&uptime=";
+  q += String(device.uptimeMs);
+  q += "&heap=";
+  q += String(device.freeHeap);
+  q += "&rssi=";
+  q += String(device.rssi);
+  q += "&utc_offset_sec=";
+  q += String(device.utcOffsetSec);
+  if (device.lanIp.length() > 0) {
+    q += "&lan_ip=";
+    q += device.lanIp;
+  }
+  if (device.mdnsName.length() > 0) {
+    q += "&mdns_name=";
+    q += device.mdnsName;
+  }
+  return q;
+}
+
 class WagFamBdayClient: public JsonListener {
 
   public:

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -30,6 +30,7 @@
 #include "MdnsHelpers.h"
 #include "FamilyHelpers.h"
 #include "ConfigUpdateVerify.h"
+#include "EnrollmentClient.h"
 #include "CorsSupport.h"
 #include "HwVerifyTest.h"
 #include <Fonts/Picopixel.h>
@@ -127,6 +128,10 @@ static void doOtaFlash(const String &firmwareUrl);
 // (forward-compat with older server that doesn't publish hashes).
 static bool verifyOtaSha256(const String &url, const String &expectedHex);
 
+// Issue #125: device enrollment. runEnrollmentLoop() replaces the normal
+// clock loop while the device is self-registering against the wagfam-server.
+void runEnrollmentLoop();
+
 void handleUpdateFromUrl(AsyncWebServerRequest *request);
 
 // Security helpers
@@ -219,6 +224,12 @@ String spaOtaError = "";
 // rejects any incoming configUpdate whose version is <= this value (replay
 // protection). Server is expected to increment per-device with each push.
 int lastAppliedConfigVersion = 0;
+
+// Issue #125: true when this clock has no calendar API key and is running the
+// enrollment loop (poll the server, show the setup code, apply the authorized
+// config bundle) instead of the normal clock. Decided once at the end of
+// setup(); the device reboots out of this mode rather than clearing it live.
+bool enrollmentMode = false;
 
 // Issue #99: most recent troll message override. We track it as device state
 // so a transient server outage doesn't immediately drop us back to normal
@@ -792,6 +803,16 @@ void setup() {
   // Start NTP , although it can't do anything while in config mode or when no WiFi AP connected
   timeNTPsetup();
 
+  // Issue #125: enter enrollment mode when this clock has never been given a
+  // calendar API key and the firmware was built with an enrollment endpoint.
+  // loop() then runs runEnrollmentLoop() in place of the normal clock until an
+  // admin authorizes the device (or a key is set by hand via the SPA). A build
+  // without WAGFAM_ENROLL_URL (Arduino IDE / generic build) just runs normally.
+  if (WAGFAM_ENROLL_URL[0] != '\0' && WAGFAM_API_KEY.length() == 0) {
+    enrollmentMode = true;
+    Serial.println(F("[ENROLL] No calendar API key — entering enrollment mode"));
+  }
+
   flashLED(1, 500);
 }
 
@@ -803,6 +824,16 @@ void loop() {
   // Pump the mDNS responder. The sync ESP8266mDNS variant needs this every
   // loop iteration; the wrapper is cheap when no queries are pending.
   MDNS.update();
+
+  // Issue #125: a clock with no calendar API key runs the enrollment loop
+  // instead of the normal clock — poll the server, show the setup code, and
+  // apply the signed config bundle once an admin authorizes the device. mDNS
+  // (above) and the async web server stay live, so the device is still
+  // reachable; everything else (Tasmota, clock face, weather) is skipped.
+  if (enrollmentMode) {
+    runEnrollmentLoop();
+    return;
+  }
 
   // Drive Tasmota discovery state machine. No-op when idle/done; dispatches
   // one ICMP ping (or one deferred HTTP probe) per call when running.
@@ -1824,6 +1855,9 @@ void savePersistentConfig() {
     f.println("WAGFAM_DATA_URL=" + WAGFAM_DATA_URL);
     f.println("WAGFAM_API_KEY=" + WAGFAM_API_KEY);
     f.println("WAGFAM_EVENT_TODAY=" + String(WAGFAM_EVENT_TODAY));
+    // Issue #125: enrollment identity, minted by the server. Not user-editable.
+    f.println("ENROLLMENT_SECRET=" + ENROLLMENT_SECRET);
+    f.println("ENROLLMENT_CODE=" + ENROLLMENT_CODE);
     f.println("APIKEY=" + APIKEY);
     f.println("CityID=" + geoLocation);
     f.println("ledIntensity=" + String(displayIntensity));
@@ -1884,6 +1918,13 @@ void readPersistentConfig() {
     } else if (key == "WAGFAM_EVENT_TODAY") {
       WAGFAM_EVENT_TODAY = value.toInt();
       Serial.println("WAGFAM_EVENT_TODAY: " + String(WAGFAM_EVENT_TODAY));
+    } else if (key == "ENROLLMENT_SECRET") {
+      ENROLLMENT_SECRET = value;
+      // Never log the secret itself — it is proof-of-possession.
+      Serial.println(F("ENROLLMENT_SECRET: [set]"));
+    } else if (key == "ENROLLMENT_CODE") {
+      ENROLLMENT_CODE = value;
+      Serial.println("ENROLLMENT_CODE: " + ENROLLMENT_CODE);
     } else if (key == "APIKEY") {
       APIKEY = value;
       Serial.println("APIKEY: [set]");
@@ -2152,6 +2193,15 @@ void handleApiStatus(AsyncWebServerRequest *request) {
   doc["family_display"] = familyDisplay(FAMILY);
   doc["mdns_name"] = mdnsHostname;
   doc["lan_ip"] = WiFi.localIP().toString();
+
+  // Issue #125: device-enrollment state. `has_secret` is reported instead of
+  // the secret itself — the secret is proof-of-possession and never leaves
+  // the device over the API.
+  JsonObject enroll = doc["enrollment"].to<JsonObject>();
+  enroll["mode"] = enrollmentMode;
+  enroll["code"] = ENROLLMENT_CODE;
+  enroll["has_secret"] = ENROLLMENT_SECRET.length() > 0;
+
   doc["flash_size"] = ESP.getFlashChipRealSize();
   doc["sketch_size"] = ESP.getSketchSize();
   doc["free_sketch_space"] = ESP.getFreeSketchSpace();
@@ -2259,6 +2309,169 @@ static void applyConfigJson(JsonObject json) {
   // settable here — runtime writes always land, the compile flag just
   // overrides them in the auto-update gate above.
   if (json["auto_update_enabled"].is<bool>()) AUTO_UPDATE_ENABLED = json["auto_update_enabled"].as<bool>();
+}
+
+// ── Device enrollment (issue #125) ───────────────────────────────────────────
+
+// Base interval between enrollment polls while waiting to be authorized. On
+// consecutive *failed* polls the interval backs off exponentially up to
+// ENROLL_POLL_MAX_MS, so a stranded clock (never authorized, or the server is
+// down) doesn't hammer the public endpoint forever; a successful poll resets
+// it to the base so authorization is still picked up within ~15 s.
+static const uint32_t ENROLL_POLL_INTERVAL_MS = 15000;
+static const uint32_t ENROLL_POLL_MAX_MS = 300000; // 5 min backoff ceiling
+
+// Verify and apply the signed config bundle from an authorized enrollment
+// response, then reboot into normal calendar operation. Mirrors the calendar
+// config-update path in getWeatherData() — same ECDSA signature check, same
+// applyConfigJson(), same monotonic-version guard. On a bad signature or a
+// malformed payload we log and return so the caller keeps polling.
+static void applyEnrollmentBundle(const EnrollmentClient::Result &res) {
+  if (res.configUpdateVersion <= 0 || res.configUpdatePayload.length() == 0 ||
+      res.configUpdateSignature.length() == 0) {
+    Serial.println(F("[ENROLL] authorized response carried no config bundle — ignoring"));
+    return;
+  }
+  if (res.configUpdateVersion <= lastAppliedConfigVersion) {
+    Serial.println(F("[ENROLL] bundle version <= last applied — ignoring"));
+    return;
+  }
+  if (!verifyConfigUpdateSignature(res.configUpdatePayload,
+                                   res.configUpdateSignature,
+                                   WAGFAM_CONFIG_PUBLIC_KEY)) {
+    // verifyConfigUpdateSignature already logged the reason. Keep polling —
+    // a later poll may carry a correctly-signed bundle.
+    return;
+  }
+  JsonDocument cfgDoc;
+  DeserializationError err = deserializeJson(cfgDoc, res.configUpdatePayload);
+  if (err) {
+    Serial.print(F("[ENROLL] bundle payload didn't parse as JSON: "));
+    Serial.println(err.c_str());
+    return;
+  }
+  if (!cfgDoc.is<JsonObject>()) {
+    Serial.println(F("[ENROLL] bundle payload not a JSON object — ignoring"));
+    return;
+  }
+  Serial.println("[ENROLL] applying authorized config bundle v" +
+                 String(res.configUpdateVersion));
+  applyConfigJson(cfgDoc.as<JsonObject>());
+  // Post-condition: enrollment is entered on an empty WAGFAM_API_KEY and left
+  // only by the reboot below, so the bundle MUST have populated the key. A
+  // (signed but mistaken) bundle that left it empty would otherwise bump the
+  // version, reboot, re-enter enrollment, and then be rejected by the
+  // monotonic guard on every later poll — a permanent wedge. Bail without
+  // persisting or bumping the version so a corrected bundle can still land.
+  if (WAGFAM_API_KEY.length() == 0) {
+    Serial.println(F("[ENROLL] bundle applied but no API key set — enrollment not completed"));
+    return;
+  }
+  lastAppliedConfigVersion = res.configUpdateVersion;
+  savePersistentConfig();
+  // Reboot so the device re-enters setup() cleanly with the calendar URL +
+  // key now in place — enrollmentMode evaluates false on the next boot.
+  Serial.println(F("[ENROLL] enrollment complete — restarting"));
+  delay(250);
+  ESP.restart();
+}
+
+// Perform one enrollment poll and act on the result. Persists any newly
+// minted secret/code; on an authorized response, hands off to
+// applyEnrollmentBundle() (which reboots on success). Returns true when the
+// poll produced a usable response — the caller uses this to drive backoff.
+static bool pollEnrollmentOnce() {
+  DeviceInfo devInfo;
+  devInfo.chipId = String(ESP.getChipId(), HEX);
+  devInfo.version = VERSION;
+  devInfo.uptimeMs = millis();
+  devInfo.freeHeap = ESP.getFreeHeap();
+  devInfo.rssi = WiFi.RSSI();
+  // A factory-fresh clock has no OWM data yet, so this is 0 (UTC).
+  devInfo.utcOffsetSec = weatherClient.getTimeZoneSeconds();
+  devInfo.lanIp = WiFi.localIP().toString();
+  devInfo.mdnsName = mdnsHostname;
+
+  EnrollmentClient::Result res =
+      EnrollmentClient::poll(WAGFAM_ENROLL_URL, devInfo, ENROLLMENT_SECRET);
+  if (!res.ok) {
+    Serial.println(F("[ENROLL] poll did not return a usable response"));
+    return false;
+  }
+
+  // Persist a minted secret/code. The server returns the secret on first
+  // contact and again after an admin "reset enrollment" — we overwrite in
+  // both cases, so a stale secret never wedges the recovery path.
+  bool changed = false;
+  if (res.secret.length() > 0 && res.secret != ENROLLMENT_SECRET) {
+    ENROLLMENT_SECRET = res.secret;
+    changed = true;
+    Serial.println(F("[ENROLL] stored enrollment secret"));
+  }
+  if (res.code.length() > 0 && res.code != ENROLLMENT_CODE) {
+    ENROLLMENT_CODE = res.code;
+    changed = true;
+    Serial.println("[ENROLL] enrollment code: " + ENROLLMENT_CODE);
+  }
+  if (changed) {
+    savePersistentConfig();
+  }
+
+  if (res.status == "authorized") {
+    applyEnrollmentBundle(res); // reboots on success
+  }
+  return true;
+}
+
+// Enrollment-mode loop body, called once per loop() iteration in place of the
+// normal clock. Polls the server every ENROLL_POLL_INTERVAL_MS and scrolls the
+// setup code on the LED in between. Exits (via reboot) when the device is
+// authorized or when a calendar API key is set by hand through the SPA.
+void runEnrollmentLoop() {
+  // Escape hatch: the async web server stays up during enrollment, so a user
+  // can still configure the clock by hand on the SPA Settings tab. If a key
+  // lands there, drop enrollment and reboot into normal operation.
+  if (WAGFAM_API_KEY.length() > 0) {
+    Serial.println(F("[ENROLL] calendar API key set manually — leaving enrollment mode"));
+    delay(250);
+    ESP.restart();
+  }
+
+  // Poll cadence: ENROLL_POLL_INTERVAL_MS, doubled per consecutive failed poll
+  // up to ENROLL_POLL_MAX_MS, reset on success. These statics never need
+  // resetting — enrollment mode is left only by ESP.restart().
+  static uint32_t lastPollMs = 0;
+  static bool everPolled = false;
+  static uint8_t failCount = 0;
+
+  uint32_t interval = ENROLL_POLL_INTERVAL_MS;
+  for (uint8_t i = 0; i < failCount && interval < ENROLL_POLL_MAX_MS; i++) {
+    interval *= 2;
+  }
+  if (interval > ENROLL_POLL_MAX_MS) {
+    interval = ENROLL_POLL_MAX_MS;
+  }
+
+  uint32_t nowMs = millis();
+  if (!everPolled || (nowMs - lastPollMs) >= interval) {
+    everPolled = true;
+    lastPollMs = nowMs;
+    if (pollEnrollmentOnce()) { // may reboot
+      failCount = 0;
+    } else if (failCount < 8) {
+      failCount++;
+    }
+  }
+
+  // Dedicated enrollment screen — the clock does not show the time in this
+  // mode. A ~6-char code plus its label is wider than the 32px matrix, so it
+  // is scrolled rather than statically centered.
+  matrix.fillScreen(LOW);
+  if (ENROLLMENT_CODE.length() > 0) {
+    scrollMessageWait("  Setup Code: " + ENROLLMENT_CODE + "  ");
+  } else {
+    scrollMessageWait(F("  Enrolling...  "));
+  }
 }
 
 void handleApiConfigPost(AsyncWebServerRequest *request, JsonVariant &json) {

--- a/marquee/marquee.ino
+++ b/marquee/marquee.ino
@@ -73,7 +73,7 @@ static const ScrollerFont SCROLLER_FONTS[] = {
 };
 static const int SCROLLER_FONT_COUNT = sizeof(SCROLLER_FONTS) / sizeof(SCROLLER_FONTS[0]);
 
-#define BASE_VERSION "4.8.1"
+#define BASE_VERSION "4.9.0"
 #ifdef BUILD_SUFFIX
 #define VERSION BASE_VERSION BUILD_SUFFIX
 #else

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,9 @@ extra_scripts = pre:scripts/build_version.py
 build_flags =
   #-Wl,-Map=firmware.map -Wall -Wextra -Wfatal-errors -Wunused-variable
   '-DWAGFAM_TRUSTED_FIRMWARE_DOMAINS="files-jrwagz.azurewebsites.net"'
+  ; Issue #125: device-enrollment endpoint. A clock with no calendar API key
+  ; polls this URL on boot to self-register against the wagfam-server.
+  '-DWAGFAM_ENROLL_URL="https://wagfam-server.azurewebsites.net/api/v1/enroll"'
   ; Bump LWIP's ARP cache from default 10 to 32 so a discovery scan can
   ; remember every responder on a typical /24 without evicting entries.
   ; ~28 bytes/slot, so ~900 extra bytes static RAM.

--- a/tests/native/test_enrollment/test_enrollment.cpp
+++ b/tests/native/test_enrollment/test_enrollment.cpp
@@ -1,0 +1,167 @@
+#include <unity.h>
+
+// Stubs must be first — they're found via -I tests/native/stubs
+#include "Arduino.h"
+#include "ESP8266WiFi.h"
+#include "ESP8266HTTPClient.h"
+#include "WiFiClientSecureBearSSL.h"
+
+// Library source — found via -I lib/json-streaming-parser
+#include "JsonStreamingParser.cpp"
+#include "JsonListener.cpp"
+
+// Production source — found via -I marquee. Exercises EnrollmentClient::parse(),
+// the pure JSON-response parser. poll() (the HTTPS path) is compiled here too
+// but never called — it needs a live network.
+#include "EnrollmentClient.cpp"
+
+void setUp() {}
+void tearDown() {}
+
+// ── First contact: minting response carries secret + code ───────────────────
+
+void test_first_contact_returns_secret_and_code() {
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"pending\","
+        "\"enrollment_secret\":\"a1b2c3d4e5f6\","
+        "\"enrollment_code\":\"K7M2QP\"}");
+    TEST_ASSERT_TRUE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("pending", r.status.c_str());
+    TEST_ASSERT_EQUAL_STRING("a1b2c3d4e5f6", r.secret.c_str());
+    TEST_ASSERT_EQUAL_STRING("K7M2QP", r.code.c_str());
+}
+
+// ── Subsequent pending poll: code only, secret never re-echoed ──────────────
+
+void test_pending_poll_returns_code_without_secret() {
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"pending\",\"enrollment_code\":\"K7M2QP\"}");
+    TEST_ASSERT_TRUE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("pending", r.status.c_str());
+    TEST_ASSERT_EQUAL_STRING("", r.secret.c_str());
+    TEST_ASSERT_EQUAL_STRING("K7M2QP", r.code.c_str());
+}
+
+// ── Authorized: signed config bundle in the nested "config" object ──────────
+
+void test_authorized_returns_signed_config_bundle() {
+    // configUpdatePayload is itself an (escaped) JSON string on the wire; the
+    // parser hands it back unescaped — exactly the bytes the server signed and
+    // verifyConfigUpdateSignature() must hash.
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"authorized\",\"config\":{"
+        "\"configUpdateVersion\":7,"
+        "\"configUpdatePayload\":\"{\\\"wagfam_api_key\\\":\\\"tok\\\"}\","
+        "\"configUpdateSignature\":\"c2lnYmFzZTY0\"}}");
+    TEST_ASSERT_TRUE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("authorized", r.status.c_str());
+    TEST_ASSERT_EQUAL(7, r.configUpdateVersion);
+    TEST_ASSERT_EQUAL_STRING("{\"wagfam_api_key\":\"tok\"}",
+                             r.configUpdatePayload.c_str());
+    TEST_ASSERT_EQUAL_STRING("c2lnYmFzZTY0", r.configUpdateSignature.c_str());
+}
+
+// ── Config keys must not leak to the top level, and vice versa ──────────────
+
+void test_config_block_before_status_still_parses() {
+    // Order independence: "config" object closes before "status" appears.
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"config\":{\"configUpdateVersion\":3},\"status\":\"authorized\"}");
+    TEST_ASSERT_TRUE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("authorized", r.status.c_str());
+    TEST_ASSERT_EQUAL(3, r.configUpdateVersion);
+}
+
+void test_object_nested_inside_config_does_not_displace_bundle_fields() {
+    // Regression guard: a nested object inside "config" must not relocate the
+    // bundle fields. configUpdateVersion / Payload / Signature appear *after*
+    // the nested "meta" object and must still be read as config children.
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"authorized\",\"config\":{"
+        "\"meta\":{\"issuer\":\"admin\",\"n\":1},"
+        "\"configUpdateVersion\":5,"
+        "\"configUpdatePayload\":\"P\","
+        "\"configUpdateSignature\":\"S\"}}");
+    TEST_ASSERT_TRUE(r.ok);
+    TEST_ASSERT_EQUAL(5, r.configUpdateVersion);
+    TEST_ASSERT_EQUAL_STRING("P", r.configUpdatePayload.c_str());
+    TEST_ASSERT_EQUAL_STRING("S", r.configUpdateSignature.c_str());
+}
+
+void test_bundle_fields_at_top_level_are_not_read_as_bundle() {
+    // configUpdate* are trusted-payload fields — they count only inside the
+    // "config" object. At the top level they must be ignored.
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"authorized\","
+        "\"configUpdateVersion\":9,"
+        "\"configUpdatePayload\":\"X\","
+        "\"configUpdateSignature\":\"Y\"}");
+    TEST_ASSERT_TRUE(r.ok); // status is still recognized
+    TEST_ASSERT_EQUAL(0, r.configUpdateVersion);
+    TEST_ASSERT_EQUAL_STRING("", r.configUpdatePayload.c_str());
+    TEST_ASSERT_EQUAL_STRING("", r.configUpdateSignature.c_str());
+}
+
+// ── Defensive: authorized with no bundle ────────────────────────────────────
+
+void test_authorized_without_config_bundle() {
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"authorized\"}");
+    TEST_ASSERT_TRUE(r.ok); // status is recognized
+    TEST_ASSERT_EQUAL(0, r.configUpdateVersion);
+    TEST_ASSERT_EQUAL_STRING("", r.configUpdatePayload.c_str());
+    TEST_ASSERT_EQUAL_STRING("", r.configUpdateSignature.c_str());
+}
+
+// ── Unrecognized status (e.g. server-side "revoked") ────────────────────────
+
+void test_unknown_status_is_not_ok() {
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"status\":\"revoked\"}");
+    TEST_ASSERT_FALSE(r.ok); // ok only for pending / authorized
+    TEST_ASSERT_EQUAL_STRING("revoked", r.status.c_str());
+}
+
+// ── Malformed input ─────────────────────────────────────────────────────────
+
+void test_malformed_json_is_not_ok() {
+    EnrollmentClient::Result r = EnrollmentClient::parse("{not valid json");
+    TEST_ASSERT_FALSE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("", r.status.c_str());
+}
+
+void test_empty_body_is_not_ok() {
+    EnrollmentClient::Result r = EnrollmentClient::parse("");
+    TEST_ASSERT_FALSE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("", r.status.c_str());
+}
+
+void test_json_array_is_not_ok() {
+    // The endpoint returns an object; an array (or any non-object) is rejected.
+    EnrollmentClient::Result r = EnrollmentClient::parse("[{\"status\":\"pending\"}]");
+    TEST_ASSERT_FALSE(r.ok);
+}
+
+void test_missing_status_is_not_ok() {
+    EnrollmentClient::Result r = EnrollmentClient::parse(
+        "{\"enrollment_code\":\"K7M2QP\"}");
+    TEST_ASSERT_FALSE(r.ok);
+    TEST_ASSERT_EQUAL_STRING("K7M2QP", r.code.c_str()); // the code still parsed
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+    RUN_TEST(test_first_contact_returns_secret_and_code);
+    RUN_TEST(test_pending_poll_returns_code_without_secret);
+    RUN_TEST(test_authorized_returns_signed_config_bundle);
+    RUN_TEST(test_config_block_before_status_still_parses);
+    RUN_TEST(test_object_nested_inside_config_does_not_displace_bundle_fields);
+    RUN_TEST(test_bundle_fields_at_top_level_are_not_read_as_bundle);
+    RUN_TEST(test_authorized_without_config_bundle);
+    RUN_TEST(test_unknown_status_is_not_ok);
+    RUN_TEST(test_malformed_json_is_not_ok);
+    RUN_TEST(test_empty_body_is_not_ok);
+    RUN_TEST(test_json_array_is_not_ok);
+    RUN_TEST(test_missing_status_is_not_ok);
+    return UNITY_END();
+}


### PR DESCRIPTION
Implements #125 — the firmware companion to [wagfam-server#62](https://github.com/jrwagz/wagfam-server/issues/62).

## What this does

A factory-fresh clock with no calendar API key self-registers instead of needing hand configuration. After WiFi connects, if `WAGFAM_API_KEY` is empty and the firmware was built with `WAGFAM_ENROLL_URL`, the device enters **enrollment mode**:

1. `loop()` runs `runEnrollmentLoop()` in place of the normal clock — mDNS and the async web server stay live; Tasmota / weather / clock-face are skipped.
2. It polls `GET /api/v1/enroll` over HTTPS every ~15s and scrolls a server-minted `Setup Code: XXXXXX` on the LED.
3. An admin matches that code in the wagfam-server admin UI and authorizes the device.
4. The server returns a signed config bundle; the firmware verifies it with the existing ECDSA path and applies it with `applyConfigJson()`, then reboots into normal calendar operation.

## How it's built

- **New `EnrollmentClient` module** — HTTPS poll + a `JsonListener` response parser. The parser tracks object/array nesting **depth**, so a field is classified strictly by where it sits in the document: bundle fields are read only as direct children of `config`, classification fields only at the top level. `parse()` is pure and unit-tested (`tests/native/test_enrollment/`, 12 cases incl. nested-`config` and top-level-displacement regression guards).
- **Reuse, not reinvention** — `applyEnrollmentBundle()` uses the issue #99 `verifyConfigUpdateSignature()`, `applyConfigJson()`, and the monotonic `lastAppliedConfigVersion` replay guard verbatim. `buildHeartbeatQuery()` was extracted from `WagFamBdayClient` and is now shared by both the calendar fetch and the enrollment poll.
- **`WAGFAM_ENROLL_URL`** build flag (`platformio.ini`) — a build without it just runs as a normal clock.

## Review hardening

This branch was reviewed by security and code-quality passes before opening; addressed:

- **Nesting-confusion (critical)** — the parser is depth-aware so server-controlled JSON nesting cannot relocate a trust-sensitive bundle field across the `config` boundary. Regression-tested.
- **Reboot-loop guard (high)** — `applyEnrollmentBundle()` bails without bumping the version if a bundle leaves `WAGFAM_API_KEY` empty, so a mistaken bundle can't permanently wedge the device.
- **Backoff (high)** — exponential backoff (15s → 5min) on consecutive failed polls so a stranded clock doesn't hammer the public endpoint; resets on success.
- Secret handling — `ENROLLMENT_SECRET` is never logged or echoed over the API (`/api/status` reports `has_secret` only).

## Design decisions (confirmed with maintainer)

- Enrollment triggers on an empty `WAGFAM_API_KEY` (+ a baked-in enroll URL).
- TLS uses `setInsecure()`, consistent with `WagFamBdayClient` — the bundle's ECDSA signature is the integrity guarantee; the one-time secret being MITM-able is a documented, accepted residual risk.
- Dedicated enroll screen — the clock does not show the time while enrolling.

## Verification

- `make lint` — clean (markdown + ruff)
- `pio test -e native_test` — 167/167 (12 new enrollment tests)
- `pio run -e default -e dev` — both build (RAM 56.9%, Flash 62.0%)

Hardware end-to-end (fresh-flash enrollment, authorized pickup, signature rejection, secret-loss recovery) is **not** covered by CI and should be exercised on a device once wagfam-server#62 is deployed.

Closes #125.